### PR TITLE
refactor(242): move the remaining diagnostics into Diagnostics/

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackDiagnostic.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackDiagnostic.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics;
 
 final class FallbackDiagnostic
 {

--- a/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
@@ -6,7 +6,6 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\ClassificationContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SubtreeClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\CustomBlockGenerator;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\FallbackDiagnostic;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\GeneratedBlockRegistry;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\RuntimeDomState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\RuntimeSelectorState;

--- a/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackFindingNormalizer.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackFindingNormalizer.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics;
 
 use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionFindingContract;
 

--- a/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
@@ -6,7 +6,6 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics;
 use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionFindingContract;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\ShellLandmarkPolicy;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\DomHelpersTrait;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\TypographyParityAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use DOMElement;
 

--- a/php-transformer/src/HtmlToBlocks/Diagnostics/TypographyParityAnalyzer.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/TypographyParityAnalyzer.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics;
 
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\FontMaterializationPlanBuilder;
 

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -11,6 +11,8 @@ use Automattic\BlocksEngine\PhpTransformer\Contract\TransformationOptions;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
 use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\SrcsetParser;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\ContentRoundTripReporter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackDiagnostic;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\TypographyParityAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\DiagnosticsCollector;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackEmitter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\SemanticParityReporter;

--- a/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
@@ -6,7 +6,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\AuthoredInputBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\AuthoredSelectBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\FallbackDiagnostic;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackDiagnostic;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\FormLayoutGraphBuilder;
 use DOMDocument;
 use DOMElement;

--- a/php-transformer/tests/unit/fallback-finding-normalizer.php
+++ b/php-transformer/tests/unit/fallback-finding-normalizer.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\FallbackFindingNormalizer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackFindingNormalizer;
 
 $assert = static function (bool $condition, string $message, string $detail = ''): void {
     if ( ! $condition ) {


### PR DESCRIPTION
Slice of #242.

## What

`FallbackDiagnostic`, `FallbackFindingNormalizer` and `TypographyParityAnalyzer` sat at the `HtmlToBlocks` root. `DiagnosticsCollector`, `FallbackEmitter`, `SemanticParityReporter` and `ContentRoundTripReporter` were already in `Diagnostics/`.

Nothing distinguished the two groups. The layer had won the argument already — it just never collected its stragglers. This moves them.

`Diagnostics/` goes 4 → 7 files, and the root drops from 29 loose files to 26.

## Why this shape of change

The point is that the tree should tell an agent where things go without anyone writing it down. A rule saying *"diagnostics belong in Diagnostics/"* would have been a promise contradicted by three files one directory up. Moving them makes it a fact instead: every diagnostic is visibly in one place, and the convention is now readable straight off the directory listing.

That is the whole change. No rule, no doc, no new abstraction.

## Pure relocation

7 insertions, 7 deletions. Git detects all three files as renames. Every edited line is a namespace declaration or an import that follows from one:

- 3 namespace declarations updated
- 2 imports repointed (`FormDispatchTrait`, and the normalizer's unit test)
- 2 imports dropped as redundant — `FallbackEmitter` and `SemanticParityReporter` are now siblings of what they import
- 2 imports added to `HtmlTransformer`, which lost same-namespace resolution for `FallbackDiagnostic` and `TypographyParityAnalyzer`

That last point is the trap in this kind of move: a class referenced without a `use` because it shared your namespace stops resolving the moment it moves, and PHP only tells you at runtime. I checked for surviving references to the old paths explicitly (`none — all repointed`) rather than relying on the suite to find them.

No class body changed.

## Verification

Full `composer test` on the php-transformer package, before and after:

- baseline: `EXIT=0`, **289 parity fixtures passed**
- after: `EXIT=0`, **289 parity fixtures passed**

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode mapped the references, performed the moves, repointed the imports, and verified the parity suite before and after. Chris Huber directed the work and remains responsible for the change.