### PR TITLE
Extract figure conversion

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -3247,55 +3247,8 @@ if ( $this->isInlineContentElement($tagName) ) {
             return $this->recognizePatterns($element, $fallbacks, array(QuotePattern::class));
         }
 
-        if ( 'figure' === $tagName ) {
-            $gallery = $this->mediaGalleryBlockFromElement($element, $fallbacks);
-            if ( null !== $gallery ) {
-                return $gallery;
-            }
-
-            $codeWindow = $this->recognizePatterns($element, $fallbacks, array(CodeWindowPattern::class));
-            if ( null !== $codeWindow ) {
-                return $codeWindow;
-            }
-
-            $linkedMedia = $this->figureLinkedMediaAnchor($element);
-            if ( $linkedMedia instanceof DOMElement ) {
-                $linkedPicture = $this->firstChildElement($linkedMedia, 'picture');
-                if ( $linkedPicture instanceof DOMElement ) {
-                    return $this->convertPictureElement($linkedPicture, $element, $linkedMedia);
-                }
-
-                $linkedImage = $this->firstChildElement($linkedMedia, 'img');
-                if ( $linkedImage instanceof DOMElement ) {
-                    return $this->convertImageElement($linkedImage, $element, null, $linkedMedia);
-                }
-            }
-
-            $image = $this->figureMediaElement($element, 'img');
-            if ( $image instanceof DOMElement ) {
-                return $this->convertImageElement($image, $element);
-            }
-
-            $picture = $this->figureMediaElement($element, 'picture');
-            if ( $picture instanceof DOMElement ) {
-                return $this->convertPictureElement($picture, $element);
-            }
-
-            $blockquote = $this->firstChildElement($element, 'blockquote');
-            if ( $blockquote instanceof DOMElement ) {
-                return $this->recognizePatterns($element, $fallbacks, array(FigureQuotePattern::class));
-            }
-
-            return $this->convertFigureGeneric($element, $fallbacks);
-        }
-
-        if ( 'figcaption' === $tagName ) {
-            $content = $this->innerHtml($element);
-            if ( '' === trim($this->runtime->stripAllTags($content)) ) {
-                return null;
-            }
-
-            return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
+        if ( 'figure' === $tagName || 'figcaption' === $tagName ) {
+            return $this->convertFigureElement($element, $fallbacks);
         }
 
         if ( 'noscript' === $tagName ) {
@@ -3523,6 +3476,70 @@ if ( 'svg' === $tagName ) {
 
             $fallbacks[] = FallbackDiagnostic::build($fallback, $this->transformationProvenance()->fallback());
         }
+
+        return null;
+    }
+
+    /**
+     * Convert one figure or its caption: the media the figure carries, or the caption paragraph that accompanies it.
+     *
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array<string, mixed>|null
+     */
+    private function convertFigureElement(DOMElement $element, array &$fallbacks): ?array
+    {
+        $tagName = strtolower($element->tagName);
+
+    if ( 'figure' === $tagName ) {
+        $gallery = $this->mediaGalleryBlockFromElement($element, $fallbacks);
+        if ( null !== $gallery ) {
+            return $gallery;
+        }
+
+        $codeWindow = $this->recognizePatterns($element, $fallbacks, array(CodeWindowPattern::class));
+        if ( null !== $codeWindow ) {
+            return $codeWindow;
+        }
+
+        $linkedMedia = $this->figureLinkedMediaAnchor($element);
+        if ( $linkedMedia instanceof DOMElement ) {
+            $linkedPicture = $this->firstChildElement($linkedMedia, 'picture');
+            if ( $linkedPicture instanceof DOMElement ) {
+                return $this->convertPictureElement($linkedPicture, $element, $linkedMedia);
+            }
+
+            $linkedImage = $this->firstChildElement($linkedMedia, 'img');
+            if ( $linkedImage instanceof DOMElement ) {
+                return $this->convertImageElement($linkedImage, $element, null, $linkedMedia);
+            }
+        }
+
+        $image = $this->figureMediaElement($element, 'img');
+        if ( $image instanceof DOMElement ) {
+            return $this->convertImageElement($image, $element);
+        }
+
+        $picture = $this->figureMediaElement($element, 'picture');
+        if ( $picture instanceof DOMElement ) {
+            return $this->convertPictureElement($picture, $element);
+        }
+
+        $blockquote = $this->firstChildElement($element, 'blockquote');
+        if ( $blockquote instanceof DOMElement ) {
+            return $this->recognizePatterns($element, $fallbacks, array(FigureQuotePattern::class));
+        }
+
+        return $this->convertFigureGeneric($element, $fallbacks);
+    }
+
+    if ( 'figcaption' === $tagName ) {
+        $content = $this->innerHtml($element);
+        if ( '' === trim($this->runtime->stripAllTags($content)) ) {
+            return null;
+        }
+
+        return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
+    }
 
         return null;
     }


### PR DESCRIPTION
## Summary

- move the adjacent `figure` and `figcaption` branches of `convertElement()` into `convertFigureElement()`
- keep both branch bodies verbatim apart from one dedent level

Refs #242.

## Why

This continues the decomposition from #1263, #1264, and #1269. `figure` and `figcaption` sat adjacent with nothing interleaved and describe one subject: a figure and the caption that accompanies it.

The replacement guard is equivalent because both branches end in an unconditional return, so a figure tag always returned from inside the run and any other tag always fell through both.

`convertElement()` is now 442 lines, down from 932 before this series.

## Evidence

Behavior preservation on a real 130 MB, 19-page artifact: all 19 compiled receipt digests are unchanged, `sha256(digests)` = `9caf6b4fd601b31e65ef33e911eee3081006d3ce14875e18fe00e747c7e95b64`, matching trunk exactly, with 19 HTML document transforms.

## Verification

- `composer test`
- `php tests/contract/run.php`
- 289 parity fixtures
- package installation proof

## AI assistance

OpenAI gpt-5.6-sol was used through OpenCode to confirm the run was contiguous and return-terminated, script the extraction against an explicit branch count, and run verification. The seam analysis and evidence were reviewed and orchestrated by Chris Huber.