### PR TITLE
ci: bump the promotion gate pin to the tightened parity threshold

### DIFF
--- a/.github/workflows/solved-fixture-regression.yml
+++ b/.github/workflows/solved-fixture-regression.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   solved-site-promotion:
-    uses: Automattic/static-site-importer/.github/workflows/solved-site-promotion.yml@2edd49e6e03696f8a147dbac0db17d871d9a5687
+    uses: Automattic/static-site-importer/.github/workflows/solved-site-promotion.yml@5d6c5ed4bbfff777e2e08e25e527053009715264
     with:
       static-site-importer-sha: 2edd49e6e03696f8a147dbac0db17d871d9a5687
       blocks-engine-sha: ${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
Consumes Automattic/static-site-importer#1359.

```diff
-    uses: .../solved-site-promotion.yml@2edd49e6e03696f8a147dbac0db17d871d9a5687
+    uses: .../solved-site-promotion.yml@5d6c5ed4bbfff777e2e08e25e527053009715264
```

## Why

The gate is pinned by SHA, so the upstream fix does not reach this repo until the pin moves. Until then trunk keeps failing on sub-perceptual render noise.

`f972274e` on trunk, after eleven consecutive greens:

```
Aligned visual parity mismatch: 6/9955320 pixels (0.00%)
exceed the 0.00% threshold
(raw full-page 0.00%, detected offset x=0px, y=0px)
```

Same commit, no code change between attempts: **fail, fail, pass**. The prior commit passed as a control. The change under suspicion was verified unreachable — an import inside a method with no callers — so it could not have moved a pixel.

## What the new SHA changes

`--visual-parity-pixelmatch-threshold` is pixelmatch's per-pixel colour distance, not a count of allowed pixels. At `0` a pixel counts as mismatched when any channel differs by `1/255`, so the gate demanded a bit-exact render across two independent headless browser runs.

`5d6c5ed4` sets it to `0.01`. Measured against the library, that tolerates the ±2/255 drift renderers actually produce and flags any pixel differing by 3 levels or more. Verified present at the pinned SHA:

```
--pixel-threshold 0 \
--visual-parity-pixelmatch-threshold 0.01 \
```

`--pixel-threshold 0` and both shift tolerances are unchanged, so a single perceptibly different pixel, or any layout movement, still fails the gate.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the flaky gate from a red trunk run, measured the threshold's real tolerance against pixelmatch, landed the upstream fix, and verified the new SHA carries it before bumping. Chris Huber directed the work and remains responsible for the change.