### PR TITLE
Keep form labels, submit copy, and stacked fields

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -124,6 +124,7 @@
        "php tests/unit/block-metadata-capabilities.php",
       "php tests/unit/content-round-trip-reporter.php",
       "php tests/unit/content-round-trip-form-echo.php",
+      "php tests/unit/form-associated-label-submit.php",
       "php tests/unit/corpus-detectors.php",
       "php tests/unit/live-wp-parity-runner.php",
       "php tests/unit/deterministic-row-deduplicator.php",

--- a/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
@@ -643,7 +643,7 @@ trait FormDispatchTrait
                 return null;
             }
 
-            if ( 'submit' === $this->formControlType($control) ) {
+            if ( $this->isSubmitLikeControl($control) ) {
                 $buttonBlocks[] = $this->createBlock('core/button', array_merge($this->presentationAttributes($control), array(
                     'text' => $this->runtime->escapeHtml($this->readableSubmitText($control)),
                 )), array(), $control);
@@ -659,9 +659,22 @@ trait FormDispatchTrait
             }
 
             $readableControlBlock = $this->readableFormControlBlockFromElement($control);
-            if ( null !== $readableControlBlock ) {
-                $contentBlocks[] = $readableControlBlock;
+            if ( null === $readableControlBlock ) {
+                continue;
             }
+
+            $fieldBlocks = array();
+            $associatedLabel = $this->associatedLabelElement($control);
+            if ( $associatedLabel instanceof DOMElement && AuthoredInputBlockGenerator::NAME === ($readableControlBlock['blockName'] ?? '') ) {
+                $labelBlock = $this->readableFormControlBlockFromElement($associatedLabel);
+                if ( null !== $labelBlock ) {
+                    $fieldBlocks[] = $labelBlock;
+                }
+            }
+            $fieldBlocks[] = $readableControlBlock;
+            $contentBlocks[] = ( 1 === count($fieldBlocks) && AuthoredInputBlockGenerator::NAME !== ($readableControlBlock['blockName'] ?? '') )
+                ? $fieldBlocks[0]
+                : $this->createBlock('core/group', array(), $fieldBlocks, $control);
         }
 
         if ( array() !== $buttonBlocks ) {
@@ -1342,7 +1355,42 @@ trait FormDispatchTrait
             return false;
         }
 
-        return $this->hasSubmitSemantics($control);
+        return $this->hasSubmitSemantics($control) || $this->isSoleFormActionControl($control);
+    }
+
+    /**
+     * The only non-reset button-like control in the enclosing form is the form's
+     * action, even when its type is `button` and its label is not a submit verb.
+     */
+    private function isSoleFormActionControl(DOMElement $control): bool
+    {
+        $form = null;
+        for ( $parent = $control->parentNode; $parent instanceof DOMElement; $parent = $parent->parentNode ) {
+            if ( 'form' === strtolower($parent->tagName) ) {
+                $form = $parent;
+                break;
+            }
+        }
+        if ( ! $form instanceof DOMElement ) {
+            return false;
+        }
+
+        $actions = 0;
+        foreach ( $this->formControlElements($form) as $candidate ) {
+            $tagName = strtolower($candidate->tagName);
+            $type = $this->formControlType($candidate);
+            if ( 'reset' === $type ) {
+                continue;
+            }
+            if ( 'button' === $tagName || ( 'input' === $tagName && in_array($type, array( 'submit', 'image', 'button' ), true) ) ) {
+                ++$actions;
+                if ( 1 < $actions ) {
+                    return false;
+                }
+            }
+        }
+
+        return 1 === $actions;
     }
 
     /**
@@ -1358,6 +1406,9 @@ trait FormDispatchTrait
             $this->attr($control, 'id'),
             $this->attr($control, 'name'),
             $this->attr($control, 'aria-label'),
+            $this->attr($control, 'data-hook'),
+            $this->attr($control, 'data-field-type'),
+            $this->attr($control, 'data-testid'),
         )));
 
         foreach ( array( 'submit', 'subscribe', 'sign up', 'sign-up', 'signup', 'send' ) as $needle ) {
@@ -1521,11 +1572,34 @@ trait FormDispatchTrait
         }
 
         $type = $this->formControlType($control);
+        if ( '' === $label && $this->isSubmitLikeControl($control) ) {
+            $label = trim(preg_replace('/\s+/', ' ', $control->textContent ?? '') ?? '');
+        }
         if ( '' === $label ) {
             return 'select' === $type ? 'Select option' : ucfirst($type);
         }
 
         return $label;
+    }
+
+    /**
+     * Label associated by `for`, not a wrapping parent label. Wrapping labels
+     * are converted with the control they contain.
+     */
+    private function associatedLabelElement(DOMElement $control): ?DOMElement
+    {
+        $id = $this->attr($control, 'id');
+        if ( '' === $id || ! $control->ownerDocument instanceof DOMDocument ) {
+            return null;
+        }
+
+        foreach ( $control->ownerDocument->getElementsByTagName('label') as $label ) {
+            if ( $label instanceof DOMElement && $id === $this->attr($label, 'for') ) {
+                return $label;
+            }
+        }
+
+        return null;
     }
 
     private function readableSubmitText(DOMElement $control): string

--- a/php-transformer/tests/unit/form-associated-label-submit.php
+++ b/php-transformer/tests/unit/form-associated-label-submit.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Form conversion must keep associated labels, submit copy, and stacked fields
+ * (issue #1282). Source builders often use `<button type="button">` as the
+ * submit control and associate labels with `for`, not wrapping markup.
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$failures = 0;
+$passes   = 0;
+
+$assert = static function (bool $condition, string $message, string $detail = '') use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ( '' !== $detail ? ' - ' . $detail : '' ) . PHP_EOL);
+};
+
+$transformer = new HtmlTransformer();
+$serialize = static function (string $html, array $options = array()) use ($transformer): string {
+    return (string) ( $transformer->transform($html, $options)->toArray()['serialized_blocks'] ?? '' );
+};
+
+$form = '<main><form aria-label="Contact">'
+    . '<label for="first">First name<span aria-hidden="true">*</span></label>'
+    . '<input id="first" type="text" aria-label="First name" required style="display:block;width:100%">'
+    . '<label for="last">Last name</label>'
+    . '<input id="last" type="text" aria-label="Last name" required style="display:block;width:100%">'
+    . '<label for="email">Email</label>'
+    . '<input id="email" type="email" aria-label="Email" required style="display:block;width:100%">'
+    . '<button type="button"><span>Claim My Spot</span></button>'
+    . '</form></main>';
+
+$serialized = $serialize($form);
+
+$assert(
+    str_contains($serialized, 'Claim My Spot') && ! str_contains($serialized, '>Button<'),
+    '1: type=button submit keeps visible copy instead of the type name',
+    $serialized
+);
+$assert(
+    str_contains($serialized, '<!-- wp:button') && str_contains($serialized, 'Claim My Spot'),
+    '1b: submit copy lives on a core/button',
+    $serialized
+);
+$assert(
+    str_contains($serialized, 'First name') && str_contains($serialized, 'Last name') && str_contains($serialized, 'Email'),
+    '2: associated labels remain visible',
+    $serialized
+);
+$assert(
+    str_contains($serialized, 'authored-input') && 3 <= substr_count($serialized, '<!-- wp:group'),
+    '3: authored fields are wrapped so stacked layout survives flattening',
+    $serialized
+);
+
+$nativeSubmit = $serialize('<main><form><label for="e">Email</label><input id="e" type="email" required><button type="submit">Send</button></form></main>');
+$assert(
+    str_contains($nativeSubmit, 'Send') && str_contains($nativeSubmit, '<!-- wp:button'),
+    '4: type=submit still becomes a core/button',
+    $nativeSubmit
+);
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, PHP_EOL . "form associated-label/submit tests: {$passes} passed, {$failures} FAILED" . PHP_EOL);
+    exit(1);
+}
+
+fwrite(STDOUT, "form associated-label/submit tests: {$passes} passed" . PHP_EOL);


### PR DESCRIPTION
Closes #1282.

## Problem

A captured contact form with visible labels, CSS-grid stacking, and a `<button type="button">Claim My Spot</button>` submit was flattened into unlabelled inline inputs and a paragraph whose text was the control type name `Button`.

The artifact was correct. `readableFormBlockFromForm()` walked `formControlElements()` only, so associated `<label for>` elements were never converted. `<button type="button">` was not treated as submit-like, and `readableFormControlLabel()` fell back to `ucfirst($type)`. `readableSubmitText()` already returned the visible copy and was only consulted for `type="submit"`. Flattening discarded the per-field wrappers that stacked the inputs.

## Change

- Treat a sole form action control, or a `type="button"` whose `data-hook` / `data-field-type` / `data-testid` carries submit semantics, as submit-like and emit `core/button` using `readableSubmitText()`.
- Prefer the control's visible text over `ucfirst($type)` when synthesizing a readable label.
- Emit associated `for=` labels next to authored inputs.
- Wrap each authored field so stacked layout survives flattening.

## Coverage

`tests/unit/form-associated-label-submit.php` (5 assertions). On trunk:

```
FAIL: 1: type=button submit keeps visible copy instead of the type name
FAIL: 1b: submit copy lives on a core/button
FAIL: 3: authored fields are wrapped so stacked layout survives flattening
```

With this change the same tests pass, and `composer test` exits 0. Transforming the captured Nimbus form fragment emits `Claim My Spot` on a `core/button` and no `>Button<` paragraph.

## AI assistance

Claude Sonnet 4.5 via OpenCode compared the captured artifact to materialized blocks, traced `FormDispatchTrait`, implemented the change, and ran verification. Chris Huber reviewed and is responsible for the submitted change.
