### PR TITLE
fix(php-transformer): apply depth-pressure compression without geometry proofs

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -70,6 +70,7 @@
        "php tests/unit/authored-marquee-block.php",
        "php tests/unit/responsive-document-variants.php",
        "php tests/unit/editability-report.php",
+      "php tests/unit/depth-pressure-compression.php",
       "php tests/unit/core-block-capability-matrix.php",
       "php tests/unit/list-item-lowering.php",
       "php tests/unit/artifact-normalizer-idempotence.php",

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -524,7 +524,11 @@ final class HtmlTransformer
         $this->collectGeneratedComponentCandidates($body);
         $blocks      = $this->navigationBlockNormalizer->normalize($this->convertChildren($body, $fallbacks, true), $this->transformationProvenance()->sources(), $this->transformationProvenance()->sourceBaseHiddenStates());
         $blocks = $this->compressProjectedGroupChains($blocks);
-        if ($this->layoutGeometry()->hasProofReductions() && self::MAX_NATIVE_LIST_VIEW_DEPTH < $this->blockTreeDepth($blocks)) {
+        // Last resort under measured depth pressure: past this cap the
+        // editability policy hard-fails the document anyway, so admit exact
+        // two-wrapper branch shells whether or not layout-geometry proofs
+        // accompanied the artifact.
+        if (self::MAX_NATIVE_LIST_VIEW_DEPTH < $this->blockTreeDepth($blocks)) {
             $blocks = $this->compressProjectedGroupChains($blocks, true);
         }
         $fallbacks = array_merge($fallbacks, $this->transformationEvidence()->responsiveImageFallbacks());

--- a/php-transformer/tests/unit/depth-pressure-compression.php
+++ b/php-transformer/tests/unit/depth-pressure-compression.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
+
+$assert = static function (bool $condition, string $message): void {
+    if (!$condition) {
+        fwrite(STDERR, 'FAIL: ' . $message . PHP_EOL);
+        exit(1);
+    }
+};
+
+/**
+ * Each unit contributes an exact two-wrapper projected branch chain: a
+ * single-child outer group holding a branch group with two children (a
+ * paragraph and the next unit). The conservative compression threshold of
+ * three wrappers leaves every unit intact, so twelve nested units compile
+ * about twenty-five levels deep — past the editability policy's twenty —
+ * while the depth-pressure pass compresses each unit to one layout shell.
+ * No layout-geometry proof accompanies the artifact.
+ */
+$units = 12;
+$deepMarkup = '<h3>Depth leaf heading</h3><p>Depth leaf paragraph</p>';
+for ($unit = $units; 1 <= $unit; $unit--) {
+    $deepMarkup = '<div id="dp-outer-' . $unit . '" class="blocks-engine-source-div-dp-outer' . $unit . '-1">'
+        . '<div id="dp-branch-' . $unit . '" class="blocks-engine-source-div-dp-branch' . $unit . '-1">'
+        . $deepMarkup
+        . '</div></div>';
+    if (1 < $unit) {
+        $deepMarkup = '<p>Depth unit ' . $unit . ' content</p>' . $deepMarkup;
+    }
+}
+
+$deepArtifact = array(
+    'schema' => ArtifactCompiler::INPUT_SCHEMA,
+    'entrypoint' => 'website/index.html',
+    'files' => array(
+        array(
+            'path' => 'website/index.html',
+            'content' => '<!doctype html><html><head></head><body>' . $deepMarkup . '</body></html>',
+        ),
+    ),
+);
+
+$deepResult = (new ArtifactCompiler())->compile($deepArtifact)->toArray();
+$deepCodes = array_column($deepResult['diagnostics'] ?? array(), 'code');
+$deepQuality = $deepResult['source_reports']['wordpress_site_plan']['quality'] ?? array();
+$deepMetrics = $deepResult['source_reports']['editability_report']['metrics'] ?? array();
+$deepBlocks = (string) ($deepResult['serialized_blocks'] ?? '');
+
+$assert(!in_array('editability_policy_failed', $deepCodes, true), 'A proof-free page over the depth cap compiles without an editability policy failure.');
+$assert('failed' !== ($deepResult['status'] ?? null), 'A proof-free page over the depth cap does not fail the whole compile.');
+$assert(true === ($deepQuality['pass'] ?? null) && 'failed' !== ($deepQuality['status'] ?? null), 'The canonical plan quality gate passes without layout-geometry proofs.');
+$assert('passed' === ($deepQuality['editability_policy']['status'] ?? null), 'The plan editability policy verdict is passed, not failed.');
+$assert(is_int($deepMetrics['max_nesting_depth'] ?? null) && 20 >= $deepMetrics['max_nesting_depth'], 'Depth-pressure compression brings the measured nesting depth within the editability maximum.');
+$assert($units === substr_count($deepBlocks, '<!-- wp:custom/layout-shell'), 'Depth pressure compresses every two-wrapper projected branch into a layout shell.');
+$assert(str_contains($deepBlocks, '>Depth leaf heading<') && str_contains($deepBlocks, '>Depth leaf paragraph<') && str_contains($deepBlocks, '>Depth unit 2 content<'), 'Compressed output preserves the deep editable content.');
+$assert(str_contains($deepBlocks, 'id="dp-outer-1"') && str_contains($deepBlocks, 'id="dp-branch-' . $units . '"'), 'Compressed layout shells retain the source wrapper identities.');
+
+// A page already within the depth policy keeps the conservative threshold:
+// its identical two-wrapper branch unit must stay as ordinary groups.
+$shallowMarkup = '<div id="dp-outer-1" class="blocks-engine-source-div-dp-outer1-1">'
+    . '<div id="dp-branch-1" class="blocks-engine-source-div-dp-branch1-1">'
+    . '<h3>Depth leaf heading</h3><p>Depth leaf paragraph</p>'
+    . '</div></div>';
+$shallowArtifact = array(
+    'schema' => ArtifactCompiler::INPUT_SCHEMA,
+    'entrypoint' => 'website/index.html',
+    'files' => array(
+        array(
+            'path' => 'website/index.html',
+            'content' => '<!doctype html><html><head></head><body>' . $shallowMarkup . '</body></html>',
+        ),
+    ),
+);
+
+$shallowResult = (new ArtifactCompiler())->compile($shallowArtifact)->toArray();
+$shallowCodes = array_column($shallowResult['diagnostics'] ?? array(), 'code');
+$shallowBlocks = (string) ($shallowResult['serialized_blocks'] ?? '');
+
+$assert(!in_array('editability_policy_failed', $shallowCodes, true) && 'failed' !== ($shallowResult['status'] ?? null), 'A shallow page keeps compiling cleanly.');
+$assert(!str_contains($shallowBlocks, '/layout-shell'), 'Within policy, the two-wrapper branch stays below the conservative compression threshold.');
+$assert(2 === substr_count($shallowBlocks, '<!-- wp:group') && str_contains($shallowBlocks, 'id="dp-outer-1"') && str_contains($shallowBlocks, 'id="dp-branch-1"'), 'Within policy, both wrapper groups survive unchanged.');
+
+fwrite(STDOUT, "Depth-pressure compression tests passed.\n");


### PR DESCRIPTION
## Symptom

A Wix homepage (16-route capture of 360chiro.co.uk, re-imported after #1255 restored its author styles) compiles to `max_nesting_depth` 21. The editability policy caps it at 20, `editability_policy_failed` is an error diagnostic, the canonical plan reports `failed` / `pass: false`, and SSI's quality gate then refuses the **entire 16-page import** over one page one level over the cap. Full details in #1267.

## Root cause

`HtmlTransformer` already has a depth-pressure pass for exactly this case — `compressProjectedGroupChains($blocks, true)` admits exact two-wrapper projected branch shells when the normally-compressed tree exceeds `MAX_NATIVE_LIST_VIEW_DEPTH` — but it was gated on the artifact carrying layout-geometry proof reductions:

```php
if ($this->layoutGeometry()->hasProofReductions() && self::MAX_NATIVE_LIST_VIEW_DEPTH < $this->blockTreeDepth($blocks)) {
```

Complex Wix captures commonly ship no accepted proofs (this one reports thousands of `runtime_or_semantics_unproven` omissions), so the pass was skipped and the page hard-failed.

### Verified counterfactual (trunk ba7a02bc, real captured artifact)

- Stock trunk, `compose()` of `website/index.html`: depth **21** → `editability_policy_failed` → plan `failed` / `pass: false`.
- Same compile with only the `hasProofReductions() &&` conjunct removed: depth **19**, no error, plan `success_with_warnings` / `pass: true`.

## Why the gate is safe to drop (history)

The gate and the depth-pressure pass were born together in #1146 (`fix: target projected branches under depth pressure`, for #1133), whose reproducing scenario was a **proof-backed** site (Greek Corner) that stayed over-depth after proof reductions. The PR summary says it plainly: "detect proof-backed documents that remain over the native List View depth policy". The proof check was scoping to that repro, not a fidelity precondition:

- the depth-pressure pass never consumes proofs — its only effect is relaxing the projected-chain minimum from 3 wrappers to 2 for branch endpoints, on transformer-generated projected group chains;
- proof-gated *wrapper coalescing* (#1141 / `coalescedSingleGroupWrapper`, where proofs genuinely justify merging author wrappers) is untouched by this change.

Even read conservatively, the ungated formulation is still a last resort: the pass only runs when the tree already exceeds `MAX_NATIVE_LIST_VIEW_DEPTH`, i.e. when the editability policy would hard-fail the document (and with it the whole import) anyway. A slightly more aggressive shell compression strictly dominates refusing the site.

## Change

- `HtmlTransformer::compose()`: drop the `hasProofReductions()` conjunct; the depth check alone now triggers the pass (with a comment stating the last-resort semantics).
- New unit test `php-transformer/tests/unit/depth-pressure-compression.php` (registered in `test:unit`):
  - a proof-free artifact whose page compiles ~25 levels deep (12 nested two-wrapper projected branch units) must compile with **no** `editability_policy_failed`, plan quality `pass: true`, policy verdict `passed`, measured `max_nesting_depth` back within 20 (observed: 13), all 12 units compressed to layout shells, deep content and wrapper identities preserved;
  - an identical single-unit page already within policy must keep both wrapper groups uncompressed (no `layout-shell`), proving the conservative threshold still governs in-policy documents.

## Test evidence

- New test fails on unmodified trunk with exactly the reported failure (`editability_policy_failed`) and passes with the fix.
- `composer validate --strict` passes.
- Focused runs at `memory_limit=1G`: `responsive-document-variants`, `custom-block-generator` (58), `editability-report`, `author-selector-semantics` (96), `list-item-lowering`, `geometry-chain-coalescing`, `contract/layout-geometry-proof`, `contract/empty-visual-figure` — all pass.
- Full `composer test` (canonical + parity + packaging) passes locally at 1G. (`tests/unit/html-transformer-shared-analysis-cache.php` exhausts the default local 128M limit identically on clean trunk — pre-existing, unrelated.)

Fixes #1267

🤖 Generated with [Claude Code](https://claude.com/claude-code)
