### PR TITLE
fix(php-transformer): scan inline styles without PCRE backtracking

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -86,6 +86,7 @@
       "php tests/unit/media-text-pattern.php",
       "php tests/unit/cover-style-resolver.php",
       "php tests/unit/css-stylesheet-transformer.php",
+      "php tests/unit/style-tag-scanner.php",
       "php tests/unit/admin-bar-accommodation.php",
       "php tests/unit/css-rule-analyzer.php",
       "php tests/unit/css-selector-matcher.php",

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -16,6 +16,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformerAnalysisC
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AdminBarAccommodation;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssStylesheetTransformer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\FormLayoutGraphBuilder;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleTagScanner;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\ShellLandmarkPolicy;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\MaterializationPlanBuilder;
@@ -2467,37 +2468,34 @@ final class ArtifactCompiler
         $seenPaths = array();
         $inlineIndex = 0;
         $linkOccurrences = array();
-        if ( preg_match_all('/<style\b[^>]*>.*?<\/style>|<link\b[^>]*>/is', $html, $matches) ) {
-            foreach ( $matches[0] as $tag ) {
-                if ( preg_match('/^<style\b/i', $tag) ) {
-                    $attributes = '';
-                    preg_match('/^<style\b([^>]*)>/i', $tag, $styleMatch);
-                    $attributes = (string) ($styleMatch[1] ?? '');
-                    if ( ! $this->isCssStylesheetType($this->htmlAttribute($attributes, 'type')) ) {
-                        continue;
-                    }
-                    if ( '' === trim((string) preg_replace('@^<style\b[^>]*>|</style>$@is', '', $tag)) ) {
-                        continue;
-                    }
-                    ++$inlineIndex;
-                    $file = $inline[$inlineIndex] ?? null;
-                    if ( is_array($file) && ! isset($seenPaths[$file['path']]) ) {
-                        $assets[] = array( 'path' => $file['path'], 'source_path' => $file['source_path'] ?? $file['path'], 'content' => $file['content'], 'source_hash' => (string) ($file['provenance']['hash'] ?? hash('sha256', $file['content']) ), 'media' => (string) ($file['media'] ?? ''), 'type' => (string) ($file['type'] ?? '') );
-                        $seenPaths[$file['path']] = true;
-                    }
+        foreach ( StyleTagScanner::styleAndLinkTags($html) as $token ) {
+            if ( 'style' === $token['kind'] ) {
+                $attributes = $token['attributes'];
+                if ( ! $this->isCssStylesheetType($this->htmlAttribute($attributes, 'type')) ) {
                     continue;
                 }
-                if ( ! preg_match('/^<link\b/i', $tag) || ! preg_match('/(?:^|\s)stylesheet(?:\s|$)/i', $this->htmlAttribute((string) $tag, 'rel') ) || ! $this->isCssStylesheetType($this->htmlAttribute((string) $tag, 'type')) ) {
+                if ( '' === trim($token['css']) ) {
                     continue;
                 }
-                $sourcePathForLink = $this->stylesheetPathFromHref($this->htmlAttribute((string) $tag, 'href'), $sourcePath, $files);
-                $linkOccurrences[$sourcePathForLink] = ($linkOccurrences[$sourcePathForLink] ?? 0) + 1;
-                $path = $occurrencePaths[$sourcePathForLink][$linkOccurrences[$sourcePathForLink]] ?? '';
-                $file = $byPath[$path] ?? null;
-                if ( is_array($file) && ! isset($seenPaths[$path]) ) {
-                    $assets[] = array( 'path' => $path, 'source_path' => $file['stylesheet_source_path'] ?? $sourcePathForLink, 'content' => $file['content'], 'source_hash' => (string) ($file['provenance']['hash'] ?? hash('sha256', $file['content']) ), 'media' => $this->htmlAttribute((string) $tag, 'media'), 'type' => $this->htmlAttribute((string) $tag, 'type') );
-                    $seenPaths[$path] = true;
+                ++$inlineIndex;
+                $file = $inline[$inlineIndex] ?? null;
+                if ( is_array($file) && ! isset($seenPaths[$file['path']]) ) {
+                    $assets[] = array( 'path' => $file['path'], 'source_path' => $file['source_path'] ?? $file['path'], 'content' => $file['content'], 'source_hash' => (string) ($file['provenance']['hash'] ?? hash('sha256', $file['content']) ), 'media' => (string) ($file['media'] ?? ''), 'type' => (string) ($file['type'] ?? '') );
+                    $seenPaths[$file['path']] = true;
                 }
+                continue;
+            }
+            $tag = $token['markup'];
+            if ( ! preg_match('/(?:^|\s)stylesheet(?:\s|$)/i', $this->htmlAttribute($tag, 'rel') ) || ! $this->isCssStylesheetType($this->htmlAttribute($tag, 'type')) ) {
+                continue;
+            }
+            $sourcePathForLink = $this->stylesheetPathFromHref($this->htmlAttribute($tag, 'href'), $sourcePath, $files);
+            $linkOccurrences[$sourcePathForLink] = ($linkOccurrences[$sourcePathForLink] ?? 0) + 1;
+            $path = $occurrencePaths[$sourcePathForLink][$linkOccurrences[$sourcePathForLink]] ?? '';
+            $file = $byPath[$path] ?? null;
+            if ( is_array($file) && ! isset($seenPaths[$path]) ) {
+                $assets[] = array( 'path' => $path, 'source_path' => $file['stylesheet_source_path'] ?? $sourcePathForLink, 'content' => $file['content'], 'source_hash' => (string) ($file['provenance']['hash'] ?? hash('sha256', $file['content']) ), 'media' => $this->htmlAttribute($tag, 'media'), 'type' => $this->htmlAttribute($tag, 'type') );
+                $seenPaths[$path] = true;
             }
         }
         return $assets;

--- a/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
 
 use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\ReferenceAnalyzer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleTagScanner;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
 
 /**
@@ -397,14 +398,14 @@ final class ArtifactNormalizer
                 continue;
             }
             $content = $this->payload($file, (string) ($file['path'] ?? ''))['content'];
-            if ( ! $this->isHtmlLikeFile($file) || '' === trim($content) || ! preg_match_all('@<style\b([^>]*)>(.*?)</style>@is', $content, $matches, PREG_SET_ORDER) ) {
+            if ( ! $this->isHtmlLikeFile($file) || '' === trim($content) ) {
                 continue;
             }
 
             $styles = array();
-            foreach ( $matches as $match ) {
-                $attributes = (string) $match[1];
-                $css = trim((string) $match[2]);
+            foreach ( StyleTagScanner::styleBlocks($content) as $block ) {
+                $attributes = $block['attributes'];
+                $css = trim($block['css']);
                 if ( '' === $css || ! $this->isCssType($this->htmlAttribute($attributes, 'type')) ) {
                     continue;
                 }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -57,6 +57,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AdminBarAccommodat
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssValueSplitter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\FormLayoutGraphBuilder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleAttributeMapper;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleTagScanner;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\BackgroundImageExtractor;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\ButtonLinkDispatchTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\DomHelpersTrait;
@@ -2746,12 +2747,10 @@ final class HtmlTransformer
     private function combinedAuthorStylesheet(string $html, string $staticCss): string
     {
         $cssParts = array();
-        if ( preg_match_all('@<style\b[^>]*>(.*?)</style>@is', $html, $matches) ) {
-            foreach ( $matches[1] as $styleBlock ) {
-                $styleBlock = trim(html_entity_decode((string) $styleBlock, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
-                if ( '' !== $styleBlock ) {
-                    $cssParts[] = $styleBlock;
-                }
+        foreach ( StyleTagScanner::styleBlocks($html) as $block ) {
+            $styleBlock = trim(html_entity_decode($block['css'], ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+            if ( '' !== $styleBlock ) {
+                $cssParts[] = $styleBlock;
             }
         }
         $staticCss = trim($staticCss);
@@ -2824,11 +2823,7 @@ final class HtmlTransformer
     /** @return list<string> */
     private function inlineStylesheetPayloads(string $html): array
     {
-        if ( ! preg_match_all('@<style\b[^>]*>(.*?)</style>@is', $html, $matches) ) {
-            return array();
-        }
-
-        return array_map(static fn (string $payload): string => trim($payload), $matches[1]);
+        return array_map(static fn (array $block): string => trim($block['css']), StyleTagScanner::styleBlocks($html));
     }
 
     /** @param list<string> $payloads */

--- a/php-transformer/src/HtmlToBlocks/Style/StyleTagScanner.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleTagScanner.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
+
+/**
+ * Linear extraction of `<style>` blocks (and stylesheet `<link>` tags) from HTML.
+ *
+ * `preg_match_all('@<style\b([^>]*)>(.*?)</style>@is', ...)` exhausts PCRE's
+ * backtracking budget (pcre.backtrack_limit, 1,000,000 by default) once a
+ * single style body approaches ~1MB and then returns `false`, which call sites
+ * cannot distinguish from "no matches" — so every author stylesheet on the
+ * page is silently dropped. Captured pages routinely carry multi-megabyte
+ * inline stylesheets, so extraction must not depend on PCRE limits.
+ *
+ * This scanner walks the document once with `stripos()`/`strpos()` and
+ * preserves the regex's semantics for well-formed input: case-insensitive
+ * tags, attributes read up to the first `>`, verbatim body capture, and an
+ * unclosed `<style>` yields no match.
+ *
+ * @internal Shared style-tag extraction for compiler and transformer paths.
+ */
+final class StyleTagScanner
+{
+    /**
+     * Every `<style>` block in document order. Bodies are verbatim; callers
+     * own trimming and type filtering.
+     *
+     * @return list<array{attributes: string, css: string}>
+     */
+    public static function styleBlocks(string $html): array
+    {
+        $blocks = array();
+        foreach ( self::styleBlockSpans($html) as $span ) {
+            $blocks[] = array( 'attributes' => $span['attributes'], 'css' => $span['css'] );
+        }
+
+        return $blocks;
+    }
+
+    /**
+     * Every `<style>` block and `<link>` tag in interleaved document order,
+     * preserving the cascade order of inline and linked stylesheets. As with
+     * the regex alternation this replaces, a `<link>` inside a style element
+     * is not emitted.
+     *
+     * @return list<array{kind: 'style', attributes: string, css: string}|array{kind: 'link', markup: string}>
+     */
+    public static function styleAndLinkTags(string $html): array
+    {
+        $spans = self::styleBlockSpans($html);
+        $entries = array();
+        foreach ( $spans as $span ) {
+            $entries[] = array(
+                'offset' => $span['start'],
+                'token' => array( 'kind' => 'style', 'attributes' => $span['attributes'], 'css' => $span['css'] ),
+            );
+        }
+        if ( preg_match_all('/<link\b[^>]*>/i', $html, $matches, PREG_OFFSET_CAPTURE) ) {
+            $spanIndex = 0;
+            $spanCount = count($spans);
+            foreach ( $matches[0] as $match ) {
+                $offset = (int) $match[1];
+                while ( $spanIndex < $spanCount && $spans[$spanIndex]['end'] <= $offset ) {
+                    ++$spanIndex;
+                }
+                if ( $spanIndex < $spanCount && $spans[$spanIndex]['start'] <= $offset ) {
+                    continue;
+                }
+                $entries[] = array( 'offset' => $offset, 'token' => array( 'kind' => 'link', 'markup' => (string) $match[0] ) );
+            }
+        }
+        usort($entries, static fn (array $a, array $b): int => $a['offset'] <=> $b['offset']);
+
+        return array_column($entries, 'token');
+    }
+
+    /**
+     * @return list<array{start: int, end: int, attributes: string, css: string}>
+     */
+    private static function styleBlockSpans(string $html): array
+    {
+        $spans = array();
+        $offset = 0;
+        $length = strlen($html);
+        while ( $offset < $length && false !== ( $start = stripos($html, '<style', $offset) ) ) {
+            $openEnd = strpos($html, '>', $start + 6);
+            if ( false === $openEnd ) {
+                break;
+            }
+            $attributes = substr($html, $start + 6, $openEnd - $start - 6);
+            if ( '' !== $attributes && 1 !== preg_match('/^[\s\/]/', $attributes) ) {
+                // A longer tag name (e.g. a <style-guide> custom element), not a style boundary.
+                $offset = $start + 6;
+                continue;
+            }
+            $close = stripos($html, '</style>', $openEnd + 1);
+            if ( false === $close ) {
+                break;
+            }
+            $spans[] = array(
+                'start' => $start,
+                'end' => $close + 8,
+                'attributes' => rtrim($attributes, '/'),
+                'css' => substr($html, $openEnd + 1, $close - $openEnd - 1),
+            );
+            $offset = $close + 8;
+        }
+
+        return $spans;
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssStylesheetTransformer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleTagScanner;
 use DOMElement;
 
 trait SvgMaterializationTrait
@@ -552,8 +553,9 @@ trait SvgMaterializationTrait
     private function cssCustomProperties(string $html, string $linkedCss): array
     {
         $css = trim($linkedCss);
-        if ( preg_match_all('@<style\b[^>]*>(.*?)</style>@is', $html, $matches) ) {
-            $css .= ( '' === $css ? '' : "\n" ) . implode("\n", array_map('trim', $matches[1]));
+        $styleBlocks = StyleTagScanner::styleBlocks($html);
+        if ( array() !== $styleBlocks ) {
+            $css .= ( '' === $css ? '' : "\n" ) . implode("\n", array_map(static fn (array $block): string => trim($block['css']), $styleBlocks));
         }
         if ( '' === trim($css) ) {
             return array();

--- a/php-transformer/tests/unit/style-tag-scanner.php
+++ b/php-transformer/tests/unit/style-tag-scanner.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleTagScanner;
+
+$assert = static function (bool $condition, string $message): void {
+    if (!$condition) {
+        fwrite(STDERR, 'FAIL: ' . $message . PHP_EOL);
+        exit(1);
+    }
+};
+
+// Parity with the regex the scanner replaced, on well-formed markup.
+$html = '<html><head><style type="text/css" media="(max-width: 600px)">.a{color:red}</style>'
+    . '<link rel="stylesheet" href="site.css"><STYLE>.b{color:blue}</STYLE>'
+    . '<link rel="icon" href="favicon.ico"></head><body><style>p{margin:0}</style></body></html>';
+$blocks = StyleTagScanner::styleBlocks($html);
+preg_match_all('@<style\b([^>]*)>(.*?)</style>@is', $html, $regex, PREG_SET_ORDER);
+$assert(count($regex) === count($blocks), 'scanner finds the same style blocks as the regex');
+foreach ($regex as $index => $match) {
+    $assert($blocks[$index]['attributes'] === $match[1] && $blocks[$index]['css'] === $match[2], 'scanner block ' . $index . ' matches the regex capture');
+}
+
+$tokens = StyleTagScanner::styleAndLinkTags($html);
+$assert(array('style', 'link', 'style', 'link', 'style') === array_column($tokens, 'kind'), 'style and link tags interleave in document order');
+$assert('<link rel="stylesheet" href="site.css">' === ($tokens[1]['markup'] ?? ''), 'link tokens carry the raw tag markup');
+$assert('.b{color:blue}' === ($tokens[2]['css'] ?? ''), 'uppercase style tags are scanned case-insensitively');
+
+$assert(array() === StyleTagScanner::styleBlocks('<style>.unclosed{color:red}'), 'an unclosed style tag yields no match, like the regex');
+$assert(array(array('attributes' => '', 'css' => '.real{}')) === StyleTagScanner::styleBlocks('<style-guide>copy</style-guide><style>.real{}</style>'), 'longer tag names are not style boundaries');
+$assert(array(
+    array('kind' => 'style', 'attributes' => '', 'css' => '.a{content:"x"}<link rel="stylesheet" href="in.css">'),
+    array('kind' => 'link', 'markup' => '<link rel="stylesheet" href="out.css">'),
+) === StyleTagScanner::styleAndLinkTags('<style>.a{content:"x"}<link rel="stylesheet" href="in.css"></style><link rel="stylesheet" href="out.css">'), 'links inside a style body are not emitted');
+
+// Regression for issue #1241: one style body beyond pcre.backtrack_limit made
+// preg_match_all() return false, and every author stylesheet on the page was
+// silently dropped. The fixture must run under DEFAULT pcre ini values.
+$bigCss = str_repeat('.bulk{background-image:url(data:image/png;base64,' . str_repeat('QUJD', 1500) . ')}', 200) . '.big-marker{color:#00fed1}';
+$smallCss = '.small-marker{color:#123456}';
+$hugeHtml = '<html><head><style>' . $bigCss . '</style><style media="print">' . $smallCss . '</style></head>'
+    . '<body><p class="big-marker">Big</p><p class="small-marker">Small</p></body></html>';
+
+preg_match_all('@<style\b([^>]*)>(.*?)</style>@is', $hugeHtml, $unused);
+$assert(PREG_BACKTRACK_LIMIT_ERROR === preg_last_error(), 'precondition: the fixture exhausts the default PCRE backtrack limit');
+
+$scanned = StyleTagScanner::styleBlocks($hugeHtml);
+$assert(2 === count($scanned), 'the scanner is immune to the PCRE backtrack limit');
+$assert($bigCss === $scanned[0]['css'] && $smallCss === $scanned[1]['css'] && ' media="print"' === $scanned[1]['attributes'], 'oversized and trailing style blocks are captured verbatim');
+
+$result = ( new ArtifactCompiler() )->compile(array(
+    'files' => array(
+        array( 'path' => 'index.html', 'kind' => 'html', 'content' => $hugeHtml ),
+    ),
+) )->toArray();
+$assets = array_values(array_filter($result['assets'] ?? array(), 'is_array'));
+$assetPaths = array_column($assets, 'path');
+$assetCss = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), $assets));
+$assert(in_array('index.inline-1.css', $assetPaths, true) && in_array('index.inline-2.css', $assetPaths, true), 'both inline style tags materialize as author stylesheet assets');
+$assert(str_contains($assetCss, 'color:#00fed1'), 'author styles from the oversized style tag survive compilation');
+$assert(str_contains($assetCss, 'color:#123456'), 'author styles from the style tag after the oversized one survive compilation');
+
+fwrite(STDOUT, "StyleTagScanner unit tests passed.\n");


### PR DESCRIPTION
## Problem

Compiling a captured page whose HTML carries a large inline `<style>` tag (>~1MB) silently loses every author stylesheet for that page: no `inline-style` records are materialized, no stylesheet bundles are emitted, and the page renders as bare document flow — with no diagnostic. On the #1241 reproduction (360chiro.co.uk, Wix, 16 routes), 13 pages styled correctly while the two pages carrying 2.65MB / 1.46MB style tags materialized unstyled. Wix captures routinely carry 1–3MB inline style payloads.

## Root cause

`preg_match_all('@<style\b([^>]*)>(.*?)</style>@is', ...)` exhausts PCRE's default backtracking budget (`pcre.backtrack_limit` = 1,000,000) once a single style body approaches ~1MB and returns `false`. Every call site treated `false` exactly like "no matches":

- `ArtifactNormalizer::withInlineStyleFiles()` — the page is skipped, so no inline-style assets exist (the proven production loss)
- `ArtifactCompiler::stylesheetAssetsForSource()` — ALL stylesheet assets for the page are dropped, linked CSS included, because the style/link alternation regex fails as a whole
- `HtmlTransformer::combinedAuthorStylesheet()` and `HtmlTransformer::inlineStylesheetPayloads()`
- `SvgMaterializationTrait::cssCustomProperties()`

## Fix

One shared linear scanner, `HtmlToBlocks\Style\StyleTagScanner` (a `stripos`/`strpos` walk, no backtracking), now backs all five sites:

- `styleBlocks()` — (attributes, css) pairs per style tag, verbatim capture
- `styleAndLinkTags()` — style and link tags in interleaved document order, preserving the cascade order `stylesheetAssetsForSource()` depends on (`<link\b[^>]*>` offsets merged against style spans; that pattern cannot backtrack pathologically)

Semantics are preserved for well-formed input: case-insensitive tags, attributes read up to the first `>`, verbatim bodies, an unclosed `<style>` yields no match, and a `<link>` inside a style body is not emitted. A 3,000-case randomized parity fuzz against the old regex found no divergence on well-formed markup; the one intentional divergence is that longer tag names (e.g. a `<style-guide>` custom element) are no longer treated as style openers, which the regex's `\b` wrongly accepted.

## Test evidence

`php-transformer/tests/unit/style-tag-scanner.php`, registered in the `test:unit` script:

- scanner/regex parity on well-formed markup, interleaved style+link document order, unclosed tags, case-insensitivity
- regression at integration level: a page with a ~1.2MB style tag followed by a small one first asserts the fixture really exhausts the default backtrack limit (`PREG_BACKTRACK_LIMIT_ERROR`), then compiles through `ArtifactCompiler::compile` and asserts both tags materialize (`index.inline-1.css`, `index.inline-2.css`) with their content present in emitted assets — under default pcre ini values

On trunk the integration section fails (zero stylesheet assets emitted for the page). With the fix, block output for the oversized page is byte-identical to the same page carrying a small style tag, and assets hold exactly one copy of the oversized CSS.

Local verification: `composer validate --strict`; the new test plus `responsive-document-variants`, `artifact-author-stylesheet-projection`, `compile-fragment-author-stylesheet`, and `artifact-normalizer-source-budget` all pass under `php -d memory_limit=1G`; parity (289 fixtures) and packaging pass. The only local `composer test` failure is the pre-existing 128M memory exhaustion in `html-transformer-shared-analysis-cache.php`, which fails identically on clean trunk and passes with `memory_limit=1G`.

## Out of scope / follow-up

A few other `<style` regexes remain (`ArtifactCompiler::withoutMaterializedStyleTags()` and the engine-support CSS collection, `ResponsiveDocumentVariants::styles()`, `TypographyParityAnalyzer`, `AssetReferenceCanonicalizer`). The block-materialization path was verified unaffected on oversized pages (byte-identical output as above); the rest degrade analysis or reference-rewriting quality on oversized bodies rather than dropping page assets, and can move to the scanner in a follow-up.

Fixes #1241

🤖 Generated with [Claude Code](https://claude.com/claude-code)
