### PR TITLE
Extract flow container conversion

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -3691,224 +3691,7 @@ final class HtmlTransformer
         }
 
         if ( ShellLandmarkPolicy::isFlowContainerTag($tagName) ) {
-            if ( $this->shouldPreserveRuntimeAppShell($element) ) {
-                $targets = $this->runtimeTargetsInSubtree($element, 8);
-                $this->recordRuntimeIsland($element, 'app_shell', 'runtime_app_shell', 'client_script_execution', array(
-                    'events'          => $this->eventMetadata($element),
-                    'target_count'    => count($targets),
-                    'targets'         => $targets,
-                    'app_shell_signals' => $this->runtimeAppShellSignals($element),
-                    'required_scripts' => $this->requiredScriptsForElement($element),
-                ));
-
-                return $this->htmlPreservationBlock($element);
-            }
-
-            if ( $this->isEmptyInteractiveFeatureShell($element) ) {
-                return null;
-            }
-
-            $this->captureDivBasedPseudoFormFallback($element, $fallbacks);
-
-            $spacer = $this->recognizePatterns($element, $fallbacks, array(SpacerPattern::class));
-            if ( null !== $spacer ) {
-                return $spacer;
-            }
-
-            $flankedSeparator = $this->flankedSeparatorBlockFromElement($element);
-            if ( null !== $flankedSeparator ) {
-                return $flankedSeparator;
-            }
-
-            $capturedMediaLayout = $this->capturedMediaLayoutBoundaryBlock($element);
-            if ( null !== $capturedMediaLayout ) {
-                return $capturedMediaLayout;
-            }
-
-            // A gallery can only contain native image blocks. Preserve the
-            // complete media collection in the responsive-media companion before
-            // author-layout recognition can create an invalid core/gallery child.
-            if ( $this->hasResponsiveImageSources($element) && $this->hasGalleryMediaItems($element) ) {
-                return $this->responsiveMediaBlock($element);
-            }
-
-            if ( $this->isDirectChildOfAuthorOwnedLayout($element) && '' !== $this->attr($element, 'role') ) {
-                return $this->authorLayoutBlockFromElement($element, $fallbacks);
-            }
-
-            if ( in_array($tagName, array( 'div', 'section', 'article' ), true) && ! $this->hasResponsiveImageSources($element) ) {
-                // A strict two-pane media/text candidate is a more specific
-                // recognition than generic author-owned layout preservation:
-                // media-text candidates are by definition authored flex/grid
-                // containers, so they must be recognized before the layout is
-                // demoted to a css-owned core/group.
-                $mediaText = $this->recognizePatterns($element, $fallbacks, array(MediaTextPattern::class));
-                if ( null !== $mediaText ) {
-                    return $mediaText;
-                }
-            }
-
-            // Keep safe phrasing runs together before generic flex/grid preservation can split
-            // selector-addressed inline targets into block-level children. The recognizer rejects
-            // children with independent layout geometry, so structural inline items still fall
-            // through to the author-owned layout path below.
-            if ( $this->hasMultipleRuntimeInlineTextTargets($element) ) {
-                $inlineContent = $this->paragraphBlockFromInlineContentWrapper($element);
-                if ( null !== $inlineContent ) {
-                    return $inlineContent;
-                }
-            }
-
-            if ( 'button' !== strtolower($this->attr($element, 'role'))
-                && ! $this->hasClass($element, 'wp-block-columns')
-                && ! $this->isGeneratedComponentCandidate($element)
-                && $this->isAuthorOwnedLayout($element)
-            ) {
-                $proofBacked = $this->proofBackedWrapperCoalescing($element, $fallbacks);
-                if (null !== $proofBacked) return $proofBacked;
-                return $this->authorLayoutBlockFromElement($element, $fallbacks);
-            }
-
-            // A direct child of an author-owned layout is itself a layout item.
-            // Keep its semantic container instead of allowing a core Group to
-            // contribute flow layout defaults to the author-owned parent.
-            if ( ! $this->isGeneratedComponentCandidate($element) && $this->isDirectChildOfAuthorOwnedLayout($element) && in_array($tagName, array( 'div', 'section', 'article', 'aside', 'header', 'footer', 'main' ), true) ) {
-                if ( 0 === $this->childElementCount($element) && '' === trim($element->textContent) && $this->shouldPreserveEmptyVisualElement($element) ) {
-                    return $this->createBlock('core/group', $this->emptyVisualElementAttributes($element), array(), $element);
-                }
-                return $this->authorLayoutBlockFromElement($element, $fallbacks);
-            }
-
-            $logo = $this->recognizePatterns($element, $fallbacks, array(LogoPattern::class));
-            if ( null !== $logo ) {
-                return $logo;
-            }
-
-            $navigationSection = $this->navigationSectionBlockFromElement($element);
-            if ( null !== $navigationSection ) {
-                return $navigationSection;
-            }
-
-            if ( ! $this->shouldDeferNavigationPatternToChildren($element) ) {
-                $navigation = $this->recognizePatterns($element, $fallbacks, array(AccordionPattern::class, SocialLinksPattern::class, NavigationPattern::class));
-                if ( null !== $navigation ) {
-                    return $this->rememberAccordionDisclosureRoot($navigation, $element);
-                }
-            }
-
-            if ( in_array($tagName, array( 'div', 'section', 'article' ), true) ) {
-                $metadataGrid = $this->metadataGridBlockFromElement($element);
-                if ( null !== $metadataGrid ) {
-                    return $metadataGrid;
-                }
-
-                $disclosure = $this->recognizePatterns($element, $fallbacks, array(DetailsPattern::class));
-                if ( null !== $disclosure ) {
-                    $this->runtimeBehavior()->rememberNativeDisclosureRoot($element->getNodePath() ?? '');
-
-                    return $disclosure;
-                }
-
-                $cover = $this->recognizePatterns($element, $fallbacks, array(CoverPattern::class));
-                if ( null !== $cover ) {
-                    return $cover;
-                }
-
-                // core/media-text is dispatched earlier in this method, before
-                // author-owned layout preservation — its candidates are by
-                // definition authored flex/grid containers.
-            }
-
-            $columns = $this->recognizePatterns($element, $fallbacks, array(ColumnsPattern::class));
-            if ( null !== $columns ) {
-                return $columns;
-            }
-
-            $gallery = $this->mediaGalleryBlockFromElement($element, $fallbacks);
-            if ( null !== $gallery ) {
-                return $gallery;
-            }
-
-            $codeWindow = $this->recognizePatterns($element, $fallbacks, array(CodeWindowPattern::class));
-            if ( null !== $codeWindow ) {
-                return $codeWindow;
-            }
-
-            $namePriceRow = $this->namePriceRowBlockFromElement($element, $fallbacks);
-            if ( null !== $namePriceRow ) {
-                return $namePriceRow;
-            }
-
-            $inlineTokenGroup = $this->inlineTokenGroupBlockFromElement($element, $fallbacks);
-            if ( null !== $inlineTokenGroup ) {
-                return $inlineTokenGroup;
-            }
-
-            $visualTextWrapper = $this->visualTextWrapperBlockFromElement($element);
-            if ( null !== $visualTextWrapper ) {
-                return $visualTextWrapper;
-            }
-
-            $inlineContent = $this->paragraphBlockFromInlineContentWrapper($element);
-            if ( null !== $inlineContent ) {
-                return $inlineContent;
-            }
-
-            $standaloneSearch = $this->searchBlockFromStandaloneControl($element);
-            if ( null !== $standaloneSearch ) {
-                return $standaloneSearch;
-            }
-
-            $buttons = $this->recognizePatterns($element, $fallbacks, array(ButtonsContainerPattern::class));
-            if ( null !== $buttons ) {
-                return $buttons;
-            }
-
-            // A select's option text is not prose. Route it before generic text
-            // flow can flatten the control into a paragraph.
-            if ( 'select' === $tagName ) {
-                $selectBlock = $this->readableFormControlBlockFromElement($element);
-                if ( null !== $selectBlock ) {
-                    return $selectBlock;
-                }
-            }
-
-            if ( $this->isGeneratedComponentCandidate($element) ) {
-                $generated = $this->fallbackEmitter()->maybeGenerateCustomBlock($element, $this->generatedBlocks(), true, true);
-                if ( null !== $generated ) {
-                    return $this->generatedComponentBlock($generated, $element);
-                }
-            }
-
-            $textFlow = $this->textFlowBlockFromElement($element);
-            if ( null !== $textFlow ) {
-                return $textFlow;
-            }
-
-            $children = $this->convertChildren($element, $fallbacks, true);
-            if ( array() === $children && ! $this->hasDirectMediaChild($element) ) {
-                $backgroundImage = $this->backgroundImageBlockFromElement($element);
-                if ( null !== $backgroundImage ) {
-                    $children[] = $backgroundImage;
-                }
-            }
-            if ( 1 === count($children) ) {
-                $coalesced = $this->coalescedSingleGroupWrapper($element, $children[0]);
-                if ( null !== $coalesced ) {
-                    return $coalesced;
-                }
-                if ( $this->shouldPreserveWrapper($element) || $this->isDirectChildOfAuthorOwnedLayout($element) ) {
-                    return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
-                }
-                return $children[0];
-            }
-            if ( array() !== $children ) {
-                return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
-            }
-            if ( $this->shouldPreserveEmptyVisualElement($element) ) {
-                return $this->emptyVisualSpacerBlock($element);
-            }
-            return null;
+            return $this->convertFlowContainerElement($element, $fallbacks);
         }
 
         if ( $this->isGeneratedComponentCandidate($element) ) {
@@ -3967,6 +3750,238 @@ final class HtmlTransformer
             $fallbacks[] = FallbackDiagnostic::build($fallback, $this->transformationProvenance()->fallback());
         }
 
+        return null;
+    }
+
+    /**
+     * Convert one flow container: a runtime app shell, a recognized
+     * pattern, an author-owned layout, or the group that carries its
+     * converted children.
+     *
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array<string, mixed>|null
+     */
+    private function convertFlowContainerElement(DOMElement $element, array &$fallbacks): ?array
+    {
+        $tagName = strtolower($element->tagName);
+
+        if ( $this->shouldPreserveRuntimeAppShell($element) ) {
+            $targets = $this->runtimeTargetsInSubtree($element, 8);
+            $this->recordRuntimeIsland($element, 'app_shell', 'runtime_app_shell', 'client_script_execution', array(
+                'events'          => $this->eventMetadata($element),
+                'target_count'    => count($targets),
+                'targets'         => $targets,
+                'app_shell_signals' => $this->runtimeAppShellSignals($element),
+                'required_scripts' => $this->requiredScriptsForElement($element),
+            ));
+
+            return $this->htmlPreservationBlock($element);
+        }
+
+        if ( $this->isEmptyInteractiveFeatureShell($element) ) {
+            return null;
+        }
+
+        $this->captureDivBasedPseudoFormFallback($element, $fallbacks);
+
+        $spacer = $this->recognizePatterns($element, $fallbacks, array(SpacerPattern::class));
+        if ( null !== $spacer ) {
+            return $spacer;
+        }
+
+        $flankedSeparator = $this->flankedSeparatorBlockFromElement($element);
+        if ( null !== $flankedSeparator ) {
+            return $flankedSeparator;
+        }
+
+        $capturedMediaLayout = $this->capturedMediaLayoutBoundaryBlock($element);
+        if ( null !== $capturedMediaLayout ) {
+            return $capturedMediaLayout;
+        }
+
+        // A gallery can only contain native image blocks. Preserve the
+        // complete media collection in the responsive-media companion before
+        // author-layout recognition can create an invalid core/gallery child.
+        if ( $this->hasResponsiveImageSources($element) && $this->hasGalleryMediaItems($element) ) {
+            return $this->responsiveMediaBlock($element);
+        }
+
+        if ( $this->isDirectChildOfAuthorOwnedLayout($element) && '' !== $this->attr($element, 'role') ) {
+            return $this->authorLayoutBlockFromElement($element, $fallbacks);
+        }
+
+        if ( in_array($tagName, array( 'div', 'section', 'article' ), true) && ! $this->hasResponsiveImageSources($element) ) {
+            // A strict two-pane media/text candidate is a more specific
+            // recognition than generic author-owned layout preservation:
+            // media-text candidates are by definition authored flex/grid
+            // containers, so they must be recognized before the layout is
+            // demoted to a css-owned core/group.
+            $mediaText = $this->recognizePatterns($element, $fallbacks, array(MediaTextPattern::class));
+            if ( null !== $mediaText ) {
+                return $mediaText;
+            }
+        }
+
+        // Keep safe phrasing runs together before generic flex/grid preservation can split
+        // selector-addressed inline targets into block-level children. The recognizer rejects
+        // children with independent layout geometry, so structural inline items still fall
+        // through to the author-owned layout path below.
+        if ( $this->hasMultipleRuntimeInlineTextTargets($element) ) {
+            $inlineContent = $this->paragraphBlockFromInlineContentWrapper($element);
+            if ( null !== $inlineContent ) {
+                return $inlineContent;
+            }
+        }
+
+        if ( 'button' !== strtolower($this->attr($element, 'role'))
+            && ! $this->hasClass($element, 'wp-block-columns')
+            && ! $this->isGeneratedComponentCandidate($element)
+            && $this->isAuthorOwnedLayout($element)
+        ) {
+            $proofBacked = $this->proofBackedWrapperCoalescing($element, $fallbacks);
+            if (null !== $proofBacked) return $proofBacked;
+            return $this->authorLayoutBlockFromElement($element, $fallbacks);
+        }
+
+        // A direct child of an author-owned layout is itself a layout item.
+        // Keep its semantic container instead of allowing a core Group to
+        // contribute flow layout defaults to the author-owned parent.
+        if ( ! $this->isGeneratedComponentCandidate($element) && $this->isDirectChildOfAuthorOwnedLayout($element) && in_array($tagName, array( 'div', 'section', 'article', 'aside', 'header', 'footer', 'main' ), true) ) {
+            if ( 0 === $this->childElementCount($element) && '' === trim($element->textContent) && $this->shouldPreserveEmptyVisualElement($element) ) {
+                return $this->createBlock('core/group', $this->emptyVisualElementAttributes($element), array(), $element);
+            }
+            return $this->authorLayoutBlockFromElement($element, $fallbacks);
+        }
+
+        $logo = $this->recognizePatterns($element, $fallbacks, array(LogoPattern::class));
+        if ( null !== $logo ) {
+            return $logo;
+        }
+
+        $navigationSection = $this->navigationSectionBlockFromElement($element);
+        if ( null !== $navigationSection ) {
+            return $navigationSection;
+        }
+
+        if ( ! $this->shouldDeferNavigationPatternToChildren($element) ) {
+            $navigation = $this->recognizePatterns($element, $fallbacks, array(AccordionPattern::class, SocialLinksPattern::class, NavigationPattern::class));
+            if ( null !== $navigation ) {
+                return $this->rememberAccordionDisclosureRoot($navigation, $element);
+            }
+        }
+
+        if ( in_array($tagName, array( 'div', 'section', 'article' ), true) ) {
+            $metadataGrid = $this->metadataGridBlockFromElement($element);
+            if ( null !== $metadataGrid ) {
+                return $metadataGrid;
+            }
+
+            $disclosure = $this->recognizePatterns($element, $fallbacks, array(DetailsPattern::class));
+            if ( null !== $disclosure ) {
+                $this->runtimeBehavior()->rememberNativeDisclosureRoot($element->getNodePath() ?? '');
+
+                return $disclosure;
+            }
+
+            $cover = $this->recognizePatterns($element, $fallbacks, array(CoverPattern::class));
+            if ( null !== $cover ) {
+                return $cover;
+            }
+
+            // core/media-text is dispatched earlier in this method, before
+            // author-owned layout preservation — its candidates are by
+            // definition authored flex/grid containers.
+        }
+
+        $columns = $this->recognizePatterns($element, $fallbacks, array(ColumnsPattern::class));
+        if ( null !== $columns ) {
+            return $columns;
+        }
+
+        $gallery = $this->mediaGalleryBlockFromElement($element, $fallbacks);
+        if ( null !== $gallery ) {
+            return $gallery;
+        }
+
+        $codeWindow = $this->recognizePatterns($element, $fallbacks, array(CodeWindowPattern::class));
+        if ( null !== $codeWindow ) {
+            return $codeWindow;
+        }
+
+        $namePriceRow = $this->namePriceRowBlockFromElement($element, $fallbacks);
+        if ( null !== $namePriceRow ) {
+            return $namePriceRow;
+        }
+
+        $inlineTokenGroup = $this->inlineTokenGroupBlockFromElement($element, $fallbacks);
+        if ( null !== $inlineTokenGroup ) {
+            return $inlineTokenGroup;
+        }
+
+        $visualTextWrapper = $this->visualTextWrapperBlockFromElement($element);
+        if ( null !== $visualTextWrapper ) {
+            return $visualTextWrapper;
+        }
+
+        $inlineContent = $this->paragraphBlockFromInlineContentWrapper($element);
+        if ( null !== $inlineContent ) {
+            return $inlineContent;
+        }
+
+        $standaloneSearch = $this->searchBlockFromStandaloneControl($element);
+        if ( null !== $standaloneSearch ) {
+            return $standaloneSearch;
+        }
+
+        $buttons = $this->recognizePatterns($element, $fallbacks, array(ButtonsContainerPattern::class));
+        if ( null !== $buttons ) {
+            return $buttons;
+        }
+
+        // A select's option text is not prose. Route it before generic text
+        // flow can flatten the control into a paragraph.
+        if ( 'select' === $tagName ) {
+            $selectBlock = $this->readableFormControlBlockFromElement($element);
+            if ( null !== $selectBlock ) {
+                return $selectBlock;
+            }
+        }
+
+        if ( $this->isGeneratedComponentCandidate($element) ) {
+            $generated = $this->fallbackEmitter()->maybeGenerateCustomBlock($element, $this->generatedBlocks(), true, true);
+            if ( null !== $generated ) {
+                return $this->generatedComponentBlock($generated, $element);
+            }
+        }
+
+        $textFlow = $this->textFlowBlockFromElement($element);
+        if ( null !== $textFlow ) {
+            return $textFlow;
+        }
+
+        $children = $this->convertChildren($element, $fallbacks, true);
+        if ( array() === $children && ! $this->hasDirectMediaChild($element) ) {
+            $backgroundImage = $this->backgroundImageBlockFromElement($element);
+            if ( null !== $backgroundImage ) {
+                $children[] = $backgroundImage;
+            }
+        }
+        if ( 1 === count($children) ) {
+            $coalesced = $this->coalescedSingleGroupWrapper($element, $children[0]);
+            if ( null !== $coalesced ) {
+                return $coalesced;
+            }
+            if ( $this->shouldPreserveWrapper($element) || $this->isDirectChildOfAuthorOwnedLayout($element) ) {
+                return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
+            }
+            return $children[0];
+        }
+        if ( array() !== $children ) {
+            return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
+        }
+        if ( $this->shouldPreserveEmptyVisualElement($element) ) {
+            return $this->emptyVisualSpacerBlock($element);
+        }
         return null;
     }
 


### PR DESCRIPTION
## Summary

- move the flow-container branch of `convertElement()` into `convertFlowContainerElement()`
- keep the branch body verbatim apart from one dedent level

Refs #242.

## Why

`convertElement()` was 932 lines, 3.4x the next largest method in the package, and reading any single tag branch meant scrolling past every other one. Its flow-container branch was the largest at 220 lines.

The branch is a clean seam:

- it reads only `$element`, `$fallbacks`, and `$tagName` from the enclosing scope, and `$tagName` is derived from `$element`
- its final statement is an unconditional `return null;`, so every path already returned and no execution could fall through to the branches below it

`convertElement()` is now 715 lines and the extracted behavior has a name.

## Evidence

Behavior preservation on a real 130 MB, 19-page artifact: all 19 compiled receipt digests are unchanged, `sha256(digests)` = `9caf6b4fd601b31e65ef33e911eee3081006d3ce14875e18fe00e747c7e95b64`, matching trunk exactly, with 19 HTML document transforms.

## Verification

- `composer test`
- `php tests/contract/run.php`
- 289 parity fixtures
- package installation proof

## AI assistance

OpenAI gpt-5.6-sol was used through OpenCode to measure method sizes, verify the branch had no free variables and no fall-through path, perform the extraction, and run verification. The seam analysis and evidence were reviewed and orchestrated by Chris Huber.