### PR TITLE
Signature repeatable children by heading landmark

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Classification/SubtreeClassifier.php
+++ b/php-transformer/src/HtmlToBlocks/Classification/SubtreeClassifier.php
@@ -47,6 +47,18 @@ final class SubtreeClassifier
      */
     private const MIN_MARGIN = 1.5;
 
+    /**
+     * Heading tags used as the structural landmark in a child's repetition
+     * signature.
+     */
+    private const HEADING_TAGS = array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' );
+
+    /**
+     * Upper bound on descendants inspected when profiling a child's headings;
+     * the profile is deliberately coarse, so deep subtrees need no full walk.
+     */
+    private const HEADING_PROFILE_SCAN_LIMIT = 256;
+
     private const INTERACTIVE_ROLES = array(
         'tablist',
         'tab',
@@ -438,9 +450,20 @@ final class SubtreeClassifier
     }
 
     /**
-     * Largest group of direct child elements that share the same tag + class
-     * signature — the structural hallmark of a repeatable content unit. Returns
-     * the size of that group (0 or 1 means "not repeatable").
+     * Largest group of direct child elements that share the same structural
+     * signature — the hallmark of a repeatable content unit. Returns the size of
+     * that group (0 or 1 means "not repeatable").
+     *
+     * The signature pairs the child's own tag + class shape with the heading
+     * levels it carries. Sources routinely wrap every element in an identical
+     * wrapper (custom elements, class-less layout divs), so wrapper shape alone
+     * reports repetition the content does not have. Peers in a collection agree
+     * on their heading structure; a section heading and the body copy beside it
+     * do not, even when their wrappers match exactly.
+     *
+     * Headings are the landmark rather than a full content profile so that
+     * genuine peers still match when they differ in incidental content, such as
+     * one card carrying an icon its siblings omit.
      */
     private function repeatableChildCount(DOMElement $element): int
     {
@@ -451,11 +474,42 @@ final class SubtreeClassifier
             }
             $classes = $this->classNames($child);
             sort($classes);
-            $signature = strtolower($child->tagName) . '|' . implode('.', $classes);
+            $signature = strtolower($child->tagName) . '|' . implode('.', $classes)
+                . '|' . implode('.', $this->headingProfile($child));
             $signatures[$signature] = ( $signatures[$signature] ?? 0 ) + 1;
         }
 
         return empty($signatures) ? 0 : max($signatures);
+    }
+
+    /**
+     * Distinct heading levels carried by a child subtree, including the child
+     * itself when it is a heading.
+     *
+     * @return array<int, string> Sorted distinct heading tag names.
+     */
+    private function headingProfile(DOMElement $element): array
+    {
+        $profile = array();
+        if ( in_array(strtolower($element->tagName), self::HEADING_TAGS, true) ) {
+            $profile[strtolower($element->tagName)] = true;
+        }
+
+        $scanned = 0;
+        foreach ( $element->getElementsByTagName('*') as $descendant ) {
+            if ( ++$scanned > self::HEADING_PROFILE_SCAN_LIMIT ) {
+                break;
+            }
+            $tag = strtolower($descendant->tagName);
+            if ( in_array($tag, self::HEADING_TAGS, true) ) {
+                $profile[$tag] = true;
+            }
+        }
+
+        $tags = array_keys($profile);
+        sort($tags);
+
+        return $tags;
     }
 
     /**

--- a/php-transformer/tests/unit/subtree-classifier.php
+++ b/php-transformer/tests/unit/subtree-classifier.php
@@ -183,6 +183,70 @@ $assert($r->signals()['interactive_role'] === true, '10: result exposes structur
 $assert(isset($r->toArray()['bucket'], $r->toArray()['confidence'], $r->toArray()['signals']), '10: toArray shape');
 
 // ---------------------------------------------------------------------------
+// 11. repeatable_children reflects content shape, not wrapper shape (issue #1278).
+//     Site builders wrap every element in an identical wrapper, so wrapper shape
+//     alone reported repetition that the content does not have.
+// ---------------------------------------------------------------------------
+$wrappedSection = $element(
+    '<div role="group" class="section">'
+    . '<interact-element><div class="rich"><h1><span>Commute with Purpose</span></h1></div></interact-element>'
+    . '<interact-element><div class="rich"><p>Turn your daily transit into rewards.</p></div></interact-element>'
+    . '</div>'
+);
+$r = $classifier->classify($wrappedSection, new ClassificationContext('.section { display: grid; }', ''));
+$assert(
+    $r->signals()['repeatable_children'] < 2,
+    '11: identical wrappers around a heading and a paragraph are not repetition',
+    json_encode($r->signals()['repeatable_children'])
+);
+
+// True positive must survive: sibling units with matching content shape still repeat.
+$wrappedCards = $element(
+    '<div class="grid">'
+    . '<interact-element><div class="card"><img src="a.jpg"><h3>One</h3><p>First.</p></div></interact-element>'
+    . '<interact-element><div class="card"><img src="b.jpg"><h3>Two</h3><p>Second.</p></div></interact-element>'
+    . '<interact-element><div class="card"><img src="c.jpg"><h3>Three</h3><p>Third.</p></div></interact-element>'
+    . '</div>'
+);
+$r = $classifier->classify($wrappedCards, new ClassificationContext('.card { border: 1px solid #ccc; }', ''));
+$assert(
+    $r->signals()['repeatable_children'] === 3,
+    '11: wrapped cards with matching content shape still repeat',
+    json_encode($r->signals()['repeatable_children'])
+);
+$assert($r->is(SubtreeClassifier::BUCKET_CUSTOM_BLOCK), '11: wrapped card grid -> custom_block', $summarize($r));
+
+// Peers that differ only in incidental content must still repeat: collections
+// routinely carry an icon or image on some items and not others.
+$unevenCards = $element(
+    '<section class="cards">'
+    . '<article class="card"><svg viewBox="0 0 1 1"><path d="M0 0h1v1z"/></svg><h3>One</h3><p>First.</p></article>'
+    . '<article class="card"><h3>Two</h3><p>Second with <strong>bold</strong>.</p></article>'
+    . '<article class="card"><h3>Three</h3><ul><li>Third</li></ul></article>'
+    . '</section>'
+);
+$r = $classifier->classify($unevenCards, new ClassificationContext('.card { padding: 8px; }', ''));
+$assert(
+    $r->signals()['repeatable_children'] === 3,
+    '11: peers differing in incidental content still repeat',
+    json_encode($r->signals()['repeatable_children'])
+);
+
+// Headings at different levels are not peers.
+$mixedHeadings = $element(
+    '<div class="stack">'
+    . '<div class="row"><h2>Section title</h2></div>'
+    . '<div class="row"><h4>Sub label</h4></div>'
+    . '</div>'
+);
+$r = $classifier->classify($mixedHeadings, new ClassificationContext('.row { margin: 4px; }', ''));
+$assert(
+    $r->signals()['repeatable_children'] < 2,
+    '11: differing heading levels in matching wrappers are not repetition',
+    json_encode($r->signals()['repeatable_children'])
+);
+
+// ---------------------------------------------------------------------------
 
 if ( $failures > 0 ) {
     fwrite(STDERR, PHP_EOL . "SubtreeClassifier unit tests: {$passes} passed, {$failures} FAILED" . PHP_EOL);


### PR DESCRIPTION
Closes #1279.

## Problem

`SubtreeClassifier::repeatableChildCount()` signatured a subtree's immediate children by tag name and class list alone, never inspecting what each child carries. Sources that wrap every content element in an identical wrapper therefore reported repetition their content does not have: a section heading and the body copy beside it collapsed to one signature, adding `+2.0` toward `BUCKET_CUSTOM_BLOCK` and letting `generatedBlockStem()` label the pair a `collection`.

## Change

Pair the child's tag and class shape with the heading levels it carries. Peers in a collection agree on heading structure; a heading and adjacent body copy do not, even when their wrappers match exactly.

Headings are the landmark rather than a full content profile so genuine peers still match when they differ in incidental content. A full content-shape profile was implemented first and regressed the existing `fluid-columns-repeater` case in `tests/unit/inert-capture-scaffolding.php`, where one column carries an icon the other omits. That is a legitimate collection and must keep repeating.

## Coverage

Four assertions added to `tests/unit/subtree-classifier.php`:

- identical class-less wrappers around a heading and a paragraph do not report repetition
- matching wrappers around different heading levels do not report repetition
- wrapped sibling cards sharing a heading level still repeat and still classify as `custom_block`
- peers differing only in incidental content (icon, list instead of paragraph) still repeat

The two negative assertions fail on trunk with `repeatable_children = 2` and pass with this change:

```
FAIL: 11: identical wrappers around a heading and a paragraph are not repetition - 2
FAIL: 11: differing heading levels in matching wrappers are not repetition - 2
SubtreeClassifier unit tests: 26 passed, 2 FAILED
```

With the change:

```
SubtreeClassifier unit tests: 28 passed
```

`composer test` passes end to end (exit 0).

## Scope

This is a false positive in the repetition signal only. It is independent of #1278 and does not change that source's output: subtrees there reach `maybeGenerateCustomBlock()` with `$confirmedComponent = true`, which bypasses `SubtreeClassifier` entirely. Rebuilding the Static Site Importer development package against this branch and re-running that import produced byte-identical results (same generated block names, same 82.6 percent opaque content). The remaining defect is tracked in #1278.

## AI assistance

Claude Sonnet 4.5 via OpenCode traced the classification path, measured the child signatures, implemented the change, wrote the coverage, and ran verification including the end-to-end re-import used to confirm scope. Chris Huber reviewed and is responsible for the submitted change.
