### PR TITLE
refactor(242): extract runtime-island recognition from HtmlTransformer

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -64,6 +64,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\ButtonLinkDispat
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\DomHelpersTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\FormDispatchTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\LinkUrlSanitizer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\RuntimeIslandTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\NavigationToggleSuppressionTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SvgMaterializationTrait;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\FontMaterializationPlanBuilder;
@@ -81,6 +82,7 @@ final class HtmlTransformer
     use FormDispatchTrait;
     use NavigationStyleProjectionTrait;
     use NavigationToggleSuppressionTrait;
+    use RuntimeIslandTrait;
     use StyleResolutionTrait;
     use SvgMaterializationTrait;
 
@@ -10552,169 +10554,6 @@ if ( 'svg' === $tagName ) {
         $this->fallbackEmitter()->captureInlineSvgFallback($element, $fallbacks);
     }
 
-    /**
-     * @param array<int, array<string, mixed>> $fallbacks
-     */
-    private function captureCanvasFallback(DOMElement $element, array &$fallbacks): void
-    {
-        $this->fallbackEmitter()->captureCanvasFallback($element, $fallbacks, $this->runtimeDom());
-    }
-
-    private function isRuntimeCanvasTarget(DOMElement $element): bool
-    {
-        return $this->fallbackEmitter()->isRuntimeCanvasTarget($element);
-    }
-
-    /**
-     * @param array<string, mixed> $options
-     * @return array<string, bool>
-     */
-    private function runtimeCanvasSelectorsFromOptions(array $options): array
-    {
-        return $this->runtimeSelectorsFromOptions($options, 'runtime_canvas_selectors');
-    }
-
-    private function isRuntimeDomTarget(DOMElement $element): bool
-    {
-        $id = trim($this->attr($element, 'id'));
-        if ( '' !== $id && $this->runtimeSelectors()->hasDom('#' . $id) && ! $this->isPresentationalRuntimeSelector('#' . $id) ) {
-            return true;
-        }
-
-        foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) {
-            if ( '' !== $class && $this->runtimeSelectors()->hasDom('.' . $class) && ! $this->isPresentationalRuntimeSelector('.' . $class) ) {
-                return true;
-            }
-        }
-
-        foreach ( array_keys($this->runtimeSelectors()->domSelectors()) as $selector ) {
-            if ( ! $this->isPresentationalRuntimeSelector((string) $selector) && $this->elementMatchesRuntimeSelector($element, (string) $selector) ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /** @return array<int,string> */
-    private function runtimeDomSelectorsForElement(DOMElement $element): array
-    {
-        $selectors = array();
-        $id = trim($this->attr($element, 'id'));
-        if ( '' !== $id && $this->runtimeSelectors()->hasDom('#' . $id) ) $selectors[] = '#' . $id;
-        foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) if ( '' !== $class && $this->runtimeSelectors()->hasDom('.' . $class) ) $selectors[] = '.' . $class;
-        foreach ( array_keys($this->runtimeSelectors()->domSelectors()) as $selector ) {
-            if ( str_starts_with((string) $selector, '.') || str_starts_with((string) $selector, '#') || strtolower((string) $selector) === strtolower($element->tagName) ) continue;
-            if ( ! $this->isPresentationalRuntimeSelector((string) $selector) && $this->elementMatchesRuntimeSelector($element, (string) $selector) ) $selectors[] = (string) $selector;
-        }
-        return array_values(array_unique($selectors));
-    }
-
-    private function shouldPreserveRuntimeAppShell(DOMElement $element): bool
-    {
-        if ( ! $this->runtimeSelectors()->hasRuntimeTargets() ) {
-            return false;
-        }
-
-        $tagName = strtolower($element->tagName);
-        if ( ShellLandmarkPolicy::isGlobalShellLandmarkTag($tagName) ) {
-            return false;
-        }
-
-        $targets = $this->runtimeTargetsInSubtree($element, 4);
-        if ( count($targets) < 2 ) {
-            return false;
-        }
-
-        $signals = $this->runtimeAppShellSignals($element);
-        if ( in_array($tagName, array( 'body', 'main' ), true) && ! in_array('app_root_token', $signals, true) ) {
-            return false;
-        }
-
-        return in_array('app_root_token', $signals, true) || in_array('workspace_surface', $signals, true);
-    }
-
-    /**
-     * @return array<int, array<string, mixed>>
-     */
-    private function runtimeTargetsInSubtree(DOMElement $element, int $limit): array
-    {
-        $targets = array();
-        foreach ( $this->descendantElements($element) as $descendant ) {
-            if ( $this->isRuntimeDomTarget($descendant) || $this->isRuntimeCanvasTarget($descendant) ) {
-                $targets[] = array_filter(array(
-                    'selector'   => $this->runtimeIslandSelector($descendant),
-                    'tag'        => strtolower($descendant->tagName),
-                    'attributes' => $this->boundedRuntimeTargetAttributes($descendant),
-                ), static fn (mixed $value): bool => '' !== $value && array() !== $value);
-            }
-
-            if ( count($targets) >= $limit ) {
-                break;
-            }
-        }
-
-        return $targets;
-    }
-
-    private function shouldRecordRuntimeHtmlSubtreeIsland(DOMElement $element): bool
-    {
-        if ( ! in_array(strtolower($element->tagName), array( 'article', 'aside', 'div', 'main', 'section' ), true) ) {
-            return false;
-        }
-
-        if ( $this->isRuntimeDomTarget($element) ) {
-            return false;
-        }
-
-        if ( 0 < count($this->runtimeTargetsInSubtree($element, 1)) ) {
-            return true;
-        }
-
-        foreach ( $this->descendantElements($element) as $descendant ) {
-            $tagName = strtolower($descendant->tagName);
-            if ( 'form' === $tagName && $this->formHasDataEntryControls($descendant) ) {
-                return true;
-            }
-            if ( in_array($tagName, array( 'canvas', 'template' ), true) ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $blocks
-     */
-    private function recordRuntimeIslandsForPreservedHtmlBlocks(array $blocks): void
-    {
-        foreach ( $blocks as $block ) {
-            if ( ! is_array($block) ) {
-                continue;
-            }
-
-            if ( 'core/html' === ($block['blockName'] ?? '') ) {
-                $content = is_array($block['attrs'] ?? null) && is_scalar($block['attrs']['content'] ?? null) ? (string) $block['attrs']['content'] : '';
-                $element = $this->preservedHtmlRootElement($content);
-                if ( $element instanceof DOMElement && $this->shouldRecordRuntimeHtmlSubtreeIsland($element) ) {
-                    $targets = $this->runtimeTargetsInSubtree($element, 8);
-                    $this->recordRuntimeIsland($element, 'app_shell', 'runtime_html_subtree', 'client_script_execution', array(
-                        'events'            => $this->eventMetadata($element),
-                        'target_count'      => count($targets),
-                        'targets'           => $targets,
-                        'app_shell_signals' => $this->runtimeAppShellSignals($element),
-                        'required_scripts'  => $this->requiredScriptsForElement($element),
-                    ));
-                }
-            }
-
-            if ( isset($block['innerBlocks']) && is_array($block['innerBlocks']) ) {
-                $this->recordRuntimeIslandsForPreservedHtmlBlocks($block['innerBlocks']);
-            }
-        }
-    }
-
     private function preservedHtmlRootElement(string $html): ?DOMElement
     {
         if ( '' === trim($html) ) {
@@ -10763,34 +10602,6 @@ if ( 'svg' === $tagName ) {
         return $descendants;
     }
 
-    /**
-     * @return array<int, string>
-     */
-    private function runtimeAppShellSignals(DOMElement $element): array
-    {
-        $signals = array();
-        if ( $this->hasRuntimeAppRootToken($element) ) {
-            $signals[] = 'app_root_token';
-        }
-        if ( $this->hasWorkspaceSurface($element) ) {
-            $signals[] = 'workspace_surface';
-        }
-
-        return array_values(array_unique($signals));
-    }
-
-    private function hasRuntimeAppRootToken(DOMElement $element): bool
-    {
-        $tokens = preg_split('/[^A-Za-z0-9]+/', strtolower(trim($this->attr($element, 'id') . ' ' . $this->attr($element, 'class')))) ?: array();
-        foreach ( $tokens as $token ) {
-            if ( in_array($token, self::RUNTIME_APP_ROOT_TOKENS, true) ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     private function hasWorkspaceSurface(DOMElement $element): bool
     {
         foreach ( $this->descendantElements($element) as $descendant ) {
@@ -10802,76 +10613,6 @@ if ( 'svg' === $tagName ) {
                 return true;
             }
             if ( '' !== trim($this->attr($descendant, 'contenteditable')) ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function textareaIsRuntimeWorkspaceSurface(DOMElement $textarea, DOMElement $root): bool
-    {
-        if ( ! $this->isRuntimeDomTarget($textarea) || $this->hasFormAncestor($textarea) ) {
-            return false;
-        }
-
-        // A plain wrapper that pairs data entry with a submit action is a
-        // pseudo-form, not an editor surface. Only a non-control target inside
-        // that same candidate upgrades it to a runtime workspace.
-        for ( $ancestor = $textarea->parentNode; $ancestor instanceof DOMElement; $ancestor = $ancestor->parentNode ) {
-            if ( $this->isDivBasedPseudoForm($ancestor) ) {
-                return $ancestor === $root && $this->hasNonFormControlRuntimeTarget($ancestor);
-            }
-            if ( $ancestor === $root ) {
-                break;
-            }
-        }
-
-        return true;
-    }
-
-    private function hasNonFormControlRuntimeTarget(DOMElement $element): bool
-    {
-        foreach ( $this->descendantElements($element) as $descendant ) {
-            if ( $this->isRuntimeDomTarget($descendant) && ! $this->isFormControlElement($descendant) ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    private function boundedRuntimeTargetAttributes(DOMElement $element): array
-    {
-        $attributes = array();
-        foreach ( array( 'id', 'class', 'role', 'aria-label', 'type', 'name' ) as $name ) {
-            $value = trim($this->attr($element, $name));
-            if ( '' !== $value ) {
-                $attributes[$name] = substr($value, 0, 160);
-            }
-        }
-
-        foreach ( $element->attributes ?? array() as $attribute ) {
-            if ( str_starts_with(strtolower($attribute->name), 'data-') ) {
-                $attributes[$attribute->name] = substr((string) $attribute->value, 0, 160);
-            }
-        }
-
-        return $attributes;
-    }
-
-    private function shouldPreserveDataAttributeRuntimeTarget(DOMElement $element): bool
-    {
-        $tagName = strtolower($element->tagName);
-        if ( in_array($tagName, array( 'canvas', 'form', 'script' ), true) || $this->isFormControlElement($element) ) {
-            return false;
-        }
-
-        foreach ( array_keys($this->runtimeSelectors()->domSelectors()) as $selector ) {
-            if ( str_contains((string) $selector, '[') && $this->elementMatchesRuntimeSelector($element, (string) $selector) ) {
                 return true;
             }
         }
@@ -10903,114 +10644,12 @@ if ( 'svg' === $tagName ) {
         return false;
     }
 
-    private function isPresentationalRuntimeSelector(string $selector): bool
-    {
-        return $this->isPresentationalAnimationSelector($selector) && ! $this->runtimeSelectors()->hasBehavioral($selector);
-    }
-
-    private function elementMatchesRuntimeSelector(DOMElement $element, string $selector): bool
-    {
-        $tag = strtolower($element->tagName);
-        if ( $selector === $tag && in_array($tag, array_merge(array('canvas', 'svg'), self::RUNTIME_TAG_SELECTORS), true) ) {
-            return true;
-        }
-        if ( preg_match('/^([a-z][a-z0-9-]*)\.([A-Za-z][A-Za-z0-9_-]*)$/', $selector, $match) ) {
-            return $tag === strtolower((string) $match[1]) && in_array((string) $match[2], preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array(), true);
-        }
-        if ( preg_match('/^(?:([a-z][a-z0-9-]*))?\[(data-[A-Za-z][A-Za-z0-9_-]*)(?:=["\'][^"\']{1,80}["\'])?\]$/', $selector, $match) ) {
-            return ( '' === (string) ($match[1] ?? '') || $tag === strtolower((string) $match[1]) ) && $element->hasAttribute(strtolower((string) $match[2]));
-        }
-
-        return false;
-    }
-
-    /**
-     * @param array<string, mixed> $metadata
-     */
-    private function recordRuntimeIsland(DOMElement $element, string $kind, string $reason, string $runtimeRequirement, array $metadata = array()): void
-    {
-        $this->fallbackEmitter()->recordRuntimeIsland($element, $kind, $reason, $runtimeRequirement, $metadata, $this->runtimeDom());
-    }
-
-    private function recordNativeRuntimeDomPreservation(DOMElement $element, string $blockName, bool $includeRichTextDescendants = false): void
-    {
-        $elements = array($element);
-        if ($includeRichTextDescendants) {
-            foreach ($this->descendantElements($element) as $descendant) {
-                if ($this->isInlineContentElement(strtolower($descendant->tagName))) {
-                    $elements[] = $descendant;
-                }
-            }
-        }
-        foreach ($elements as $target) {
-            foreach ($this->runtimeDomSelectorsForElement($target) as $selector) {
-                $this->runtimeDom()->recordPreservation($blockName, strtolower($target->tagName), $selector);
-            }
-        }
-    }
-
-    private function recordRuntimeDomFallback(DOMElement $element, string $blockName): void
-    {
-        foreach ($this->runtimeDomSelectorsForElement($element) as $selector) {
-            $this->runtimeDom()->recordFallback($blockName, strtolower($element->tagName), $selector);
-        }
-    }
-
-    private function canRetainRuntimeDomContractNatively(DOMElement $element, string $blockName): bool
-    {
-        if ( ! in_array($blockName, array('core/group', 'core/paragraph', 'core/heading'), true) ) {
-            return false;
-        }
-
-        // Group can serialize these semantic wrappers exactly. Generic div app
-        // surfaces retain their existing bounded-island treatment.
-        if ('core/group' === $blockName && ! in_array(strtolower($element->tagName), array('article', 'aside', 'footer', 'header', 'main', 'section'), true)) {
-            return false;
-        }
-
-        if (array_intersect($this->runtimeAppShellSignals($element), array('app_root_token', 'workspace_surface'))) {
-            return false;
-        }
-
-        foreach ($this->descendantElements($element) as $descendant) {
-            if (in_array(strtolower($descendant->tagName), array('button', 'input', 'select', 'textarea', 'canvas', 'form', 'template'), true)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
     /**
      * @return array<int, array<string, mixed>>
      */
     private function requiredScriptsForElement(DOMElement $element): array
     {
         return $this->fallbackEmitter()->requiredScriptsForElement($element);
-    }
-
-    /**
-     * @param array<string, mixed> $options
-     * @return array<int, array<string, mixed>>
-     */
-    private function runtimeScriptMetadataFromOptions(array $options): array
-    {
-        $metadata = array();
-        foreach ( $options['runtime_script_metadata'] ?? array() as $script ) {
-            if ( ! is_array($script) ) {
-                continue;
-            }
-
-            $metadata[] = array_filter(array(
-                'path'               => is_string($script['path'] ?? null) ? $script['path'] : '',
-                'selector'           => is_string($script['selector'] ?? null) ? $script['selector'] : '',
-                'attributes'         => is_array($script['attributes'] ?? null) ? $script['attributes'] : array(),
-                'script_role'        => 'runtime',
-                'script_source_kind' => is_string($script['script_source_kind'] ?? null) ? $script['script_source_kind'] : 'external',
-            ), static fn (mixed $value): bool => '' !== $value && array() !== $value);
-        }
-
-        return $this->dedupeArrayRows($metadata);
     }
 
     /**
@@ -11024,29 +10663,6 @@ if ( 'svg' === $tagName ) {
         $namespace = is_scalar($options['generated_block_namespace'] ?? null) ? trim((string) $options['generated_block_namespace']) : '';
 
         return '' !== $namespace ? $namespace : 'custom';
-    }
-
-    /**
-     * @param array<string, mixed> $options
-     * @return array<string, bool>
-     */
-    private function runtimeSelectorsFromOptions(array $options, string $key): array
-    {
-        $selectors = array();
-        foreach ( $options[$key] ?? array() as $selector ) {
-            if ( is_string($selector) && $this->isBoundedRuntimeSelector($selector) ) {
-                $selectors[$selector] = true;
-            }
-        }
-
-        return $selectors;
-    }
-
-    private function isBoundedRuntimeSelector(string $selector): bool
-    {
-        $name = '[A-Za-z][A-Za-z0-9_-]*';
-        $runtimeTags = implode('|', self::RUNTIME_TAG_SELECTORS);
-        return 1 === preg_match('/^(?:[#.]' . $name . '|' . $name . '\.' . $name . '|\[data-' . $name . '(?:=["\'][^"\']{1,80}["\'])?\]|' . $name . '\[data-' . $name . '(?:=["\'][^"\']{1,80}["\'])?\]|canvas|svg|' . $runtimeTags . ')$/', $selector);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Support/RuntimeIslandTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/RuntimeIslandTrait.php
@@ -1,0 +1,404 @@
+<?php
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\ShellLandmarkPolicy;
+use DOMElement;
+
+/**
+ * Runtime-target and runtime-island recognition.
+ *
+ * Decides which elements carry a runtime contract the block output cannot
+ * express natively — canvas and DOM targets, app-shell roots, workspace
+ * surfaces, bounded data-attribute targets — and records the islands and
+ * preservation fallbacks that follow from that. Moved verbatim out of
+ * HtmlTransformer under #242; behaviour is unchanged.
+ */
+trait RuntimeIslandTrait
+{
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     */
+    private function captureCanvasFallback(DOMElement $element, array &$fallbacks): void
+    {
+        $this->fallbackEmitter()->captureCanvasFallback($element, $fallbacks, $this->runtimeDom());
+    }
+
+    private function isRuntimeCanvasTarget(DOMElement $element): bool
+    {
+        return $this->fallbackEmitter()->isRuntimeCanvasTarget($element);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     * @return array<string, bool>
+     */
+    private function runtimeCanvasSelectorsFromOptions(array $options): array
+    {
+        return $this->runtimeSelectorsFromOptions($options, 'runtime_canvas_selectors');
+    }
+
+    private function isRuntimeDomTarget(DOMElement $element): bool
+    {
+        $id = trim($this->attr($element, 'id'));
+        if ( '' !== $id && $this->runtimeSelectors()->hasDom('#' . $id) && ! $this->isPresentationalRuntimeSelector('#' . $id) ) {
+            return true;
+        }
+
+        foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) {
+            if ( '' !== $class && $this->runtimeSelectors()->hasDom('.' . $class) && ! $this->isPresentationalRuntimeSelector('.' . $class) ) {
+                return true;
+            }
+        }
+
+        foreach ( array_keys($this->runtimeSelectors()->domSelectors()) as $selector ) {
+            if ( ! $this->isPresentationalRuntimeSelector((string) $selector) && $this->elementMatchesRuntimeSelector($element, (string) $selector) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** @return array<int,string> */
+    private function runtimeDomSelectorsForElement(DOMElement $element): array
+    {
+        $selectors = array();
+        $id = trim($this->attr($element, 'id'));
+        if ( '' !== $id && $this->runtimeSelectors()->hasDom('#' . $id) ) $selectors[] = '#' . $id;
+        foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) if ( '' !== $class && $this->runtimeSelectors()->hasDom('.' . $class) ) $selectors[] = '.' . $class;
+        foreach ( array_keys($this->runtimeSelectors()->domSelectors()) as $selector ) {
+            if ( str_starts_with((string) $selector, '.') || str_starts_with((string) $selector, '#') || strtolower((string) $selector) === strtolower($element->tagName) ) continue;
+            if ( ! $this->isPresentationalRuntimeSelector((string) $selector) && $this->elementMatchesRuntimeSelector($element, (string) $selector) ) $selectors[] = (string) $selector;
+        }
+        return array_values(array_unique($selectors));
+    }
+
+    private function shouldPreserveRuntimeAppShell(DOMElement $element): bool
+    {
+        if ( ! $this->runtimeSelectors()->hasRuntimeTargets() ) {
+            return false;
+        }
+
+        $tagName = strtolower($element->tagName);
+        if ( ShellLandmarkPolicy::isGlobalShellLandmarkTag($tagName) ) {
+            return false;
+        }
+
+        $targets = $this->runtimeTargetsInSubtree($element, 4);
+        if ( count($targets) < 2 ) {
+            return false;
+        }
+
+        $signals = $this->runtimeAppShellSignals($element);
+        if ( in_array($tagName, array( 'body', 'main' ), true) && ! in_array('app_root_token', $signals, true) ) {
+            return false;
+        }
+
+        return in_array('app_root_token', $signals, true) || in_array('workspace_surface', $signals, true);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function runtimeTargetsInSubtree(DOMElement $element, int $limit): array
+    {
+        $targets = array();
+        foreach ( $this->descendantElements($element) as $descendant ) {
+            if ( $this->isRuntimeDomTarget($descendant) || $this->isRuntimeCanvasTarget($descendant) ) {
+                $targets[] = array_filter(array(
+                    'selector'   => $this->runtimeIslandSelector($descendant),
+                    'tag'        => strtolower($descendant->tagName),
+                    'attributes' => $this->boundedRuntimeTargetAttributes($descendant),
+                ), static fn (mixed $value): bool => '' !== $value && array() !== $value);
+            }
+
+            if ( count($targets) >= $limit ) {
+                break;
+            }
+        }
+
+        return $targets;
+    }
+
+    private function shouldRecordRuntimeHtmlSubtreeIsland(DOMElement $element): bool
+    {
+        if ( ! in_array(strtolower($element->tagName), array( 'article', 'aside', 'div', 'main', 'section' ), true) ) {
+            return false;
+        }
+
+        if ( $this->isRuntimeDomTarget($element) ) {
+            return false;
+        }
+
+        if ( 0 < count($this->runtimeTargetsInSubtree($element, 1)) ) {
+            return true;
+        }
+
+        foreach ( $this->descendantElements($element) as $descendant ) {
+            $tagName = strtolower($descendant->tagName);
+            if ( 'form' === $tagName && $this->formHasDataEntryControls($descendant) ) {
+                return true;
+            }
+            if ( in_array($tagName, array( 'canvas', 'template' ), true) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks
+     */
+    private function recordRuntimeIslandsForPreservedHtmlBlocks(array $blocks): void
+    {
+        foreach ( $blocks as $block ) {
+            if ( ! is_array($block) ) {
+                continue;
+            }
+
+            if ( 'core/html' === ($block['blockName'] ?? '') ) {
+                $content = is_array($block['attrs'] ?? null) && is_scalar($block['attrs']['content'] ?? null) ? (string) $block['attrs']['content'] : '';
+                $element = $this->preservedHtmlRootElement($content);
+                if ( $element instanceof DOMElement && $this->shouldRecordRuntimeHtmlSubtreeIsland($element) ) {
+                    $targets = $this->runtimeTargetsInSubtree($element, 8);
+                    $this->recordRuntimeIsland($element, 'app_shell', 'runtime_html_subtree', 'client_script_execution', array(
+                        'events'            => $this->eventMetadata($element),
+                        'target_count'      => count($targets),
+                        'targets'           => $targets,
+                        'app_shell_signals' => $this->runtimeAppShellSignals($element),
+                        'required_scripts'  => $this->requiredScriptsForElement($element),
+                    ));
+                }
+            }
+
+            if ( isset($block['innerBlocks']) && is_array($block['innerBlocks']) ) {
+                $this->recordRuntimeIslandsForPreservedHtmlBlocks($block['innerBlocks']);
+            }
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function runtimeAppShellSignals(DOMElement $element): array
+    {
+        $signals = array();
+        if ( $this->hasRuntimeAppRootToken($element) ) {
+            $signals[] = 'app_root_token';
+        }
+        if ( $this->hasWorkspaceSurface($element) ) {
+            $signals[] = 'workspace_surface';
+        }
+
+        return array_values(array_unique($signals));
+    }
+
+    private function hasRuntimeAppRootToken(DOMElement $element): bool
+    {
+        $tokens = preg_split('/[^A-Za-z0-9]+/', strtolower(trim($this->attr($element, 'id') . ' ' . $this->attr($element, 'class')))) ?: array();
+        foreach ( $tokens as $token ) {
+            if ( in_array($token, self::RUNTIME_APP_ROOT_TOKENS, true) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function textareaIsRuntimeWorkspaceSurface(DOMElement $textarea, DOMElement $root): bool
+    {
+        if ( ! $this->isRuntimeDomTarget($textarea) || $this->hasFormAncestor($textarea) ) {
+            return false;
+        }
+
+        // A plain wrapper that pairs data entry with a submit action is a
+        // pseudo-form, not an editor surface. Only a non-control target inside
+        // that same candidate upgrades it to a runtime workspace.
+        for ( $ancestor = $textarea->parentNode; $ancestor instanceof DOMElement; $ancestor = $ancestor->parentNode ) {
+            if ( $this->isDivBasedPseudoForm($ancestor) ) {
+                return $ancestor === $root && $this->hasNonFormControlRuntimeTarget($ancestor);
+            }
+            if ( $ancestor === $root ) {
+                break;
+            }
+        }
+
+        return true;
+    }
+
+    private function hasNonFormControlRuntimeTarget(DOMElement $element): bool
+    {
+        foreach ( $this->descendantElements($element) as $descendant ) {
+            if ( $this->isRuntimeDomTarget($descendant) && ! $this->isFormControlElement($descendant) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function boundedRuntimeTargetAttributes(DOMElement $element): array
+    {
+        $attributes = array();
+        foreach ( array( 'id', 'class', 'role', 'aria-label', 'type', 'name' ) as $name ) {
+            $value = trim($this->attr($element, $name));
+            if ( '' !== $value ) {
+                $attributes[$name] = substr($value, 0, 160);
+            }
+        }
+
+        foreach ( $element->attributes ?? array() as $attribute ) {
+            if ( str_starts_with(strtolower($attribute->name), 'data-') ) {
+                $attributes[$attribute->name] = substr((string) $attribute->value, 0, 160);
+            }
+        }
+
+        return $attributes;
+    }
+
+    private function shouldPreserveDataAttributeRuntimeTarget(DOMElement $element): bool
+    {
+        $tagName = strtolower($element->tagName);
+        if ( in_array($tagName, array( 'canvas', 'form', 'script' ), true) || $this->isFormControlElement($element) ) {
+            return false;
+        }
+
+        foreach ( array_keys($this->runtimeSelectors()->domSelectors()) as $selector ) {
+            if ( str_contains((string) $selector, '[') && $this->elementMatchesRuntimeSelector($element, (string) $selector) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isPresentationalRuntimeSelector(string $selector): bool
+    {
+        return $this->isPresentationalAnimationSelector($selector) && ! $this->runtimeSelectors()->hasBehavioral($selector);
+    }
+
+    private function elementMatchesRuntimeSelector(DOMElement $element, string $selector): bool
+    {
+        $tag = strtolower($element->tagName);
+        if ( $selector === $tag && in_array($tag, array_merge(array('canvas', 'svg'), self::RUNTIME_TAG_SELECTORS), true) ) {
+            return true;
+        }
+        if ( preg_match('/^([a-z][a-z0-9-]*)\.([A-Za-z][A-Za-z0-9_-]*)$/', $selector, $match) ) {
+            return $tag === strtolower((string) $match[1]) && in_array((string) $match[2], preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array(), true);
+        }
+        if ( preg_match('/^(?:([a-z][a-z0-9-]*))?\[(data-[A-Za-z][A-Za-z0-9_-]*)(?:=["\'][^"\']{1,80}["\'])?\]$/', $selector, $match) ) {
+            return ( '' === (string) ($match[1] ?? '') || $tag === strtolower((string) $match[1]) ) && $element->hasAttribute(strtolower((string) $match[2]));
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    private function recordRuntimeIsland(DOMElement $element, string $kind, string $reason, string $runtimeRequirement, array $metadata = array()): void
+    {
+        $this->fallbackEmitter()->recordRuntimeIsland($element, $kind, $reason, $runtimeRequirement, $metadata, $this->runtimeDom());
+    }
+
+    private function recordNativeRuntimeDomPreservation(DOMElement $element, string $blockName, bool $includeRichTextDescendants = false): void
+    {
+        $elements = array($element);
+        if ($includeRichTextDescendants) {
+            foreach ($this->descendantElements($element) as $descendant) {
+                if ($this->isInlineContentElement(strtolower($descendant->tagName))) {
+                    $elements[] = $descendant;
+                }
+            }
+        }
+        foreach ($elements as $target) {
+            foreach ($this->runtimeDomSelectorsForElement($target) as $selector) {
+                $this->runtimeDom()->recordPreservation($blockName, strtolower($target->tagName), $selector);
+            }
+        }
+    }
+
+    private function recordRuntimeDomFallback(DOMElement $element, string $blockName): void
+    {
+        foreach ($this->runtimeDomSelectorsForElement($element) as $selector) {
+            $this->runtimeDom()->recordFallback($blockName, strtolower($element->tagName), $selector);
+        }
+    }
+
+    private function canRetainRuntimeDomContractNatively(DOMElement $element, string $blockName): bool
+    {
+        if ( ! in_array($blockName, array('core/group', 'core/paragraph', 'core/heading'), true) ) {
+            return false;
+        }
+
+        // Group can serialize these semantic wrappers exactly. Generic div app
+        // surfaces retain their existing bounded-island treatment.
+        if ('core/group' === $blockName && ! in_array(strtolower($element->tagName), array('article', 'aside', 'footer', 'header', 'main', 'section'), true)) {
+            return false;
+        }
+
+        if (array_intersect($this->runtimeAppShellSignals($element), array('app_root_token', 'workspace_surface'))) {
+            return false;
+        }
+
+        foreach ($this->descendantElements($element) as $descendant) {
+            if (in_array(strtolower($descendant->tagName), array('button', 'input', 'select', 'textarea', 'canvas', 'form', 'template'), true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     * @return array<int, array<string, mixed>>
+     */
+    private function runtimeScriptMetadataFromOptions(array $options): array
+    {
+        $metadata = array();
+        foreach ( $options['runtime_script_metadata'] ?? array() as $script ) {
+            if ( ! is_array($script) ) {
+                continue;
+            }
+
+            $metadata[] = array_filter(array(
+                'path'               => is_string($script['path'] ?? null) ? $script['path'] : '',
+                'selector'           => is_string($script['selector'] ?? null) ? $script['selector'] : '',
+                'attributes'         => is_array($script['attributes'] ?? null) ? $script['attributes'] : array(),
+                'script_role'        => 'runtime',
+                'script_source_kind' => is_string($script['script_source_kind'] ?? null) ? $script['script_source_kind'] : 'external',
+            ), static fn (mixed $value): bool => '' !== $value && array() !== $value);
+        }
+
+        return $this->dedupeArrayRows($metadata);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     * @return array<string, bool>
+     */
+    private function runtimeSelectorsFromOptions(array $options, string $key): array
+    {
+        $selectors = array();
+        foreach ( $options[$key] ?? array() as $selector ) {
+            if ( is_string($selector) && $this->isBoundedRuntimeSelector($selector) ) {
+                $selectors[$selector] = true;
+            }
+        }
+
+        return $selectors;
+    }
+
+    private function isBoundedRuntimeSelector(string $selector): bool
+    {
+        $name = '[A-Za-z][A-Za-z0-9_-]*';
+        $runtimeTags = implode('|', self::RUNTIME_TAG_SELECTORS);
+        return 1 === preg_match('/^(?:[#.]' . $name . '|' . $name . '\.' . $name . '|\[data-' . $name . '(?:=["\'][^"\']{1,80}["\'])?\]|' . $name . '\[data-' . $name . '(?:=["\'][^"\']{1,80}["\'])?\]|canvas|svg|' . $runtimeTags . ')$/', $selector);
+    }
+}


### PR DESCRIPTION
Slice of #242, workstream 1 — the epic names "nav-chrome / runtime-island units" as extraction targets.

## What moved

`Support/RuntimeIslandTrait` now owns the runtime-target and runtime-island cluster: canvas and DOM target recognition, app-shell roots, workspace surfaces, bounded data-attribute targets, and the island and preservation records that follow from them.

24 methods, ~404 lines. `HtmlTransformer` goes **13,242 → 12,858 lines**.

## Why this cluster

It was already a contiguous band in the file and cohesive by responsibility. Eight non-runtime methods were interleaved in that range and are deliberately **left in place** — `descendantElements` (9 callers) and `requiredScriptsForElement` (5 callers) are shared utilities, and the rest are single-caller helpers belonging to other clusters. Moving only the runtime-named methods keeps the boundary unambiguous.

The three state accessors (`runtimeBehavior`, `runtimeDom`, `runtimeSelectors`) and the scattered runtime predicates elsewhere in the file also stay put; they are embedded in other clusters and are not this slice.

## Pure move, verified

The epic requires behaviour-preserving slices with no logic smuggled in. Rather than assert that, I checked it:

- **All 24 method bodies are byte-identical to `origin/trunk`** — compared programmatically, signature through closing brace, not eyeballed.
- **Method inventory unchanged**: trunk resolved 522 methods on the class; class + trait still resolve exactly 522. No method lost, none added.
- The extraction was scripted rather than hand-edited so the moves could not drift.

One necessary change: `ShellLandmarkPolicy` gains an explicit import. It lived in the same namespace as `HtmlTransformer` and needed no `use` there; in `Support\` it does. That is a namespace-resolution consequence of the move, not a behaviour change — and it surfaced as a hard fatal in the contract suite, which is how I caught it.

## Verification

Full `composer test` on the php-transformer package, before and after:

- baseline: **289 parity fixtures passed**, all contract suites green
- after: **289 parity fixtures passed**, all contract suites green, `SUITE EXIT=0`

Identical green, zero block-output diff.

## Base

Taken on a quiet base. #939, #764 and #659 were the open PRs touching this file and were closed as superseded or unsalvageably stale before starting. #1268 is open against `HtmlTransformer` but has zero hunks in the extracted band, so it will not conflict.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode identified the cluster from method-density analysis, scripted the extraction to guarantee byte-identical moves, and verified the parity suite before and after. Chris Huber directed the work and remains responsible for the change.