### PR TITLE
Verify one batch shared plan once

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -299,7 +299,7 @@ final class ArtifactCompiler
             if (!is_array($pagePlan) || !is_string($pagePlan['page_id'] ?? null) || isset($receipts[$pagePlan['page_id']])) {
                 throw new \InvalidArgumentException('Prepared page batches require unique page plans with string page ids.');
             }
-            $receipts[$pagePlan['page_id']] = $this->compilePreparedPageWithCompiler($sharedPlan, $pagePlan, $stageCompiler, $payloadReader);
+            $receipts[$pagePlan['page_id']] = $this->compilePreparedPageWithCompiler($sharedPlan, $pagePlan, $stageCompiler, $payloadReader, true);
         }
         return $receipts;
     }
@@ -311,12 +311,18 @@ final class ArtifactCompiler
         return $compiler;
     }
 
-    /** @param array<string,mixed> $sharedPlan @param array<string,mixed> $pagePlan @return array<string,mixed> */
-    private function compilePreparedPageWithCompiler(array $sharedPlan, array $pagePlan, self $stageCompiler, ?PayloadReader $payloadReader): array
+    /**
+     * A shared plan is immutable for the whole batch, and verifying its
+     * reduction digest rehashes every shared fact. Callers that already
+     * verified this exact plan declare it so one batch validates once.
+     *
+     * @param array<string,mixed> $sharedPlan @param array<string,mixed> $pagePlan @return array<string,mixed>
+     */
+    private function compilePreparedPageWithCompiler(array $sharedPlan, array $pagePlan, self $stageCompiler, ?PayloadReader $payloadReader, bool $sharedPlanVerified = false): array
     {
         $startedAt = hrtime(true);
         $initialTransformCount = $stageCompiler->htmlDocumentTransformCount;
-        $this->assertSharedPlan($sharedPlan);
+        if (!$sharedPlanVerified) $this->assertSharedPlan($sharedPlan);
         $this->assertPagePlan($pagePlan, $sharedPlan);
         $sharedArtifact = isset($sharedPlan['shared_reduction'])
             ? array_merge($sharedPlan['artifact'], array('files' => $this->sharedReductionFiles($sharedPlan, $payloadReader)))

--- a/php-transformer/tests/contract/staged-artifact-compilation.php
+++ b/php-transformer/tests/contract/staged-artifact-compilation.php
@@ -60,6 +60,17 @@ foreach ($compiledPages as &$compiledPage) unset($compiledPage['work']['compile_
 unset($compiledPage);
 $assert($compiledPages === $compiledBatch, 'Worker-batch compilation reuses bounded analysis without changing independently compiled receipt content.');
 
+// One batch verifies its immutable shared plan once, so the batch entry point
+// stays the enforcement boundary for every shared-plan invariant.
+$tamperedReduction = $shared;
+$tamperedReduction['shared_reduction']['component_facts']['tampered'] = true;
+$throws(static fn () => $compiler->compilePreparedPages($tamperedReduction, $pages), 'Batch compilation rejects a shared reduction whose contents no longer match its digest.');
+$throws(static fn () => $compiler->compilePreparedPage($tamperedReduction, $pages['index.html']), 'Single-page compilation rejects a shared reduction whose contents no longer match its digest.');
+$tamperedSharedDigest = $shared;
+$tamperedSharedDigest['digest'] = str_repeat('0', 64);
+$throws(static fn () => $compiler->compilePreparedPages($tamperedSharedDigest, $pages), 'Batch compilation rejects a shared plan whose declared plan digest is invalid.');
+$throws(static fn () => $compiler->compilePreparedPages(array_diff_key($shared, array('schema' => null)), $pages), 'Batch compilation rejects a shared plan that omits its staged schema.');
+
 // Simulate interruption/resume and arbitrary parallel completion order.
 $resumedShared = json_decode(json_encode($shared, JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
 $resumedPages = json_decode(json_encode(array($pages['contact.html'], $pages['index.html'], $pages['about.html']), JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);


### PR DESCRIPTION
## Summary

- verify an immutable shared plan once per worker batch instead of once per page
- keep the batch entry point as the enforcement boundary for every shared-plan invariant
- add contract coverage proving tampered shared plans are still rejected by both entry points

Refs #1044.

## Why

Phase profiling of a real 130 MB, 19-page artifact showed `assertSharedPlan()` consuming ~4.3s per page, about 45% of page compile time. The cost is `planDigest()` rehashing every shared fact. `compilePreparedPages()` already verifies that exact shared plan value at batch entry, so each additional page rehashed an identical, immutable plan.

## Evidence

19-page batch compilation through the public `compilePreparedPages()` API:

| Run | Baseline `6d6194f9` | This branch | Change |
|---|---:|---:|---:|
| Pair 1 | 200.3s | 106.3s | -46.9% |
| Pair 2 (reversed order) | 228.3s | 142.4s | -37.6% |

- all 19 receipt digests identical across baseline and candidate (`sha256(digests)` = `9caf6b4fd601b31e65ef33e911eee3081006d3ce14875e18fe00e747c7e95b64`)
- 19 HTML document transforms in both
- peak PHP memory 310.4 MiB -> 309.5 MiB

Host timing is noisy, so both ordered pairs are reported rather than a single number.

## Verification

- `composer test`
- `php tests/contract/run.php`
- `php tests/contract/staged-artifact-compilation.php`
- 289 parity fixtures
- package installation proof

## AI assistance

OpenAI gpt-5.6-sol was used through OpenCode to add temporary phase instrumentation, attribute per-page compile time, identify the redundant shared-plan verification, implement the fix, add contract coverage, and run verification. The implementation and evidence were reviewed and orchestrated by Chris Huber.