### PR TITLE
Lower inline social clusters to core/social-links

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/SocialLinksPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/SocialLinksPattern.php
@@ -42,8 +42,8 @@ final class SocialLinksPattern implements PatternRecognizerInterface
         $structuralItems = true;
         foreach ( $anchors as $anchor ) {
             $url = LinkUrlSanitizer::sanitize($this->attr($anchor, 'href'));
-            if ( '' === $url ) {
-                return null;
+            if ( '' === $url || ! $this->isUsableSocialUrl($url) ) {
+                continue;
             }
 
             $label = trim($this->attr($anchor, 'aria-label'));
@@ -66,6 +66,10 @@ final class SocialLinksPattern implements PatternRecognizerInterface
                 'label' => $label,
                 ), static fn(string $value): bool => '' !== $value)
             ), array(), $sourceElement);
+        }
+
+        if ( array() === $links ) {
+            return null;
         }
 
         $attrs = $context->presentationAttributes($element);
@@ -131,8 +135,22 @@ final class SocialLinksPattern implements PatternRecognizerInterface
         return $anchors;
     }
 
+    private function isUsableSocialUrl(string $url): bool
+    {
+        if ( str_starts_with(strtolower($url), 'mailto:') ) {
+            return true;
+        }
+
+        $resolved = str_contains($url, '://') ? $url : (str_starts_with($url, '//') ? 'https:' . $url : 'https://' . $url);
+        return '' !== strtolower((string) parse_url($resolved, PHP_URL_HOST));
+    }
+
     private function service(string $url): ?string
     {
+        if ( str_starts_with(strtolower($url), 'mailto:') ) {
+            return 'mail';
+        }
+
         $host = strtolower((string) parse_url(str_contains($url, '://') ? $url : 'https://' . $url, PHP_URL_HOST));
         foreach ( self::HOST_SERVICES as $domain => $service ) {
             if ( $host === $domain || str_ends_with($host, '.' . $domain) ) {
@@ -155,8 +173,11 @@ final class SocialLinksPattern implements PatternRecognizerInterface
 
     private function hasIcon(DOMElement $anchor): bool
     {
-        return 0 < $anchor->getElementsByTagName('img')->length
-            || 0 < $anchor->getElementsByTagName('svg')->length;
+        if ( 0 < $anchor->getElementsByTagName('img')->length || 0 < $anchor->getElementsByTagName('svg')->length ) {
+            return true;
+        }
+
+        return '' === trim((string) $anchor->textContent) && 0 < $anchor->getElementsByTagName('span')->length;
     }
 
     /** @param array<int,DOMElement> $anchors */

--- a/php-transformer/src/HtmlToBlocks/Support/ElementConversionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/ElementConversionTrait.php
@@ -267,6 +267,11 @@ trait ElementConversionTrait
      */
     private function convertInlineContentElement(DOMElement $element, array &$fallbacks): ?array
     {
+        $socialLinks = $this->recognizePatterns($element, $fallbacks, array(SocialLinksPattern::class));
+        if ( null !== $socialLinks ) {
+            return $socialLinks;
+        }
+
         if ( $this->isRuntimeDomTarget($element) ) {
             return $this->htmlPreservationBlock($element);
         }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -563,6 +563,15 @@ $assert(str_contains($socialLinksCss, '.wp-block-social-links.blocks-engine-sour
 $assert(! str_contains($socialLinksMarkup, 'style="gap:') && ! str_contains($socialLinksMarkup, '<li ') && ! str_contains($socialLinksMarkup, '<a href='), 'social-link children preserve their dynamic empty-save contract inside the canonical social-links wrapper');
 $assert('pass' === ($socialLinksResult['source_reports']['wp_block_validity']['status'] ?? ''), 'dynamic social-link children and their static parent remain WordPress-valid');
 
+$spanSocialSource = '<span class="wsite-social wsite-social-default"><a class="wsite-social-item wsite-social-facebook" href="https://www.facebook.com/tasteandtravelitaly" aria-label="Facebook"><span class="wsite-social-item-inner"></span></a><a class="wsite-social-item wsite-social-twitter" href="//#" aria-label="Twitter"><span class="wsite-social-item-inner"></span></a><a class="wsite-social-item wsite-social-instagram" href="https://instagram.com/tasteandtravel_italy" aria-label="Instagram"><span class="wsite-social-item-inner"></span></a><a class="wsite-social-item wsite-social-mail" href="mailto:hello@example.com" aria-label="Mail"><span class="wsite-social-item-inner"></span></a></span>';
+$spanSocialResult = ( new HtmlTransformer() )->transform($spanSocialSource)->toArray();
+$spanSocialBlock = $spanSocialResult['blocks'][0] ?? array();
+$spanSocialServices = array_map(static fn(array $link): string => (string) ($link['attrs']['service'] ?? ''), $spanSocialBlock['innerBlocks'] ?? array());
+$assert('core/social-links' === ($spanSocialBlock['blockName'] ?? null), 'inline social clusters convert to core/social-links instead of empty mark hooks');
+$assert(array( 'facebook', 'instagram', 'mail' ) === $spanSocialServices, 'placeholder social hrefs are skipped and mailto maps to the mail service', json_encode($spanSocialServices));
+$assert(str_contains((string) ($spanSocialBlock['attrs']['className'] ?? ''), 'is-style-logos-only'), 'empty generated-content inners count as icon-only social presentation');
+$assert(! str_contains((string) ($spanSocialResult['serialized_blocks'] ?? ''), '<mark'), 'icon-font inner spans are not lowered to mark');
+
 $ordinaryFooterLinks = ( new HtmlTransformer() )->transform('<nav aria-label="Company"><a href="/about">About</a><a href="/contact">Contact</a></nav>')->toArray();
 $assert('core/navigation' === ($ordinaryFooterLinks['blocks'][0]['blockName'] ?? null), 'ordinary navigation does not become social links without profile-host or social-cluster semantics');
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/blocks-engine/issues/1284

Weebly header socials are `<span class="wsite-social">` rows of icon-font anchors with empty inner spans. SocialLinksPattern only ran on `ul`/`nav`/`div`, so those spans fell into RichText mark-lowering (`<mark class="wsite-social-item-inner">`) and the `::after` glyphs stopped painting.

This:

- Offers inline clusters to `SocialLinksPattern`
- Skips placeholder hrefs (`//#`) instead of failing the whole row
- Maps `mailto:` to the core `mail` service
- Treats empty generated-content inners as icon-only presentation

## Test
`php tests/contract/run.php` — new span-cluster case plus existing social-links coverage.

## AI assistance
Grok 4.6 through OpenCode compared Playwright computed styles of tasteandtravelitaly.com against the Studio import and implemented this fix.
