### PR TITLE
refactor(242): group the transformer session and its state under Session/

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
@@ -8,8 +8,8 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SubtreeCl
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\CustomBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\FallbackDiagnostic;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\GeneratedBlockRegistry;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\RuntimeDomState;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\RuntimeSelectorState;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeDomState;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeSelectorState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\DomHelpersTrait;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use Closure;

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -3,6 +3,14 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\AssetMaterializationState;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerSession;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\ReusableComponentState;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeBehaviorState;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeDomState;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeSelectorState;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\TransformationEvidenceState;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\TransformationProvenanceState;
 use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionReportProjection;
 use Automattic\BlocksEngine\PhpTransformer\Contract\EditabilityReport;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\CoreBlockCapabilityMatrix;

--- a/php-transformer/src/HtmlToBlocks/Session/AssetMaterializationState.php
+++ b/php-transformer/src/HtmlToBlocks/Session/AssetMaterializationState.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session;
 
 /** Per-transform source metadata and generated asset state. */
 final class AssetMaterializationState

--- a/php-transformer/src/HtmlToBlocks/Session/HtmlTransformerSession.php
+++ b/php-transformer/src/HtmlToBlocks/Session/HtmlTransformerSession.php
@@ -1,8 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\GeneratedBlockRegistry;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackEmitter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AuthorSelectorProjectionState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AuthorStyleAnalysis;

--- a/php-transformer/src/HtmlToBlocks/Session/ReusableComponentState.php
+++ b/php-transformer/src/HtmlToBlocks/Session/ReusableComponentState.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session;
 
 /** Per-transform reusable component recognition and mapping state. */
 final class ReusableComponentState

--- a/php-transformer/src/HtmlToBlocks/Session/RuntimeBehaviorState.php
+++ b/php-transformer/src/HtmlToBlocks/Session/RuntimeBehaviorState.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session;
 
 final class RuntimeBehaviorState
 {

--- a/php-transformer/src/HtmlToBlocks/Session/RuntimeDomState.php
+++ b/php-transformer/src/HtmlToBlocks/Session/RuntimeDomState.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session;
 
 /** Per-transform runtime island and retained DOM contract evidence. */
 final class RuntimeDomState

--- a/php-transformer/src/HtmlToBlocks/Session/RuntimeSelectorState.php
+++ b/php-transformer/src/HtmlToBlocks/Session/RuntimeSelectorState.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session;
 
 /** Per-transform declared and superseded runtime selectors. */
 final class RuntimeSelectorState

--- a/php-transformer/src/HtmlToBlocks/Session/TransformationEvidenceState.php
+++ b/php-transformer/src/HtmlToBlocks/Session/TransformationEvidenceState.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session;
 
 final class TransformationEvidenceState
 {

--- a/php-transformer/src/HtmlToBlocks/Session/TransformationProvenanceState.php
+++ b/php-transformer/src/HtmlToBlocks/Session/TransformationProvenanceState.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session;
 
 final class TransformationProvenanceState
 {

--- a/php-transformer/tests/unit/html-transformer-session-state.php
+++ b/php-transformer/tests/unit/html-transformer-session-state.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformerSession;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerSession;
 
 $assert = static function (bool $condition, string $message): void {
     if ( ! $condition ) {


### PR DESCRIPTION
Slice of #242.

## What changed, and why not `State/`

The plan was a `State/` directory. Checking first showed that would have been wrong.

State in this repo is already **domain-located**. `Style/` holds `LayoutGeometryState`, `SourceStyleResolutionState`, `AuthorSelectorProjectionState` and `GeneratedSupportStylesheetState` — four of the eleven `*State` classes — because they are style-domain state owned by style code. A flat `State/` would have created a second home for state and contradicted a convention the tree already follows.

So this follows the existing precedent instead: the owner and the state it owns live together. `HtmlTransformerSession` constructs **six of the seven** remaining root state objects, so the ownership is measured rather than asserted.

`Session/` now holds the session and its state. Root drops from 29 loose files to 21.

## Pure relocation

Content diff excluding renames is **only `namespace` and `use` lines** — verified, not assumed. No class body changed.

## The bug the contract suite caught

The first run came back red, and it is worth recording because it is the third variant of the same hazard tonight:

```
HtmlTransformerSession::installGeneratedBlockRegistry():
  Argument #1 ($registry) must be of type ...HtmlToBlocks\Session\GeneratedBlockRegistry,
  ...HtmlToBlocks\GeneratedBlockRegistry given
```

`GeneratedBlockRegistry` stays at the root. The session type-hinted it **unqualified**, which resolved fine while the two shared a namespace and silently repointed to `Session\GeneratedBlockRegistry` the moment the file moved.

Earlier slices hit this in the outward direction — files that referenced a class *after it moved away*. This is the inward direction: a *moved* file referencing a class that **stayed**, in a type hint rather than a `new` or `::` call. My reference sweep had only covered the outward case.

Fixed with an explicit import, then swept every moved file for unqualified references to classes remaining at the root — including parameter types, return types and docblock types. `GeneratedBlockRegistry` was the only one.

Worth noting the parity fixtures did **not** catch this; the `runtime-no-markdown` contract did, because it exercises a degraded autoload path. The contract suite is earning its keep on these moves.

## Verification

Full `composer test` on the php-transformer package:

- baseline: `EXIT=0`, **289 parity fixtures passed**
- after: `EXIT=0`, **289 parity fixtures passed**

## Relationship to the other open slices

Independent of #1272 (diagnostics) and #1273 (generators). All three take files off the same root and compose to a root of 8 once they all land.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode checked the existing state placement before accepting the `State/` plan, found the `Style/` precedent, measured session ownership, performed the moves, diagnosed the type-hint failure from the contract output, and verified the suite before and after. Chris Huber directed the work and remains responsible for the change.