### PR TITLE
Give definite source-height covers a definite box

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -176,9 +176,6 @@ final class BlockFactory
         if ( 'core/cover' === $name && 'px' === ($attrs['minHeightUnit'] ?? null) ) {
             unset($attrs['minHeightUnit']);
         }
-        if ( 'core/cover' === $name ) {
-            unset($attrs['hasDefiniteHeight']);
-        }
         if ( 'core/media-text' === $name ) {
             if ( '' === ($attrs['mediaAlt'] ?? null) ) {
                 unset($attrs['mediaAlt']);
@@ -428,12 +425,12 @@ final class BlockFactory
         unset($wrapperAttrs['layout']);
         if ( ! empty($attrs['minHeight']) ) {
             $unit = '' !== (string) ($attrs['minHeightUnit'] ?? '') ? (string) $attrs['minHeightUnit'] : 'px';
-            $geometry = 'min-height:' . (string) $attrs['minHeight'] . $unit;
-            if ( ! empty($attrs['hasDefiniteHeight']) ) {
-                $geometry .= ';height:' . (string) $attrs['minHeight'] . $unit;
-            }
+            // Only the minHeight floor rides the inline style: cover's save()
+            // regenerates it from the minHeight attribute, so the stored
+            // markup round-trips. A definite source height is pinned through
+            // the generated geometry carrier instead (CoverPattern).
             $wrapperAttrs['inlineGeometryStyle'] = trim(
-                (string) ($wrapperAttrs['inlineGeometryStyle'] ?? '') . ';' . $geometry,
+                (string) ($wrapperAttrs['inlineGeometryStyle'] ?? '') . ';min-height:' . (string) $attrs['minHeight'] . $unit,
                 ';'
             );
         }

--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -176,6 +176,9 @@ final class BlockFactory
         if ( 'core/cover' === $name && 'px' === ($attrs['minHeightUnit'] ?? null) ) {
             unset($attrs['minHeightUnit']);
         }
+        if ( 'core/cover' === $name ) {
+            unset($attrs['hasDefiniteHeight']);
+        }
         if ( 'core/media-text' === $name ) {
             if ( '' === ($attrs['mediaAlt'] ?? null) ) {
                 unset($attrs['mediaAlt']);
@@ -425,8 +428,12 @@ final class BlockFactory
         unset($wrapperAttrs['layout']);
         if ( ! empty($attrs['minHeight']) ) {
             $unit = '' !== (string) ($attrs['minHeightUnit'] ?? '') ? (string) $attrs['minHeightUnit'] : 'px';
+            $geometry = 'min-height:' . (string) $attrs['minHeight'] . $unit;
+            if ( ! empty($attrs['hasDefiniteHeight']) ) {
+                $geometry .= ';height:' . (string) $attrs['minHeight'] . $unit;
+            }
             $wrapperAttrs['inlineGeometryStyle'] = trim(
-                (string) ($wrapperAttrs['inlineGeometryStyle'] ?? '') . ';min-height:' . (string) $attrs['minHeight'] . $unit,
+                (string) ($wrapperAttrs['inlineGeometryStyle'] ?? '') . ';' . $geometry,
                 ';'
             );
         }

--- a/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
@@ -164,6 +164,9 @@ final class CoverPattern implements PatternRecognizerInterface
             if ( null !== $minHeight ) {
                 $attrs['minHeight'] = $minHeight['minHeight'];
                 $attrs['minHeightUnit'] = $minHeight['minHeightUnit'];
+                if ( ! empty($minHeight['definite']) ) {
+                    $attrs['hasDefiniteHeight'] = true;
+                }
             }
         } catch ( Throwable ) {
             // Omit underivable height attributes.

--- a/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
@@ -116,7 +116,25 @@ final class CoverPattern implements PatternRecognizerInterface
             return null;
         }
 
-        $excludedProperties = array( 'background', 'background-image', 'background-size', 'background-position', 'background-repeat', 'min-height', 'height' );
+        $minHeight = null;
+        try {
+            $minHeight = $this->styleResolver->minHeightFromStyle($style);
+        } catch ( Throwable ) {
+            $minHeight = null;
+        }
+
+        // A definite source height (fixed `height`, no `min-height`) fixes the
+        // hero box: core sizes wp-block-cover__image-background to the wrapper
+        // and already clips overflow, so the cover must keep that fixed box or
+        // in-flow overlay content grows the hero past the source section and
+        // pushes the following sections down. The height rides the generated
+        // geometry carrier (className + authored stylesheet), the one channel
+        // core/cover's save() round-trips verbatim — an inline wrapper height
+        // would diverge from save() and flag the block for editor recovery.
+        $excludedProperties = array( 'background', 'background-image', 'background-size', 'background-position', 'background-repeat', 'min-height' );
+        if ( null === $minHeight || empty($minHeight['definite']) ) {
+            $excludedProperties[] = 'height';
+        }
         try {
             $attrs = $presentationAttributes($element, $excludedProperties);
         } catch ( Throwable ) {
@@ -159,17 +177,9 @@ final class CoverPattern implements PatternRecognizerInterface
         $this->promoteDesignGradient($attrs, $dim);
         $this->removeConsumedGradient($attrs);
 
-        try {
-            $minHeight = $this->styleResolver->minHeightFromStyle($style);
-            if ( null !== $minHeight ) {
-                $attrs['minHeight'] = $minHeight['minHeight'];
-                $attrs['minHeightUnit'] = $minHeight['minHeightUnit'];
-                if ( ! empty($minHeight['definite']) ) {
-                    $attrs['hasDefiniteHeight'] = true;
-                }
-            }
-        } catch ( Throwable ) {
-            // Omit underivable height attributes.
+        if ( null !== $minHeight ) {
+            $attrs['minHeight'] = $minHeight['minHeight'];
+            $attrs['minHeightUnit'] = $minHeight['minHeightUnit'];
         }
 
         try {

--- a/php-transformer/src/HtmlToBlocks/Patterns/CoverStyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CoverStyleResolver.php
@@ -161,6 +161,7 @@ final class CoverStyleResolver
         return array(
             'minHeight'     => $number,
             'minHeightUnit' => $matches[2],
+            'definite'      => ! array_key_exists('min-height', $declarations),
         );
     }
 

--- a/php-transformer/tests/unit/cover-pattern.php
+++ b/php-transformer/tests/unit/cover-pattern.php
@@ -284,6 +284,7 @@ $minHeightCover = $minHeightResult['blocks'][0] ?? array();
 $minHeightOpening = (string) ($minHeightCover['innerContent'][0] ?? '');
 $assertSame('core/cover', $minHeightCover['blockName'] ?? null, 'K3: Min-height hero remains core/cover.');
 $assertSame(1, substr_count($minHeightOpening, 'min-height'), 'K3: Min-height hero opening markup emits min-height once.');
+$assertTrue(! (bool) preg_match('/(?<!min-)height:480px/', $minHeightOpening), 'K3: Min-height hero does not emit a definite height.');
 $assertSame(480, $minHeightCover['attrs']['minHeight'] ?? null, 'K3: Min-height hero keeps numeric minHeight attr.');
 $assertTrue(! isset($minHeightCover['attrs']['style']['dimensions']['minHeight']), 'K3: Min-height hero removes duplicate style.dimensions.minHeight.');
 $assertTrue(! str_contains($assetCss($minHeightResult), 'min-height:480px'), 'K3: Min-height hero generates no carrier min-height rule.');
@@ -293,7 +294,7 @@ $heightCover = $heightResult['blocks'][0] ?? array();
 $heightOpening = (string) ($heightCover['innerContent'][0] ?? '');
 $assertSame('core/cover', $heightCover['blockName'] ?? null, 'K3: Height-fallback hero remains core/cover.');
 $assertSame(1, substr_count($heightOpening, 'min-height'), 'K3: Height-fallback hero opening markup emits min-height once.');
-$assertSame(1, substr_count($heightOpening, 'height:345.5px'), 'K3: Height-fallback source height survives only inside emitted min-height.');
+$assertTrue((bool) preg_match('/(?<!min-)height:345.5px/', $heightOpening), 'K3: Height-fallback source height also emits height so absolute cover media is contained.');
 $assertTrue(! isset($heightCover['attrs']['style']['dimensions']['minHeight']), 'K3: Height-fallback hero removes duplicate style.dimensions.minHeight.');
 $assertTrue(! str_contains($assetCss($heightResult), 'height:345.5px'), 'K3: Height-fallback hero generates no carrier height rule.');
 

--- a/php-transformer/tests/unit/cover-pattern.php
+++ b/php-transformer/tests/unit/cover-pattern.php
@@ -288,15 +288,27 @@ $assertTrue(! (bool) preg_match('/(?<!min-)height:480px/', $minHeightOpening), '
 $assertSame(480, $minHeightCover['attrs']['minHeight'] ?? null, 'K3: Min-height hero keeps numeric minHeight attr.');
 $assertTrue(! isset($minHeightCover['attrs']['style']['dimensions']['minHeight']), 'K3: Min-height hero removes duplicate style.dimensions.minHeight.');
 $assertTrue(! str_contains($assetCss($minHeightResult), 'min-height:480px'), 'K3: Min-height hero generates no carrier min-height rule.');
+$assertTrue(! str_contains($assetCss($minHeightResult), 'height:480px'), 'K3: Min-height hero generates no carrier height rule (floor semantics, no definite box).');
 
 $heightResult = $transformHtml('<section class="hero" style="background-image:url(https://example.com/hero.jpg);background-size:cover;height:345.5px"><h1>Build</h1><p>Ship</p></section>');
 $heightCover = $heightResult['blocks'][0] ?? array();
 $heightOpening = (string) ($heightCover['innerContent'][0] ?? '');
+$heightCss = $assetCss($heightResult);
+$heightCarrierClasses = array();
+preg_match_all('/be-inline-geometry-[a-f0-9-]+/', (string) ($heightCover['attrs']['className'] ?? ''), $heightCarrierClasses);
+$heightCarrierClasses = $heightCarrierClasses[0] ?? array();
 $assertSame('core/cover', $heightCover['blockName'] ?? null, 'K3: Height-fallback hero remains core/cover.');
 $assertSame(1, substr_count($heightOpening, 'min-height'), 'K3: Height-fallback hero opening markup emits min-height once.');
-$assertTrue((bool) preg_match('/(?<!min-)height:345.5px/', $heightOpening), 'K3: Height-fallback source height also emits height so absolute cover media is contained.');
+$assertTrue(! (bool) preg_match('/(?<!min-)height:345\.5px/', $heightOpening), 'K3: Height-fallback hero keeps the wrapper inline style save()-canonical (no inline height the editor would flag for recovery).');
 $assertTrue(! isset($heightCover['attrs']['style']['dimensions']['minHeight']), 'K3: Height-fallback hero removes duplicate style.dimensions.minHeight.');
-$assertTrue(! str_contains($assetCss($heightResult), 'height:345.5px'), 'K3: Height-fallback hero generates no carrier height rule.');
+$assertTrue($heightCarrierClasses !== array(), 'K3: Definite-height hero carries a generated geometry carrier class on the cover.');
+$heightCarrierHasHeight = false;
+foreach ( $heightCarrierClasses as $heightCarrierClass ) {
+    if ( str_contains($heightCss, '.' . $heightCarrierClass . '{height:345.5px !important}') ) {
+        $heightCarrierHasHeight = true;
+    }
+}
+$assertTrue($heightCarrierHasHeight, 'K3: Definite-height hero pins the cover box through a carrier height rule so absolute cover media stays contained and the next section starts at the hero bottom (#1285).');
 
 // K4: CSS-owned semantic flex heroes retain their source section and direct children.
 $columnsResult = $transformHtml('<section style="display:flex;background-image:url(https://example.com/h.jpg);background-size:cover"><div style="flex:1"><h1>Left</h1></div><div style="flex:1"><p>Right</p></div></section>');

--- a/php-transformer/tests/unit/cover-style-resolver.php
+++ b/php-transformer/tests/unit/cover-style-resolver.php
@@ -80,8 +80,8 @@ $assertSameArray(array( 'x' => 0.25, 'y' => 0.75 ), $resolver->focalPointFromSty
 $assertNull($resolver->focalPointFromStyle('background-position:center center'), 'Center is the default; omitted.');
 $assertNull($resolver->focalPointFromStyle('background-position:10px 20px'), 'Length positions are not derivable.');
 
-$assertSameArray(array( 'minHeight' => 480, 'minHeightUnit' => 'px' ), $resolver->minHeightFromStyle('min-height:480px'), 'px minHeight parses.');
-$assertSameArray(array( 'minHeight' => 80, 'minHeightUnit' => 'vh' ), $resolver->minHeightFromStyle('height:80vh'), 'height falls back when min-height absent.');
+$assertSameArray(array( 'minHeight' => 480, 'minHeightUnit' => 'px', 'definite' => false ), $resolver->minHeightFromStyle('min-height:480px'), 'px minHeight parses.');
+$assertSameArray(array( 'minHeight' => 80, 'minHeightUnit' => 'vh', 'definite' => true ), $resolver->minHeightFromStyle('height:80vh'), 'height falls back when min-height absent.');
 $assertNull($resolver->minHeightFromStyle('min-height:50%'), 'Percentage heights are not derivable.');
 
 $assertTrue($resolver->meetsHeroSizeGate('background:url(h.jpg) center/cover'), 'Shorthand size cover passes.');
@@ -123,7 +123,7 @@ $assertSameArray(
 
 // H4: A trailing !important does not alter parsed declaration values.
 $assertSameArray(
-    array( 'minHeight' => 480, 'minHeightUnit' => 'px' ),
+    array( 'minHeight' => 480, 'minHeightUnit' => 'px', 'definite' => false ),
     $resolver->minHeightFromStyle('min-height:480px !important'),
     'Important min-height values parse.'
 );
@@ -152,7 +152,7 @@ $assertSameArray(array( 'x' => 0.5, 'y' => 0.0 ), $resolver->focalPointFromStyle
 $assertSameArray(array( 'x' => 1.0, 'y' => 0.0 ), $resolver->focalPointFromStyle('background-position:top right'), 'Vertical-first keyword pairs map to axes.');
 
 // H8: Modern viewport units parse and use the viewport hero threshold.
-$assertSameArray(array( 'minHeight' => 100, 'minHeightUnit' => 'dvh' ), $resolver->minHeightFromStyle('min-height:100dvh'), 'dvh minHeight parses.');
+$assertSameArray(array( 'minHeight' => 100, 'minHeightUnit' => 'dvh', 'definite' => false ), $resolver->minHeightFromStyle('min-height:100dvh'), 'dvh minHeight parses.');
 $assertTrue($resolver->meetsHeroSizeGate('background-image:url(h.jpg);min-height:100dvh'), '100dvh passes the hero-size gate.');
 
 // Required change 9: Oversized scraped style strings are rejected without parsing.
@@ -178,7 +178,7 @@ $assertSameArray(
     'Modern rgba slash syntax maps to dimRatio and overlay color.'
 );
 $assertSameArray(
-    array( 'minHeight' => 480, 'minHeightUnit' => 'px' ),
+    array( 'minHeight' => 480, 'minHeightUnit' => 'px', 'definite' => false ),
     $resolver->minHeightFromStyle('min-height:480px ! important'),
     'Spaced important min-height values parse.'
 );


### PR DESCRIPTION
Fixes https://github.com/Automattic/blocks-engine/issues/1285

`core/cover` media is `position:absolute`. Source heroes that set `height: 592px` were stored as `minHeight` only. The cover box stayed `height: auto`, so the image painted at intrinsic size (~969px) and opened a duplicate-height gap under the overlay.

When the source used definite `height` (not `min-height`), the cover wrapper now also emits `height` so the absolute media is contained. `min-height`-only heroes are unchanged.

## Test
`php tests/unit/cover-pattern.php` — K3 now asserts definite height is emitted for `height:` sources and not for `min-height:` sources.

## AI assistance
Grok 4.6 through OpenCode compared Playwright screenshots/geometry of tasteandtravelitaly.com against the Studio import and implemented this fix.
