### PR TITLE
Remove unreachable transformer code

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -962,46 +962,6 @@ final class ArtifactCompiler
     }
 
     /**
-     * @param array<string,mixed> $artifact
-     * @return array{shared:array<int,array<string,mixed>>,pages:array<string,array<int,array<string,mixed>>>,entrypoints:array<int,string>,limits:array<string,int>,runtime_declarations:array<int,array<string,mixed>>,schema:string,input_keys:array<int,string>}
-     */
-    private function partitionArtifact(array $artifact): array
-    {
-        $normalized = (new ArtifactNormalizer())->normalize($artifact);
-        $shared = array();
-        $pages = array();
-        foreach ($normalized['files'] as $file) {
-            $ownership = $this->fileOwnership($file);
-            if ('shared' === $ownership['scope']) {
-                $shared[] = $file;
-                continue;
-            }
-            $pages[$ownership['id']][] = $file;
-        }
-        ksort($pages, SORT_STRING);
-        foreach ($pages as $pageId => $files) {
-            $pages[$pageId] = self::sortedByPath($files);
-        }
-        $shared = self::sortedByPath($shared);
-
-        return array(
-            'shared' => $shared,
-            'pages' => $pages,
-            'entrypoints' => $normalized['entrypoints'],
-            'limits' => $normalized['limits'],
-            'runtime_declarations' => $normalized['runtime_declarations'],
-            'schema' => is_string($artifact['schema'] ?? null) ? $artifact['schema'] : '',
-            'input_keys' => array_values(array_filter(array_keys($artifact), 'is_string')),
-            'identity' => array_filter(array(
-                'site_slug' => is_string($artifact['site_slug'] ?? null) ? $artifact['site_slug'] : null,
-                'site_name' => is_string($artifact['site_name'] ?? null) ? $artifact['site_name'] : null,
-                'block_namespace' => is_string($artifact['block_namespace'] ?? null) ? $artifact['block_namespace'] : null,
-            ), static fn(mixed $value): bool => null !== $value),
-            'normalized' => $normalized,
-        );
-    }
-
-    /**
      * Partition an envelope before normalization so preparing one stage never
      * parses, expands, or transforms payloads owned by another stage.
      *

--- a/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
@@ -920,51 +920,6 @@ final class RuntimeDependencyParityReport
     /**
      * @return array<int, string>
      */
-    private function scriptDomSelectorsFromBundle(string $script): array
-    {
-        $selectors = array();
-        if ( preg_match_all('/document\s*\.\s*getElementById\s*\(\s*(["\'])([A-Za-z][A-Za-z0-9_-]*)\1\s*\)/', $script, $matches) ) {
-            foreach ( $matches[2] as $id ) {
-                $selectors['#' . (string) $id] = true;
-            }
-        }
-        if ( preg_match_all('/document\s*\.\s*querySelector(?:All)?\s*\(\s*(["\'])(' . $this->scriptSelectorPattern() . ')\1\s*\)/', $script, $matches) ) {
-            foreach ( $matches[2] as $selector ) {
-                $selector = $this->canonicalRuntimeSelector((string) $selector);
-                $selectors[$selector] = true;
-            }
-        }
-        if ( preg_match_all('/\b(?!document\b)[A-Za-z_$][A-Za-z0-9_$]*\s*\.\s*querySelector(?:All)?\s*\(\s*(["\'])(' . $this->scriptSelectorPattern() . ')\1\s*\)/', $script, $matches) ) {
-            foreach ( $matches[2] as $selector ) {
-                $selector = $this->canonicalRuntimeSelector((string) $selector);
-                $selectors[$selector] = true;
-            }
-        }
-        foreach ( $this->scriptDataAttributeSelectors($script) as $selector ) {
-            $selectors[$selector] = true;
-        }
-        foreach ( $this->scriptScopedElementSelectors($script, 'canvas') as $selector ) {
-            $selectors[$selector] = true;
-        }
-        foreach ( $this->scriptScopedElementSelectors($script, 'svg') as $selector ) {
-            $selectors[$selector] = true;
-        }
-        foreach ( $this->scriptAppendedRootSelectors($script) as $selector ) {
-            $selectors[$selector] = true;
-        }
-        if ( preg_match_all('/\.\s*closest\s*\(\s*(["\'])(' . $this->scriptSelectorPattern() . ')\1\s*\)/', $script, $matches) ) {
-            foreach ( $matches[2] as $selector ) {
-                $selector = $this->canonicalRuntimeSelector((string) $selector);
-                $selectors[$selector] = true;
-            }
-        }
-
-        return array_keys($selectors);
-    }
-
-    /**
-     * @return array<int, string>
-     */
     private function scriptDataAttributeSelectors(string $script): array
     {
         $selectors = array();

--- a/php-transformer/src/Contract/ConversionFindingContract.php
+++ b/php-transformer/src/Contract/ConversionFindingContract.php
@@ -64,8 +64,6 @@ final class ConversionFindingContract
     /**
      * Human-readable descriptor keys. Optional; type-checked when present.
      */
-    private const MESSAGE_KEYS = array('message', 'summary');
-
     /**
      * Well-known optional scalar string fields, validated for type only when
      * present. Unknown fields are tolerated.

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -58,7 +58,6 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssStylesheetTrans
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AdminBarAccommodation;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssValueSplitter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\GeneratedSupportStylesheetState;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleAttributeMapper;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\SourceStyleResolutionState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\BackgroundImageExtractor;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\ButtonLinkDispatchTrait;
@@ -153,19 +152,6 @@ final class HtmlTransformer
      * font-size, so the CSS default is the correct constant rather than a guess.
      */
     private const ROOT_FONT_SIZE_PX = 16;
-
-    private const MAX_FORM_TOPOLOGY_DEPTH = 8;
-
-    private const MAX_FORM_TOPOLOGY_NODES = 128;
-
-    private const MAX_FORM_TOPOLOGY_CLASSES = 8;
-
-    /** @var array<int, string> */
-    private const FORM_TOPOLOGY_WRAPPER_TAGS = array(
-        'article', 'aside', 'dd', 'div', 'dl', 'dt', 'fieldset', 'footer', 'header',
-        'label', 'li', 'main', 'nav', 'ol', 'p', 'section', 'span', 'table', 'tbody',
-        'td', 'tfoot', 'th', 'thead', 'tr', 'ul',
-    );
 
     /**
      * Tag-only script selectors that must keep their native DOM shape when a
@@ -2642,13 +2628,6 @@ final class HtmlTransformer
         }
 
         return $this->replaceSelectorSpans($selector, $replacements);
-    }
-
-    /** @param array<string, mixed> $parsed */
-    private function rightmostTypeIsControl(array $parsed): bool
-    {
-        $type = $parsed['compounds'][count($parsed['compounds']) - 1]['type'] ?? null;
-        return is_string($type) && in_array(strtolower($type), array( 'a', 'button' ), true);
     }
 
     private function typeSpecificityShim(): string
@@ -5433,52 +5412,6 @@ final class HtmlTransformer
         return $tags;
     }
 
-    private function authorLayoutLeafBlockFromElement(DOMElement $element): ?array
-    {
-        $this->generatedBlocks()->register(AuthorLayoutBlockGenerator::class, ( new AuthorLayoutBlockGenerator() )->definition());
-        $content = $this->richTextContentWithMaterializedInlineStyles($element);
-        $content = $this->richTextContentWithMaterializedSvgImages($element, $content);
-        if ( null === $content ) {
-            return null;
-        }
-
-        $tagName = strtolower($element->tagName);
-        $presentationAttrs = $this->presentationAttributes($element);
-        $attrs = array_filter(array(
-            'anchor' => $this->safeAnchor($this->attr($element, 'id')),
-            'className' => $this->sourceProjectionClassName($element, $this->mergePresentationClassNames(
-                (string) ($presentationAttrs['className'] ?? $this->promotedClassName($this->attr($element, 'class'))),
-                $this->editorAnchorClassName($element)
-            )),
-            'content' => $content,
-            'contentMode' => 'rich-text',
-            'sourceAttributes' => array_filter(array_merge(
-                $this->authorLayoutSourceAttributes($element),
-                array_intersect_key($this->htmlAttributes($element), array_flip(array( 'target', 'rel', 'type' )))
-            )),
-            'tagName' => $tagName,
-            'url' => 'a' === $tagName ? $this->safeLinkUrl($this->attr($element, 'href')) : '',
-        ), static fn (mixed $value): bool => array() !== $value && '' !== $value);
-        $opening = '<' . $tagName . $this->authorLayoutHtmlAttributes($attrs) . '>';
-        $closing = '</' . $tagName . '>';
-
-        $this->recordPresentationProvenance(AuthorLayoutBlockGenerator::NAME, $attrs, $element);
-        $this->recordStructureProvenance(AuthorLayoutBlockGenerator::NAME, $attrs, $element);
-        $provenanceId = $this->transformationProvenance()->registerSource(
-            $this->sourceProvenanceEntry(AuthorLayoutBlockGenerator::NAME, $element),
-            $this->sourceElementStartsHidden($element)
-        );
-
-        return array(
-            'blockName' => AuthorLayoutBlockGenerator::NAME,
-            'attrs' => $attrs,
-            'innerBlocks' => array(),
-            'innerHTML' => $opening . ($attrs['content'] ?? '') . $closing,
-            'innerContent' => array($opening . ($attrs['content'] ?? '') . $closing),
-            '_source_provenance_id' => $provenanceId,
-        );
-    }
-
     /** @return array<string, string> */
     private function authorLayoutSourceAttributes(DOMElement $element): array
     {
@@ -5711,22 +5644,6 @@ final class HtmlTransformer
         return $only instanceof DOMElement && $this->isStylingHookSpan($only) ? $only : null;
     }
 
-    private function soleRichTextAnchor(DOMElement $container): ?DOMElement
-    {
-        $only = null;
-        foreach ( $container->childNodes as $child ) {
-            if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
-                continue;
-            }
-            if ( null !== $only ) {
-                return null;
-            }
-            $only = $child;
-        }
-
-        return $only instanceof DOMElement && 'a' === strtolower($only->tagName) ? $only : null;
-    }
-
     /**
      * A `<span>` whose attributes can be represented by a semantic RichText
      * carrier. Class/id/data identity and inline styles move together onto a
@@ -5789,21 +5706,6 @@ final class HtmlTransformer
         }
 
         return $hasStyling;
-    }
-
-    /**
-     * @return array<int, DOMElement>
-     */
-    private function stylingHookSpans(DOMElement $container): array
-    {
-        $spans = array();
-        foreach ( $container->getElementsByTagName('span') as $span ) {
-            if ( $span instanceof DOMElement && $this->isStylingHookSpan($span) ) {
-                $spans[] = $span;
-            }
-        }
-
-        return $spans;
     }
 
     /**
@@ -6699,16 +6601,6 @@ final class HtmlTransformer
     {
         $identity = strtolower($this->attr($element, 'class') . ' ' . $this->attr($element, 'id'));
         return (bool) preg_match('/(?:^|[^a-z0-9])(?:band|carousel|loop|marquee|mask|rail|scroller|slider|ticker|track|viewport)(?:[^a-z0-9]|$)/', $identity);
-    }
-
-    private function hasBoxAffectingAuthorDeclarations(DOMElement $element): bool
-    {
-        foreach ( array_keys($this->matchingAuthorDeclarations($element)) as $property ) {
-            if ( preg_match('/^(?:align-content|align-items|align-self|background|border|bottom|column|contain|display|filter|flex|float|gap|grid|height|inset|isolation|left|margin|max-|min-|opacity|outline|overflow|padding|perspective|position|right|row-gap|top|transform|width|z-index)/', $property) ) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**
@@ -11775,20 +11667,6 @@ final class HtmlTransformer
         return $attrs;
     }
 
-    private function hasPositionedVisualMediaChild(DOMElement $element): bool
-    {
-        foreach ( $element->childNodes as $child ) {
-            if ( ! $child instanceof DOMElement || 0 === $child->getElementsByTagName('img')->length ) {
-                continue;
-            }
-            $position = strtolower(trim((string) ($this->structuralPresentationDeclarations($child)['position'] ?? '')));
-            if ( in_array($position, array( 'absolute', 'fixed' ), true) ) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     private function intrinsicVisualMediaHeight(DOMElement $element): string
     {
         $parent = $element->parentNode;
@@ -12729,30 +12607,6 @@ final class HtmlTransformer
         }
 
         return $rebuilt;
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    private function pictureSourceAttributes(DOMElement $picture): array
-    {
-        foreach ( $picture->childNodes as $child ) {
-            if ( ! $child instanceof DOMElement || 'source' !== strtolower($child->tagName) ) {
-                continue;
-            }
-
-            $srcset = $this->attr($child, 'srcset');
-            if ( '' === $srcset || preg_match('/javascript\s*:/i', $srcset) ) {
-                continue;
-            }
-
-            return array_filter(array(
-                'srcset' => $srcset,
-                'sizes'  => $this->attr($child, 'sizes'),
-            ), static fn (string $value): bool => '' !== $value);
-        }
-
-        return array();
     }
 
     private function safeEmbedUrl(string $url): string

--- a/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
@@ -14,6 +14,20 @@ use DOMNode;
 
 trait FormDispatchTrait
 {
+    /** Bounds for the reported form topology, owned by the dispatch that reads them. */
+    private const MAX_FORM_TOPOLOGY_DEPTH = 8;
+
+    private const MAX_FORM_TOPOLOGY_NODES = 128;
+
+    private const MAX_FORM_TOPOLOGY_CLASSES = 8;
+
+    /** @var array<int, string> */
+    private const FORM_TOPOLOGY_WRAPPER_TAGS = array(
+        'article', 'aside', 'dd', 'div', 'dl', 'dt', 'fieldset', 'footer', 'header',
+        'label', 'li', 'main', 'nav', 'ol', 'p', 'section', 'span', 'table', 'tbody',
+        'td', 'tfoot', 'th', 'thead', 'tr', 'ul',
+    );
+
     /**
      * @param array<int, array<string, mixed>> $fallbacks
      * @return array<string, mixed>|null
@@ -958,21 +972,6 @@ trait FormDispatchTrait
         }
 
         return array() === $selected ? '' : implode(', ', $selected) . ' (selected)';
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    private function searchInputRuntimeAttributes(DOMElement $input): array
-    {
-        if ( ! $this->isRuntimeDomTarget($input) ) {
-            return array();
-        }
-
-        return array_filter(array(
-            'inputAnchor'    => $this->safeAnchor($this->attr($input, 'id')),
-            'inputClassName' => $this->promotedClassName($this->attr($input, 'class')),
-        ), static fn (string $value): bool => '' !== trim($value));
     }
 
     private function formRequiresRuntimePreservation(DOMElement $form): bool

--- a/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
+++ b/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
@@ -254,29 +254,6 @@ final class FontMaterializationPlanBuilder
     }
 
     /**
-     * Parse web-font stylesheet URLs from CSS `@import` rules.
-     *
-     * @return array<int,array{family:string,weights:array<int,int>}>
-     */
-    private function fontUsageFromCssImports(string $css): array
-    {
-        $css = preg_replace('/\/\*.*?\*\//s', '', $css) ?? $css;
-        if ( '' === trim($css) || ! preg_match_all('/@import\s+(?:url\(\s*)?(?:"([^"]+)"|\'([^\']+)\'|([^\s\)"\';]+))/i', $css, $matches, PREG_SET_ORDER) ) {
-            return array();
-        }
-
-        $usage = array();
-        foreach ( $matches as $match ) {
-            $href = (string) (($match[1] ?? '') ?: ($match[2] ?? '') ?: ($match[3] ?? ''));
-            foreach ( $this->fontUsageFromFontHref($href) as $font ) {
-                $usage[] = $font;
-            }
-        }
-
-        return $usage;
-    }
-
-    /**
      * Resolve CSS imports into stable source records and typed face declarations.
      *
      * @param array<int,array<string,mixed>> $cssSources


### PR DESCRIPTION
## Summary

- remove eleven private methods that no source or test path can reach
- remove one unused import and one unused private constant
- move the form-topology bounds into the trait that reads them

Refs #242.

## Why

`HtmlTransformer` has grown to ~13,300 lines across 525 methods plus seven traits, so unreachable members cost review attention on every change. Each member removed here was verified unreferenced across `src` and `tests`, and the package uses no variable method dispatch, so private members are reachable only by their literal name.

`FormDispatchTrait` read four `self::` constants that lived in `HtmlTransformer`, which made the trait depend on its host to compile. The constants are used only by that trait, so they now travel with it.

## Removed

| File | Member |
|---|---|
| `HtmlTransformer` | `authorLayoutLeafBlockFromElement`, `hasBoxAffectingAuthorDeclarations`, `hasPositionedVisualMediaChild`, `pictureSourceAttributes`, `rightmostTypeIsControl`, `soleRichTextAnchor`, `stylingHookSpans`, `StyleAttributeMapper` import |
| `ArtifactCompiler` | `partitionArtifact` |
| `RuntimeDependencyParityReport` | `scriptDomSelectorsFromBundle` |
| `FormDispatchTrait` | `searchInputRuntimeAttributes` |
| `FontMaterializationPlanBuilder` | `fontUsageFromCssImports` |
| `ConversionFindingContract` | `MESSAGE_KEYS` |

Net change: 271 deletions, 14 insertions.

## Evidence

Behavior preservation on a real 130 MB, 19-page artifact: all 19 compiled receipt digests are unchanged, `sha256(digests)` = `9caf6b4fd601b31e65ef33e911eee3081006d3ce14875e18fe00e747c7e95b64`, matching trunk exactly, with 19 HTML document transforms.

## Verification

- `composer test`
- `php tests/contract/run.php`
- 289 parity fixtures
- package installation proof

## AI assistance

OpenAI gpt-5.6-sol was used through OpenCode to scan for unreferenced members, confirm the absence of variable method dispatch, apply the removals, and run verification. The findings and evidence were reviewed and orchestrated by Chris Huber.