### PR TITLE
Unwrap wrapper-convention custom elements before component promotion

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -88,6 +88,17 @@ use DOMNode;
 final class HtmlTransformer
 {
     private const GENERATED_COMPONENT_MIN_SOURCE_DEPTH = 14;
+
+    /**
+     * Instances a custom element tag must reach before recurring usage can be
+     * read as a wrapping convention rather than a component.
+     */
+    private const WRAPPER_CONVENTION_MIN_INSTANCES = 3;
+
+    /**
+     * Depth of the shallow tag skeleton compared across wrapper instances.
+     */
+    private const WRAPPER_CONTENT_SHAPE_DEPTH = 2;
     use ButtonLinkDispatchTrait;
     use DomHelpersTrait;
     use ElementConversionTrait;
@@ -522,6 +533,10 @@ final class HtmlTransformer
 
         $this->navigationBlockNormalizer->hydrateDuplicateSubmenus($body);
         $this->materializeDeclarativeCounters($body, (string) ($options['declarative_state_html'] ?? ''));
+        // Remove wrapper-convention custom elements before author selectors are
+        // prepared, so style projection and component promotion both observe the
+        // content rather than the source's wrapping convention.
+        $this->unwrapRenderNeutralCustomElements($body, (string) ($options['static_css'] ?? ''));
         $this->prepareAuthorSelectorSemantics($html, (string) ($options['static_css'] ?? ''), $body, $options);
         $this->fallbackEmitter()->configure($this->transformationProvenance()->fallback(), $this->runtimeBehavior()->runtimeScriptMetadata(), $this->runtimeSelectors(), $this->authorSelectorProjections()->tagMarkers());
         // Author-selector preparation marks source nodes for later projection.
@@ -917,6 +932,101 @@ final class HtmlTransformer
     private function reusableComponentFingerprintFor(DOMElement $element): ?string
     {
         return $this->reusableComponents()->fingerprintForPath((string) $element->getNodePath());
+    }
+
+    /**
+     * Remove custom elements a source uses as a wrapping convention.
+     *
+     * Site builders wrap ordinary content in presentation-only custom elements.
+     * A custom element tag is not evidence that its subtree needs a generated
+     * block, so leaving those wrappers in place freezes headings and copy into
+     * opaque markup. A tag is treated as a convention when it recurs across the
+     * document while the content it wraps diverges: a genuine component repeats
+     * its internal structure, a wrapper does not.
+     */
+    private function unwrapRenderNeutralCustomElements(DOMElement $body, string $staticCss): void
+    {
+        $instances = array();
+        foreach ( $body->getElementsByTagName('*') as $element ) {
+            if ( $element instanceof DOMElement && str_contains(strtolower($element->tagName), '-') ) {
+                $instances[strtolower($element->tagName)][] = $element;
+            }
+        }
+
+        foreach ( $instances as $tag => $elements ) {
+            if ( ! $this->isWrapperConventionTag($tag, $elements, $staticCss) ) {
+                continue;
+            }
+            foreach ( $elements as $element ) {
+                if ( $this->isRenderNeutralWrapper($element) ) {
+                    $this->unwrapElement($element);
+                }
+            }
+        }
+    }
+
+    /**
+     * Whether a custom element tag is used as a wrapping convention rather than
+     * as a component host.
+     *
+     * @param array<int, DOMElement> $elements Every instance of the tag.
+     */
+    private function isWrapperConventionTag(string $tag, array $elements, string $staticCss): bool
+    {
+        if ( self::WRAPPER_CONVENTION_MIN_INSTANCES > count($elements) ) {
+            return false;
+        }
+
+        // A styled tag carries presentation of its own and is not render-neutral.
+        if ( '' !== $staticCss && 1 === preg_match('/(?<![\w-])' . preg_quote($tag, '/') . '(?![\w-])/i', $staticCss) ) {
+            return false;
+        }
+
+        $shapes = array();
+        foreach ( $elements as $element ) {
+            $shapes[$this->wrappedContentShape($element)] = true;
+            if ( 1 < count($shapes) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Shallow tag skeleton of the content a wrapper carries. Instances of a real
+     * component repeat this shape; instances of a wrapper do not.
+     */
+    private function wrappedContentShape(DOMElement $element, int $depth = 0): string
+    {
+        $parts = array();
+        foreach ( $element->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+            $tag = strtolower($child->tagName);
+            $parts[] = self::WRAPPER_CONTENT_SHAPE_DEPTH > $depth
+                ? $tag . '(' . $this->wrappedContentShape($child, $depth + 1) . ')'
+                : $tag;
+        }
+
+        return implode(',', $parts);
+    }
+
+    /**
+     * Whether a wrapper instance carries no identity, behavior, or presentation
+     * of its own, and can therefore be replaced by its children.
+     */
+    private function isRenderNeutralWrapper(DOMElement $element): bool
+    {
+        return null !== $element->parentNode
+            && '' === trim($this->attr($element, 'id'))
+            && '' === trim($this->attr($element, 'class'))
+            && '' === trim($this->attr($element, 'role'))
+            && '' === trim($this->attr($element, 'style'))
+            && array() === $this->interactiveAttributes($element)
+            && ! $this->isRuntimeDomTarget($element)
+            && ! $this->hasMotionStructureToken($element);
     }
 
     private function collectGeneratedComponentCandidates(DOMElement $element, int $depth = 0): void

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -536,7 +536,7 @@ final class HtmlTransformer
         // Remove wrapper-convention custom elements before author selectors are
         // prepared, so style projection and component promotion both observe the
         // content rather than the source's wrapping convention.
-        $this->unwrapRenderNeutralCustomElements($body, (string) ($options['static_css'] ?? ''));
+        $this->unwrapRenderNeutralCustomElements($body, $this->authoredCssText($html, (string) ($options['static_css'] ?? '')));
         $this->prepareAuthorSelectorSemantics($html, (string) ($options['static_css'] ?? ''), $body, $options);
         $this->fallbackEmitter()->configure($this->transformationProvenance()->fallback(), $this->runtimeBehavior()->runtimeScriptMetadata(), $this->runtimeSelectors(), $this->authorSelectorProjections()->tagMarkers());
         // Author-selector preparation marks source nodes for later projection.
@@ -977,8 +977,10 @@ final class HtmlTransformer
             return false;
         }
 
-        // A styled tag carries presentation of its own and is not render-neutral.
-        if ( '' !== $staticCss && 1 === preg_match('/(?<![\w-])' . preg_quote($tag, '/') . '(?![\w-])/i', $staticCss) ) {
+        // A tag that carries presentation of its own is not render-neutral.
+        // `display:contents` is the exception that proves the rule: it states
+        // the element generates no box and renders as its children.
+        if ( ! $this->customElementCssIsRenderNeutral($tag, $staticCss) ) {
             return false;
         }
 
@@ -991,6 +993,72 @@ final class HtmlTransformer
         }
 
         return false;
+    }
+
+    /**
+     * Author CSS visible to the document: declared stylesheets plus the styles
+     * the source embeds inline.
+     */
+    private function authoredCssText(string $html, string $staticCss): string
+    {
+        $embedded = array();
+        if ( 0 < preg_match_all('/<style\b[^>]*>(.*?)<\/style>/is', $html, $matches) ) {
+            $embedded = $matches[1];
+        }
+
+        return trim($staticCss . "\n" . implode("\n", $embedded));
+    }
+
+    /**
+     * Whether every author rule addressing a custom element tag leaves it
+     * render-neutral, so replacing instances with their children preserves the
+     * authored presentation.
+     */
+    private function customElementCssIsRenderNeutral(string $tag, string $css): bool
+    {
+        if ( '' === trim($css) ) {
+            return true;
+        }
+
+        $pattern = '/(?<![\w-])' . preg_quote($tag, '/') . '(?![\w-])/i';
+        if ( 1 !== preg_match($pattern, $css) ) {
+            return true;
+        }
+
+        foreach ( $this->cssRuleBlocks($css) as $rule ) {
+            if ( 1 !== preg_match($pattern, $rule['selector']) ) {
+                continue;
+            }
+            foreach ( $this->cssDeclarations($rule['declarations']) as $property => $value ) {
+                if ( 'display' !== strtolower(trim($property)) || 'contents' !== strtolower(trim($value)) ) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Flat selector/declaration pairs for the top-level rules in a stylesheet.
+     *
+     * @return array<int, array{selector: string, declarations: string}>
+     */
+    private function cssRuleBlocks(string $css): array
+    {
+        $rules = array();
+        if ( 1 !== preg_match_all('/([^{}]+)\{([^{}]*)\}/', $css, $matches, PREG_SET_ORDER) && array() === $matches ) {
+            return $rules;
+        }
+
+        foreach ( $matches as $match ) {
+            $rules[] = array(
+                'selector'     => trim($match[1]),
+                'declarations' => trim($match[2]),
+            );
+        }
+
+        return $rules;
     }
 
     /**


### PR DESCRIPTION
Closes #1278.

## Problem

`collectGeneratedComponentCandidates()` let any tag containing a hyphen bypass the repeated-child-structure requirement:

```php
&& ($this->hasRepeatedDirectChildTags($element) || str_contains(strtolower($element->tagName), '-'))
```

A custom element tag was therefore treated as sufficient evidence that a subtree needed a generated block. Promotion then ran with `$confirmedComponent = true`, which skips `SubtreeClassifier` entirely, so no scoring could intervene.

Sources that wrap ordinary content in presentation-only custom elements had headings, copy, and quotes frozen into opaque generated blocks. For the Wix source in #1278, 24 of 28 generated blocks were rooted at `<interact-element>`, including one wrapping nothing but the page `<h1>`.

## Approach

Remove the wrappers before promotion rather than teaching promotion to recognise them. Once the wrapper is gone, the content converts through the existing native path with no special-casing.

A custom element tag is read as a wrapping convention when it recurs across the document while the content it wraps diverges. A real component repeats its internal structure; a wrapper does not. Structure alone cannot separate the two, because both commonly wrap a single child.

Instances are unwrapped only when they carry no identity, behaviour, or presentation: no `id`, `class`, `role`, or `style`, no interactive attributes, not a runtime DOM target, and no motion structure token. That vocabulary matches the gates already used by `coalescedSingleGroupWrapper()`.

Author CSS is judged by render neutrality rather than presence. Sources declare exactly one rule for these wrappers:

```css
interact-element{display:contents}
```

`display:contents` states the element generates no box and renders as its children, so a presence check preserved the wrapper on the strength of the rule that proves it is safe to remove. The pass also reads the document's embedded styles alongside the declared stylesheet so it observes the same CSS as the rest of the transform.

The pass runs before author-selector preparation so style projection and component promotion both observe content rather than the wrapping convention.

## Result on the reproduction source

Measured end to end by rebuilding the Static Site Importer development package against this branch and re-running the import.

| Measure | Before | After |
| --- | --- | --- |
| Opaque HTML in generated `content` attributes | 578,428 bytes (82.6%) | 2,586 bytes (0.8%) |
| Generated companion blocks on the page | 16 | 2 |
| Serialized block markup | 700 KB | 308 KB |
| Words represented in native blocks | 94 | 450 |
| `core/heading` | 0 | 26 |
| `core/image` | 6 | 38 |
| `core/quote` | 0 | 4 |

Transformer-level count for the same input drops from 17 generated blocks to 4.

Inline SVG artwork that previously disappeared now renders, because the artwork reaches the frontend through native blocks instead of the companion renderer's `wp_kses_post()` boundary (see static-site-importer#1361).

## Verification

- `composer test` passes end to end (exit 0).
- `tests/unit/custom-block-generator.php`: 58 passed, including `6: a deep safe custom-element host becomes one exact companion block`. `<fluid-card-grid>` is used once and keeps a repeated internal shape, so it is not read as a convention and still becomes a companion block.
- `tests/unit/inert-capture-scaffolding.php`: 11 assertions passed, including the `fluid-columns-repeater` case.

## Effects verified against the pre-change build

Each item below was measured by importing the same source with and without this change and comparing the rendered pages, including aligned screenshots and DOM geometry.

### Restored by this change

The signup form now exists. Before this change the page contained zero `input` elements: the form lived inside a generated companion block, and that renderer's `wp_kses_post()` boundary strips form controls exactly as it strips SVG (static-site-importer#1361). After this change the page has six `input` elements, three of them laid out and visible.

Inline SVG artwork also returns for the same reason: numbered feature-card icons render where they were previously empty boxes, and section headings render as text.

### Not a regression: footer logo and legal links

An earlier note on this PR claimed the footer lost its logo and `Privacy Policy` / `Accessibility Statement` links. That was a measurement error. The after page is 505px taller (5804 → 6309), and a bottom-of-page crop compared the original footer to empty space below the after footer.

Aligned to the Privacy Policy y-coordinate, both builds match the original's x-position (281 / 446). The footer wordmark is present in both DOMs at 112×28. The legal links are present in both. Nav and social labels wrap mid-word in both builds; that wrapping is pre-existing.

The after footer group is taller (431px vs 123px), which is leftover empty space from more of the page now participating in flow, not missing content.

### Pre-existing, unchanged by this change

Verified identical before and after:

- The header navigation pill is misplaced and overlaps the first section (`nav` at x=571, y=33, 298×29 and `header` at 1440×235 in both builds).
- A secondary navigation label renders one letter per line.
- Footer social labels wrap mid-word.

### Remaining defects on the restored form

- The three fields render side by side (x = 67, 227, 387 at a shared y) where the source stacks them vertically.
- Field labels are carried only as `aria-label` and are not rendered visibly.
- The submit control renders as a full-width bar labelled `Button` rather than the source's pill labelled `Claim My Spot`.

This source is not solved. The remaining items are separate layout and pattern-recognition concerns, not blockers for the promotion-path change in this PR.

## AI assistance

Claude Sonnet 4.5 via OpenCode traced the promotion path, produced the measurements, implemented the pass, and ran verification including repeated end-to-end imports to confirm effect. Two earlier root-cause hypotheses were disproved by measurement before this one; that history is recorded on #1278 and #1279. Chris Huber reviewed and is responsible for the submitted change.
