### PR TITLE
Emit geometry-carrier height without !important

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -524,15 +524,19 @@ trait StyleResolutionTrait
         // specificity. The !important tier would additionally beat authored
         // non-important `:hover`/`:focus` rules and delete the interactive
         // states the source still wants.
+        // Background-image heroes pin a definite box through :root .carrier
+        // (0,2,0). Other height carriers still need !important to beat IDs.
+        if ( isset($geometry['height']) && preg_match('/\burl\s*\(/i', $inlineBackground) ) {
+            $overrideDeclarations['height'] = $geometry['height'];
+        }
         $overridePropertyLookup = array_fill_keys(array_keys($overrideDeclarations), true);
         foreach ($geometry as $property => $value) {
             if ( isset($inlineListMarkerPropertyLookup[$property])
                 || isset($overridePropertyLookup[$property])
                 || ( isset($inlineLayoutPropertyLookup[$property]) && ! isset($forcedPropertyLookup[$property]) )
-                || 'height' === $property
             ) {
-                // Preserve source inline layout, list markers, and height over a
-                // later plain author class without introducing !important.
+                // Preserve source inline layout and list markers over a later
+                // plain author class without introducing !important.
                 $normalPriorityDeclarations[] = $property . ':' . $value;
                 continue;
             }

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -529,9 +529,10 @@ trait StyleResolutionTrait
             if ( isset($inlineListMarkerPropertyLookup[$property])
                 || isset($overridePropertyLookup[$property])
                 || ( isset($inlineLayoutPropertyLookup[$property]) && ! isset($forcedPropertyLookup[$property]) )
+                || 'height' === $property
             ) {
-                // Preserve source inline layout and list markers over a later
-                // plain author class without introducing !important.
+                // Preserve source inline layout, list markers, and height over a
+                // later plain author class without introducing !important.
                 $normalPriorityDeclarations[] = $property . ':' . $value;
                 continue;
             }

--- a/php-transformer/tests/unit/cover-pattern.php
+++ b/php-transformer/tests/unit/cover-pattern.php
@@ -304,11 +304,12 @@ $assertTrue(! isset($heightCover['attrs']['style']['dimensions']['minHeight']), 
 $assertTrue($heightCarrierClasses !== array(), 'K3: Definite-height hero carries a generated geometry carrier class on the cover.');
 $heightCarrierHasHeight = false;
 foreach ( $heightCarrierClasses as $heightCarrierClass ) {
-    if ( str_contains($heightCss, '.' . $heightCarrierClass . '{height:345.5px !important}') ) {
+    if ( str_contains($heightCss, ':root .' . $heightCarrierClass . '{height:345.5px}')
+        && ! str_contains($heightCss, '.' . $heightCarrierClass . '{height:345.5px !important}') ) {
         $heightCarrierHasHeight = true;
     }
 }
-$assertTrue($heightCarrierHasHeight, 'K3: Definite-height hero pins the cover box through a carrier height rule so absolute cover media stays contained and the next section starts at the hero bottom (#1285).');
+$assertTrue($heightCarrierHasHeight, 'K3: Definite-height hero pins the cover box through a :root carrier height rule without !important.');
 
 // K4: CSS-owned semantic flex heroes retain their source section and direct children.
 $columnsResult = $transformHtml('<section style="display:flex;background-image:url(https://example.com/h.jpg);background-size:cover"><div style="flex:1"><h1>Left</h1></div><div style="flex:1"><p>Right</p></div></section>');


### PR DESCRIPTION
Fixes https://github.com/Automattic/blocks-engine/issues/1294

Follow-up to #1289. Geometry-carrier `height` now uses the existing non-important `:root .carrier` tier (0,2,0) instead of `!important`.

## Test
`php tests/unit/cover-pattern.php`

## AI assistance
Grok 4.6 through OpenCode inspected the imported cover CSS (`height:592px !important` that still computed to 969px) and implemented this fix.
