### PR TITLE
fix: preserve large inline author styles

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -73,6 +73,7 @@
       "php tests/unit/core-block-capability-matrix.php",
       "php tests/unit/list-item-lowering.php",
       "php tests/unit/artifact-normalizer-idempotence.php",
+      "php tests/unit/style-tag-scanner.php",
       "php tests/unit/artifact-normalizer-source-budget.php",
       "php tests/unit/subtree-classifier.php",
       "php tests/unit/custom-block-generator.php",

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -20,6 +20,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\ShellLandmarkPolicy;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\MaterializationPlanBuilder;
 use Automattic\BlocksEngine\PhpTransformer\Support\DeterministicRowDeduplicator;
+use Automattic\BlocksEngine\PhpTransformer\Support\StyleTagScanner;
 use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlan;
 use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\ValidationException;
 use DOMDocument;
@@ -2467,37 +2468,44 @@ final class ArtifactCompiler
         $seenPaths = array();
         $inlineIndex = 0;
         $linkOccurrences = array();
-        if ( preg_match_all('/<style\b[^>]*>.*?<\/style>|<link\b[^>]*>/is', $html, $matches) ) {
-            foreach ( $matches[0] as $tag ) {
-                if ( preg_match('/^<style\b/i', $tag) ) {
-                    $attributes = '';
-                    preg_match('/^<style\b([^>]*)>/i', $tag, $styleMatch);
-                    $attributes = (string) ($styleMatch[1] ?? '');
-                    if ( ! $this->isCssStylesheetType($this->htmlAttribute($attributes, 'type')) ) {
-                        continue;
-                    }
-                    if ( '' === trim((string) preg_replace('@^<style\b[^>]*>|</style>$@is', '', $tag)) ) {
-                        continue;
-                    }
-                    ++$inlineIndex;
-                    $file = $inline[$inlineIndex] ?? null;
-                    if ( is_array($file) && ! isset($seenPaths[$file['path']]) ) {
-                        $assets[] = array( 'path' => $file['path'], 'source_path' => $file['source_path'] ?? $file['path'], 'content' => $file['content'], 'source_hash' => (string) ($file['provenance']['hash'] ?? hash('sha256', $file['content']) ), 'media' => (string) ($file['media'] ?? ''), 'type' => (string) ($file['type'] ?? '') );
-                        $seenPaths[$file['path']] = true;
-                    }
+        $tags = array_map(
+            static fn (array $style): array => array('kind' => 'style', 'offset' => $style['offset'], 'attributes' => $style['attributes'], 'content' => $style['content']),
+            StyleTagScanner::scan($html)
+        );
+        if ( preg_match_all('/<link\b[^>]*>/i', $html, $linkMatches, PREG_OFFSET_CAPTURE) ) {
+            foreach ($linkMatches[0] as $linkMatch) {
+                $tags[] = array('kind' => 'link', 'offset' => $linkMatch[1], 'tag' => $linkMatch[0]);
+            }
+        }
+        usort($tags, static fn (array $left, array $right): int => $left['offset'] <=> $right['offset']);
+        foreach ( $tags as $tagRecord ) {
+            if ( 'style' === $tagRecord['kind'] ) {
+                $attributes = $tagRecord['attributes'];
+                if ( ! $this->isCssStylesheetType($this->htmlAttribute($attributes, 'type')) ) {
                     continue;
                 }
-                if ( ! preg_match('/^<link\b/i', $tag) || ! preg_match('/(?:^|\s)stylesheet(?:\s|$)/i', $this->htmlAttribute((string) $tag, 'rel') ) || ! $this->isCssStylesheetType($this->htmlAttribute((string) $tag, 'type')) ) {
+                if ( '' === trim($tagRecord['content']) ) {
                     continue;
                 }
-                $sourcePathForLink = $this->stylesheetPathFromHref($this->htmlAttribute((string) $tag, 'href'), $sourcePath, $files);
-                $linkOccurrences[$sourcePathForLink] = ($linkOccurrences[$sourcePathForLink] ?? 0) + 1;
-                $path = $occurrencePaths[$sourcePathForLink][$linkOccurrences[$sourcePathForLink]] ?? '';
-                $file = $byPath[$path] ?? null;
-                if ( is_array($file) && ! isset($seenPaths[$path]) ) {
-                    $assets[] = array( 'path' => $path, 'source_path' => $file['stylesheet_source_path'] ?? $sourcePathForLink, 'content' => $file['content'], 'source_hash' => (string) ($file['provenance']['hash'] ?? hash('sha256', $file['content']) ), 'media' => $this->htmlAttribute((string) $tag, 'media'), 'type' => $this->htmlAttribute((string) $tag, 'type') );
-                    $seenPaths[$path] = true;
+                ++$inlineIndex;
+                $file = $inline[$inlineIndex] ?? null;
+                if ( is_array($file) && ! isset($seenPaths[$file['path']]) ) {
+                    $assets[] = array( 'path' => $file['path'], 'source_path' => $file['source_path'] ?? $file['path'], 'content' => $file['content'], 'source_hash' => (string) ($file['provenance']['hash'] ?? hash('sha256', $file['content']) ), 'media' => (string) ($file['media'] ?? ''), 'type' => (string) ($file['type'] ?? '') );
+                    $seenPaths[$file['path']] = true;
                 }
+                continue;
+            }
+            $tag = $tagRecord['tag'];
+            if ( ! preg_match('/^<link\b/i', $tag) || ! preg_match('/(?:^|\s)stylesheet(?:\s|$)/i', $this->htmlAttribute((string) $tag, 'rel') ) || ! $this->isCssStylesheetType($this->htmlAttribute((string) $tag, 'type')) ) {
+                continue;
+            }
+            $sourcePathForLink = $this->stylesheetPathFromHref($this->htmlAttribute((string) $tag, 'href'), $sourcePath, $files);
+            $linkOccurrences[$sourcePathForLink] = ($linkOccurrences[$sourcePathForLink] ?? 0) + 1;
+            $path = $occurrencePaths[$sourcePathForLink][$linkOccurrences[$sourcePathForLink]] ?? '';
+            $file = $byPath[$path] ?? null;
+            if ( is_array($file) && ! isset($seenPaths[$path]) ) {
+                $assets[] = array( 'path' => $path, 'source_path' => $file['stylesheet_source_path'] ?? $sourcePathForLink, 'content' => $file['content'], 'source_hash' => (string) ($file['provenance']['hash'] ?? hash('sha256', $file['content']) ), 'media' => $this->htmlAttribute((string) $tag, 'media'), 'type' => $this->htmlAttribute((string) $tag, 'type') );
+                $seenPaths[$path] = true;
             }
         }
         return $assets;

--- a/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
@@ -5,6 +5,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
 
 use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\ReferenceAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
+use Automattic\BlocksEngine\PhpTransformer\Support\StyleTagScanner;
 
 /**
  * Normalizes loose website artifact envelopes into compiler-ready file records.
@@ -397,14 +398,14 @@ final class ArtifactNormalizer
                 continue;
             }
             $content = $this->payload($file, (string) ($file['path'] ?? ''))['content'];
-            if ( ! $this->isHtmlLikeFile($file) || '' === trim($content) || ! preg_match_all('@<style\b([^>]*)>(.*?)</style>@is', $content, $matches, PREG_SET_ORDER) ) {
+            if ( ! $this->isHtmlLikeFile($file) || '' === trim($content) ) {
                 continue;
             }
 
             $styles = array();
-            foreach ( $matches as $match ) {
-                $attributes = (string) $match[1];
-                $css = trim((string) $match[2]);
+            foreach ( StyleTagScanner::scan($content) as $style ) {
+                $attributes = $style['attributes'];
+                $css = trim($style['content']);
                 if ( '' === $css || ! $this->isCssType($this->htmlAttribute($attributes, 'type')) ) {
                     continue;
                 }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -69,6 +69,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\FormDispatchTrai
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\LinkUrlSanitizer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\NavigationToggleSuppressionTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SvgMaterializationTrait;
+use Automattic\BlocksEngine\PhpTransformer\Support\StyleTagScanner;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use DOMDocument;
 use DOMElement;
@@ -1416,12 +1417,10 @@ final class HtmlTransformer
     private function combinedAuthorStylesheet(string $html, string $staticCss): string
     {
         $cssParts = array();
-        if ( preg_match_all('@<style\b[^>]*>(.*?)</style>@is', $html, $matches) ) {
-            foreach ( $matches[1] as $styleBlock ) {
-                $styleBlock = trim(html_entity_decode((string) $styleBlock, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
-                if ( '' !== $styleBlock ) {
-                    $cssParts[] = $styleBlock;
-                }
+        foreach ( StyleTagScanner::scan($html) as $style ) {
+            $styleBlock = trim(html_entity_decode($style['content'], ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+            if ( '' !== $styleBlock ) {
+                $cssParts[] = $styleBlock;
             }
         }
         $staticCss = trim($staticCss);
@@ -1494,11 +1493,7 @@ final class HtmlTransformer
     /** @return list<string> */
     private function inlineStylesheetPayloads(string $html): array
     {
-        if ( ! preg_match_all('@<style\b[^>]*>(.*?)</style>@is', $html, $matches) ) {
-            return array();
-        }
-
-        return array_map(static fn (string $payload): string => trim($payload), $matches[1]);
+        return array_map(static fn (array $style): string => trim($style['content']), StyleTagScanner::scan($html));
     }
 
     /** @param list<string> $payloads */

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
@@ -552,8 +552,9 @@ trait SvgMaterializationTrait
     private function cssCustomProperties(string $html, string $linkedCss): array
     {
         $css = trim($linkedCss);
-        if ( preg_match_all('@<style\b[^>]*>(.*?)</style>@is', $html, $matches) ) {
-            $css .= ( '' === $css ? '' : "\n" ) . implode("\n", array_map('trim', $matches[1]));
+        $styles = StyleTagScanner::scan($html);
+        if ( array() !== $styles ) {
+            $css .= ( '' === $css ? '' : "\n" ) . implode("\n", array_map(static fn (array $style): string => trim($style['content']), $styles));
         }
         if ( '' === trim($css) ) {
             return array();

--- a/php-transformer/src/Support/StyleTagScanner.php
+++ b/php-transformer/src/Support/StyleTagScanner.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\Support;
+
+final class StyleTagScanner
+{
+    /**
+     * @return list<array{attributes:string,content:string,offset:int,end_offset:int}>
+     */
+    public static function scan(string $html): array
+    {
+        $styles = array();
+        $offset = 0;
+        $length = strlen($html);
+
+        while ($offset < $length) {
+            $open = stripos($html, '<style', $offset);
+            if (false === $open) {
+                break;
+            }
+            $boundary = $html[$open + 6] ?? '';
+            if ('' !== $boundary && '>' !== $boundary && '/' !== $boundary && !ctype_space($boundary)) {
+                $offset = $open + 6;
+                continue;
+            }
+            $openEnd = self::tagEnd($html, $open + 6);
+            if (null === $openEnd) {
+                break;
+            }
+            $close = self::closingTag($html, $openEnd + 1);
+            if (null === $close) {
+                break;
+            }
+
+            $styles[] = array(
+                'attributes' => substr($html, $open + 6, $openEnd - $open - 6),
+                'content' => substr($html, $openEnd + 1, $close['offset'] - $openEnd - 1),
+                'offset' => $open,
+                'end_offset' => $close['end_offset'],
+            );
+            $offset = $close['end_offset'];
+        }
+
+        return $styles;
+    }
+
+    private static function tagEnd(string $html, int $offset): ?int
+    {
+        $quote = '';
+        for ($index = $offset, $length = strlen($html); $index < $length; ++$index) {
+            $character = $html[$index];
+            if ('' !== $quote) {
+                if ($character === $quote) {
+                    $quote = '';
+                }
+                continue;
+            }
+            if ('"' === $character || "'" === $character) {
+                $quote = $character;
+                continue;
+            }
+            if ('>' === $character) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /** @return array{offset:int,end_offset:int}|null */
+    private static function closingTag(string $html, int $offset): ?array
+    {
+        $length = strlen($html);
+        while ($offset < $length) {
+            $close = stripos($html, '</style', $offset);
+            if (false === $close) {
+                return null;
+            }
+            $boundary = $html[$close + 7] ?? '';
+            if ('' !== $boundary && '>' !== $boundary && !ctype_space($boundary)) {
+                $offset = $close + 7;
+                continue;
+            }
+            $closeEnd = self::tagEnd($html, $close + 7);
+            if (null === $closeEnd) {
+                return null;
+            }
+
+            return array('offset' => $close, 'end_offset' => $closeEnd + 1);
+        }
+
+        return null;
+    }
+}

--- a/php-transformer/tests/unit/style-tag-scanner.php
+++ b/php-transformer/tests/unit/style-tag-scanner.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
+use Automattic\BlocksEngine\PhpTransformer\Support\StyleTagScanner;
+
+$failures = 0;
+$assert = static function (bool $condition, string $message) use (&$failures): void {
+    if (!$condition) {
+        ++$failures;
+        fwrite(STDERR, "FAIL: {$message}\n");
+    }
+};
+
+$html = '<stylesheet>ignored</stylesheet><STYLE media="screen > print">first{color:red}</sTyLe ><style data-id="two">second{color:blue}</style><style>incomplete';
+$styles = StyleTagScanner::scan($html);
+$assert(2 === count($styles), 'scanner returns only complete style elements with valid tag boundaries');
+$assert(' media="screen > print"' === ($styles[0]['attributes'] ?? null), 'scanner preserves attributes containing a greater-than sign');
+$assert(array('first{color:red}', 'second{color:blue}') === array_column($styles, 'content'), 'scanner preserves payloads and source order');
+$assert(($styles[0]['offset'] ?? -1) < ($styles[1]['offset'] ?? -1), 'scanner exposes stable source offsets');
+
+$largeCss = '/*' . str_repeat('large-style-payload-', 70000) . '*/.large{color:#000}';
+$largeHtml = '<html><head><style media="all">' . $largeCss . '</style></head><body><main class="large">Large</main></body></html>';
+$assert(strlen($largeCss) > (int) ini_get('pcre.backtrack_limit'), 'regression payload exceeds the default PCRE backtracking budget');
+$assert(false === preg_match_all('@<style\b([^>]*)>(.*?)</style>@is', $largeHtml, $unused), 'regression payload reproduces the former PCRE backtracking failure');
+$started = microtime(true);
+$largeStyles = StyleTagScanner::scan($largeHtml);
+$assert(1 === count($largeStyles) && $largeCss === ($largeStyles[0]['content'] ?? ''), 'linear scanner preserves the complete multi-megabyte payload');
+$assert(microtime(true) - $started < 2.0, 'multi-megabyte scan completes in bounded time');
+
+$compiled = (new ArtifactCompiler())->compile(array(
+    'entrypoint' => 'index.html',
+    'files' => array(
+        array('path' => 'index.html', 'kind' => 'html', 'content' => $largeHtml),
+    ),
+))->toArray();
+$authorAssets = array_values(array_filter(
+    $compiled['assets'] ?? array(),
+    static fn (array $asset): bool => 'css' === ($asset['kind'] ?? '') && !in_array($asset['source'] ?? '', array('engine-support', 'editor-static-state'), true)
+));
+$assert(1 === count($authorAssets), 'canonical compiler emits the large inline author stylesheet as an asset');
+$assert(str_contains((string) ($authorAssets[0]['content'] ?? ''), '.large{color:#000}'), 'emitted author asset retains the large source CSS');
+$planAssets = $compiled['source_reports']['wordpress_site_plan']['assets'] ?? array();
+$assert((bool) array_filter($planAssets, static fn (array $asset): bool => 'css' === ($asset['kind'] ?? '') && 'inline-style' === ($asset['source'] ?? '')), 'WordPress site plan retains inline author stylesheet coverage');
+
+if ($failures > 0) {
+    exit(1);
+}
+
+fwrite(STDOUT, "style-tag-scanner: passed\n");


### PR DESCRIPTION
## Problem

Inline `<style>` extraction used lazy document-wide regular expressions. Multi-megabyte author CSS can exhaust `pcre.backtrack_limit`, causing extraction to return `false` and silently omit every author stylesheet for the affected route.

## Change

- add a shared linear `StyleTagScanner` that preserves attributes, payloads, and source offsets without document-wide regex backtracking
- use it at the five extraction paths identified in #1241
- preserve inline/link stylesheet source order when projecting canonical assets
- keep existing CSS MIME filtering, trimming, custom-property extraction, and asset provenance behavior

## Verification

- regression fixture proves the former regex returns `false` for the multi-megabyte payload
- the scanner preserves the complete payload in bounded time
- canonical `ArtifactCompiler` output retains the author stylesheet asset in the WordPress site plan
- `composer --working-dir=php-transformer test` passes, including 289 parity fixtures and package install proof

Fixes #1241

## AI assistance

GPT-5.6 Sol was used through OpenCode and Homeboy to inspect the failure paths, implement the shared scanner, review the resulting diff, and run deterministic verification. Final code and evidence were reviewed and orchestrated by Chris Huber.