### PR TITLE
Keep absolute position on empty named fragment targets

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -125,6 +125,7 @@
       "php tests/unit/content-round-trip-reporter.php",
       "php tests/unit/content-round-trip-form-echo.php",
       "php tests/unit/form-associated-label-submit.php",
+      "php tests/unit/named-fragment-target-geometry.php",
       "php tests/unit/corpus-detectors.php",
       "php tests/unit/live-wp-parity-runner.php",
       "php tests/unit/deterministic-row-deduplicator.php",

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -166,6 +166,43 @@ trait StyleResolutionTrait
     }
 
     /**
+     * Positioning that makes an empty named anchor a scroll target rather than
+     * a zero-size in-flow box.
+     *
+     * @return list<string>
+     */
+    private function namedFragmentTargetProperties(): array
+    {
+        return array(
+            'position',
+            'top',
+            'right',
+            'bottom',
+            'left',
+            'inset',
+            'overflow',
+            'pointer-events',
+        );
+    }
+
+    /**
+     * An empty element whose inline style already places it for hash navigation.
+     */
+    private function isNamedFragmentTarget(DOMElement $element): bool
+    {
+        if ( '' === trim($this->attr($element, 'id')) ) {
+            return false;
+        }
+        if ( 0 < $this->directElementChildCount($element) || '' !== trim((string) $element->textContent) ) {
+            return false;
+        }
+
+        $position = strtolower(trim((string) ($this->cssDeclarations($this->attr($element, 'style'))['position'] ?? '')));
+
+        return in_array($position, array( 'absolute', 'fixed' ), true);
+    }
+
+    /**
      * @return list<string>
      */
     private function inlineBackgroundCarrierProperties(): array
@@ -420,6 +457,9 @@ trait StyleResolutionTrait
             : $this->cssDeclarations($this->attr($element, 'style'));
         $geometry = array();
         $properties = $this->inlineGeometryProperties();
+        if ( $this->isNamedFragmentTarget($element) ) {
+            $properties = array_merge($properties, $this->namedFragmentTargetProperties());
+        }
         if ( $this->inlineDisplayOverridesAuthorLayout($element, $declarations) ) {
             $inlineDisplay = strtolower(trim((string) preg_replace('/\s*!\s*important\s*$/i', '', (string) ($declarations['display'] ?? ''))));
             if ( ! in_array($inlineDisplay, array( 'flex', 'inline-flex' ), true) ) {
@@ -1029,7 +1069,11 @@ trait StyleResolutionTrait
         $declarations = $this->cssDeclarations($this->attr($element, 'style'));
         $style = array();
         $geometryValues = array();
-        foreach (array_values(array_unique(array_merge($this->inlineGeometryProperties(), $forcedProperties))) as $property) {
+        $properties = $this->inlineGeometryProperties();
+        if ( $this->isNamedFragmentTarget($element) ) {
+            $properties = array_merge($properties, $this->namedFragmentTargetProperties());
+        }
+        foreach (array_values(array_unique(array_merge($properties, $forcedProperties))) as $property) {
             if (in_array($property, $excludedProperties, true)) {
                 continue;
             }

--- a/php-transformer/tests/unit/named-fragment-target-geometry.php
+++ b/php-transformer/tests/unit/named-fragment-target-geometry.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Empty named fragment targets must keep their capture-time position so hash
+ * navigation can scroll (issue #1290).
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$failures = 0;
+$passes   = 0;
+$assert = static function (bool $condition, string $message, string $detail = '') use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ( '' !== $detail ? ' - ' . $detail : '' ) . PHP_EOL);
+};
+
+$transformer = new HtmlTransformer();
+$html = '<main>'
+    . '<span id="features" aria-hidden="true" style="position: absolute; top: 787px; left: 0px; width: 0px; height: 0px; overflow: hidden; pointer-events: none;"></span>'
+    . '<h2>Built for the Conscious Traveler</h2>'
+    . '<a href="#features">Features</a>'
+    . '</main>';
+$out = $transformer->transform($html)->toArray();
+$serialized = (string) ( $out['serialized_blocks'] ?? '' );
+$css = '';
+foreach ( $out['assets'] ?? array() as $asset ) {
+    if ( is_array($asset) && 'css' === ( $asset['kind'] ?? '' ) ) {
+        $css .= (string) ( $asset['content'] ?? '' );
+    }
+}
+if ( '' === $css ) {
+    foreach ( $out['source_reports'] ?? array() as $report ) {
+        if ( is_array($report) ) {
+            $css .= json_encode($report);
+        }
+    }
+}
+
+$assert(str_contains($serialized, 'id="features"'), '1: fragment id is preserved', $serialized);
+$assert(
+    str_contains($css, '787px') && ( str_contains($css, 'position:absolute') || str_contains($css, 'position: absolute') ),
+    '2: empty named target keeps absolute top',
+    $css !== '' ? substr($css, 0, 1500) : $serialized
+);
+
+$filled = $transformer->transform(
+    '<main><div id="card" style="position:absolute;top:40px;width:200px;height:80px"><p>Card</p></div></main>'
+)->toArray();
+$filledCss = '';
+foreach ( $filled['assets'] ?? array() as $asset ) {
+    if ( is_array($asset) && 'css' === ( $asset['kind'] ?? '' ) ) {
+        $filledCss .= (string) ( $asset['content'] ?? '' );
+    }
+}
+$assert(
+    str_contains((string) ( $filled['serialized_blocks'] ?? '' ), 'Card'),
+    '3: non-empty positioned content still converts',
+    (string) ( $filled['serialized_blocks'] ?? '' )
+);
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, PHP_EOL . "named fragment target tests: {$passes} passed, {$failures} FAILED" . PHP_EOL);
+    exit(1);
+}
+fwrite(STDOUT, "named fragment target tests: {$passes} passed" . PHP_EOL);


### PR DESCRIPTION
Closes #1290.

## Problem

In-page hash links do not scroll. Capture emits empty named anchors with the live positions (`position:absolute; top:787px`); conversion keeps the `id` and zero size, and drops `position`/`top`. The empty group sits in flow at y=0. Clicking Features on the Nimbus import leaves `scrollY` at 0.

`inlineGeometryProperties()` carried width/height, not positioning.

## Change

When an element is a named fragment target — it has an `id`, no content, and inline `position: absolute` or `fixed` — also carry `position`, inset, `overflow`, and `pointer-events` on the inline geometry carrier.

## Coverage

`tests/unit/named-fragment-target-geometry.php`. Fails on trunk (empty target loses `top:787px`); passes with this change. `composer test` exits 0.

## Out of scope

The header chrome is still wrong on this source: Contacts renders 7×88px (one letter per line), and the header is a tall in-flow block instead of a fixed overlay. Those are separate from hash targeting.

## AI assistance

Claude Sonnet 4.5 via OpenCode traced the empty DLA anchors through inline geometry, implemented the carrier, and ran verification. Chris Huber reviewed.
