### PR TITLE
Reuse shared CSS font analysis

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
@@ -35,7 +35,10 @@ final class SemanticParityReporter
      * normalizedNavigationLabel). It mirrors the transformer's own runtime so the
      * extracted builders behave identically to the inline implementation.
      */
-    public function __construct(private readonly Runtime $runtime = new Runtime())
+    public function __construct(
+        private readonly Runtime $runtime = new Runtime(),
+        private readonly TypographyParityAnalyzer $typographyParityAnalyzer = new TypographyParityAnalyzer()
+    )
     {
     }
 
@@ -66,7 +69,7 @@ final class SemanticParityReporter
         }
         $findings = array_merge(
             $findings,
-            ( new TypographyParityAnalyzer() )->findings($html, $staticCss, $this->inlineHeadingFontDeclarations($body))
+            $this->typographyParityAnalyzer->findings($html, $staticCss, $this->inlineHeadingFontDeclarations($body))
         );
 
         $findings = array_map(

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -67,6 +67,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\FormDispatchTrai
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\LinkUrlSanitizer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\NavigationToggleSuppressionTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SvgMaterializationTrait;
+use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\FontMaterializationPlanBuilder;
 use Automattic\BlocksEngine\PhpTransformer\Support\StyleTagScanner;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use DOMDocument;
@@ -324,7 +325,10 @@ final class HtmlTransformer
         $this->navigationUnderlineColorResolver = new NavigationUnderlineColorResolver();
         $this->navigationBlockNormalizer = new NavigationBlockNormalizer(fn (string $label): string => $this->normalizedNavigationLabel($label));
         $this->diagnosticsCollector = new DiagnosticsCollector();
-        $this->semanticParityReporter = new SemanticParityReporter($this->runtime);
+        $this->semanticParityReporter = new SemanticParityReporter(
+            $this->runtime,
+            new TypographyParityAnalyzer(new FontMaterializationPlanBuilder($this->analysisCache->cssFontAnalysis))
+        );
         $this->contentRoundTripReporter = new ContentRoundTripReporter();
         $this->reusableComponentRecognizer = new ReusableComponentRecognizer();
         $this->patternContext = $this->createPatternContext(true);

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerAnalysisCache.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerAnalysisCache.php
@@ -3,11 +3,21 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
 
+use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\CssFontAnalysisCache;
+
 /**
  * Bounded cache for immutable stylesheet analysis shared by one site compile.
  */
 final class HtmlTransformerAnalysisCache
 {
+    /** Immutable CSS-derived font analysis shared by one site compile. */
+    public readonly CssFontAnalysisCache $cssFontAnalysis;
+
+    public function __construct()
+    {
+        $this->cssFontAnalysis = new CssFontAnalysisCache();
+    }
+
     // Payload analyses contain parsed selector graphs, so keep the site-scoped
     // cache small even when every route contributes a local stylesheet.
     private const MAX_PAYLOAD_ENTRIES = 16;

--- a/php-transformer/src/StaticSite/FontMaterialization/CssFontAnalysisCache.php
+++ b/php-transformer/src/StaticSite/FontMaterialization/CssFontAnalysisCache.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization;
+
+/**
+ * Bounded cache for immutable CSS-derived font analysis.
+ *
+ * Custom-property values and `font-family` declarations are pure functions of
+ * the stylesheet text. One site stylesheet is scanned by several typography
+ * consumers on every page, so the derived analysis is keyed by content and
+ * retained for the compile that shares it.
+ */
+final class CssFontAnalysisCache
+{
+    // Font analysis retains selector strings rather than parsed graphs, so a
+    // small entry budget covers one site's stylesheet set without growth.
+    private const MAX_ENTRIES = 8;
+
+    /** @var array<string, array<string, string>> */
+    private array $variables = array();
+
+    /** @var array<string, list<array{family:string,selector:string,source_snippet:string}>> */
+    private array $declarations = array();
+
+    public int $variableBuilds = 0;
+
+    public int $variableHits = 0;
+
+    public int $declarationBuilds = 0;
+
+    public int $declarationHits = 0;
+
+    /**
+     * @param list<string> $stylesheets
+     * @param callable(): array<string, string> $build
+     * @return array<string, string>
+     */
+    public function variables(array $stylesheets, callable $build): array
+    {
+        $key = self::key($stylesheets);
+        if ( array_key_exists($key, $this->variables) ) {
+            ++$this->variableHits;
+            return $this->variables[$key];
+        }
+
+        ++$this->variableBuilds;
+        $variables = $build();
+        self::retain($this->variables, $key, $variables);
+
+        return $variables;
+    }
+
+    /**
+     * @param list<string> $stylesheets
+     * @param callable(): list<array{family:string,selector:string,source_snippet:string}> $build
+     * @return list<array{family:string,selector:string,source_snippet:string}>
+     */
+    public function declarations(array $stylesheets, callable $build): array
+    {
+        $key = self::key($stylesheets);
+        if ( array_key_exists($key, $this->declarations) ) {
+            ++$this->declarationHits;
+            return $this->declarations[$key];
+        }
+
+        ++$this->declarationBuilds;
+        $declarations = $build();
+        self::retain($this->declarations, $key, $declarations);
+
+        return $declarations;
+    }
+
+    /** @param list<string> $stylesheets */
+    private static function key(array $stylesheets): string
+    {
+        $key = '';
+        foreach ( $stylesheets as $stylesheet ) {
+            $key .= hash('sha256', $stylesheet) . "\0";
+        }
+
+        return $key;
+    }
+
+    /** @param array<string, mixed> $entries */
+    private static function retain(array &$entries, string $key, mixed $value): void
+    {
+        // PHP arrays retain insertion order, making this a compact LRU queue.
+        while ( count($entries) >= self::MAX_ENTRIES ) {
+            unset($entries[array_key_first($entries)]);
+        }
+        $entries[$key] = $value;
+    }
+}

--- a/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
+++ b/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
@@ -12,6 +12,15 @@ final class FontMaterializationPlanBuilder
     private const CSS_WIDE_KEYWORDS = array('inherit', 'initial', 'revert', 'revert-layer', 'unset');
 
     /**
+     * Typography consumers rescan one shared stylesheet for every page. A
+     * caller that compiles several pages supplies a cache so the immutable
+     * CSS-derived analysis is built once for the stylesheets it shares.
+     */
+    public function __construct(private readonly CssFontAnalysisCache $fontAnalysisCache = new CssFontAnalysisCache())
+    {
+    }
+
+    /**
      * @param array<int,array<string,mixed>> $fontUsage
      * @param array<string,string> $roles
      * @return array<string,mixed>
@@ -519,6 +528,15 @@ final class FontMaterializationPlanBuilder
      */
     public function fontFamilyDeclarationsFromCssSources(array $stylesheets): array
     {
+        return $this->fontAnalysisCache->declarations($stylesheets, fn (): array => $this->buildFontFamilyDeclarations($stylesheets));
+    }
+
+    /**
+     * @param list<string> $stylesheets
+     * @return list<array{family:string,selector:string,source_snippet:string}>
+     */
+    private function buildFontFamilyDeclarations(array $stylesheets): array
+    {
         $variables = $this->cssVariableValues($stylesheets);
         $visitor = new CssStylesheetTransformer();
         $declarations = array();
@@ -549,6 +567,12 @@ final class FontMaterializationPlanBuilder
 
     /** @param list<string> $stylesheets @return array<string,string> */
     public function cssVariableValues(array $stylesheets): array
+    {
+        return $this->fontAnalysisCache->variables($stylesheets, fn (): array => $this->buildCssVariableValues($stylesheets));
+    }
+
+    /** @param list<string> $stylesheets @return array<string,string> */
+    private function buildCssVariableValues(array $stylesheets): array
     {
         $variables = array();
         $visitor = new CssStylesheetTransformer();

--- a/php-transformer/tests/unit/font-family-declaration-memory.php
+++ b/php-transformer/tests/unit/font-family-declaration-memory.php
@@ -5,6 +5,7 @@ ini_set('memory_limit', '96M');
 
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
+use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\CssFontAnalysisCache;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\FontMaterializationPlanBuilder;
 
 $css = '@keyframes inert{' . str_repeat('x', 32 * 1024 * 1024) . '}'
@@ -14,6 +15,31 @@ $roles = ( new FontMaterializationPlanBuilder() )->fontRolesFromCss($css);
 
 if ( array( 'heading' => 'Playfair Display', 'body' => 'Lora' ) !== $roles ) {
     fwrite(STDERR, 'Font-family declaration memory contract failed: ' . json_encode($roles) . PHP_EOL);
+    exit(1);
+}
+
+// One shared stylesheet is scanned by several typography consumers on every
+// page. A shared cache builds that immutable analysis once and reuses it.
+$sharedCss = ':root{--heading:"Playfair Display",serif}h1{font-family:var(--heading)}body{font-family:Lora,serif}';
+$sharedCache = new CssFontAnalysisCache();
+$cachedRoles = array();
+for ( $page = 0; $page < 4; ++$page ) {
+    $builder = new FontMaterializationPlanBuilder($sharedCache);
+    $cachedRoles[] = $builder->fontRolesFromCss($sharedCss);
+    $builder->fontFamilyDeclarationsFromCssSources(array($sharedCss));
+}
+$isolatedRoles = ( new FontMaterializationPlanBuilder() )->fontRolesFromCss($sharedCss);
+
+if ( array_unique(array_map(static fn (array $role): string => json_encode($role), $cachedRoles)) !== array(json_encode($isolatedRoles)) ) {
+    fwrite(STDERR, 'Cached font analysis changed canonical role resolution.' . PHP_EOL);
+    exit(1);
+}
+if ( 1 !== $sharedCache->declarationBuilds || 7 !== $sharedCache->declarationHits ) {
+    fwrite(STDERR, 'Font-family declarations were not built once per shared stylesheet: ' . $sharedCache->declarationBuilds . '/' . $sharedCache->declarationHits . PHP_EOL);
+    exit(1);
+}
+if ( 1 !== $sharedCache->variableBuilds || 0 !== $sharedCache->variableHits ) {
+    fwrite(STDERR, 'CSS custom properties were not built once per shared stylesheet: ' . $sharedCache->variableBuilds . '/' . $sharedCache->variableHits . PHP_EOL);
     exit(1);
 }
 


### PR DESCRIPTION
## Summary

- add a bounded, content-keyed cache for immutable CSS-derived font analysis
- reuse one site stylesheet's custom properties and `font-family` declarations across the typography consumers that scan it
- share that analysis across the pages of one compile through the existing analysis cache

Refs #1044.

## Why

Phase profiling of a real 130 MB, 19-page artifact attributed semantic parity reporting as the largest remaining transform phase, and 99.5% of it was `TypographyParityAnalyzer::findings()`. Inside that, `fontRolesFromCss()` and `headingFamiliesFromCssSources()` fully rescanned the same shared stylesheet, and `cssVariableValues()` alone ran three times per page over identical text. The stylesheet is immutable for the whole compile, so the derived analysis is now built once per distinct stylesheet set.

## Evidence

19-page batch compilation through `compilePreparedPages()`:

| Run | Baseline `8fc79ca6` | This branch | Change |
|---|---:|---:|---:|
| Pair 1 | 365.3s | 240.5s | -34.2% |
| Pair 2 | 200.3s | 139.0s | -30.6% |

- all 19 receipt digests identical across baseline and candidate (`sha256(digests)` = `9caf6b4fd601b31e65ef33e911eee3081006d3ce14875e18fe00e747c7e95b64`)
- 19 HTML document transforms in both
- peak PHP memory 309.5 MiB -> 310.4 MiB, bounded by an 8-entry budget

Absolute wall time was noisy on this host, so both ordered pairs are reported rather than a single number.

## Verification

- `composer test`
- `php tests/contract/run.php`
- `php tests/unit/font-family-declaration-memory.php`, extended to assert one build and seven reuses for a shared stylesheet plus canonical role equality against an uncached builder
- 289 parity fixtures
- package installation proof

## AI assistance

OpenAI gpt-5.6-sol was used through OpenCode to add temporary phase instrumentation, attribute transform time down to the typography analyzer, implement the bounded CSS font analysis cache, extend deterministic coverage, and run verification. The implementation and evidence were reviewed and orchestrated by Chris Huber.