### PR TITLE
Keep keyword widths off the core/buttons wrapper

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -126,6 +126,7 @@
       "php tests/unit/content-round-trip-form-echo.php",
       "php tests/unit/form-associated-label-submit.php",
       "php tests/unit/named-fragment-target-geometry.php",
+      "php tests/unit/button-wrapper-keyword-width.php",
       "php tests/unit/corpus-detectors.php",
       "php tests/unit/live-wp-parity-runner.php",
       "php tests/unit/deterministic-row-deduplicator.php",

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2118,8 +2118,12 @@ final class HtmlTransformer
         $geometry = array();
         $inner = array();
         foreach ( CssValueSplitter::splitTopLevel($body, array( ';' )) as $declaration ) {
-            $name = strtolower(trim(strtok($declaration, ':')));
-            if ( '' !== $name && str_contains($declaration, ':') && in_array($name, array( 'position', 'top', 'right', 'bottom', 'left', 'z-index', 'width', 'min-width', 'max-width', 'height', 'min-height', 'max-height' ), true) ) {
+            $colon = strpos($declaration, ':');
+            $name = strtolower(trim(false === $colon ? $declaration : substr($declaration, 0, $colon)));
+            $value = false === $colon ? '' : trim(substr($declaration, $colon + 1));
+            if ( '' !== $name && false !== $colon && in_array($name, array( 'position', 'top', 'right', 'bottom', 'left', 'z-index', 'width', 'min-width', 'max-width', 'height', 'min-height', 'max-height' ), true)
+                && ! $this->isButtonControlBoxSize($name, $value)
+            ) {
                 $geometry[] = $declaration;
             } else {
                 $inner[] = $declaration;
@@ -2144,12 +2148,14 @@ final class HtmlTransformer
         $layout = array();
         $control = array();
         foreach ( CssValueSplitter::splitTopLevel($body, array( ';' )) as $declaration ) {
-            $name = strtolower(trim(strtok($declaration, ':')));
-            if ( '' === $name || ! str_contains($declaration, ':') ) {
+            $colon = strpos($declaration, ':');
+            $name = strtolower(trim(false === $colon ? $declaration : substr($declaration, 0, $colon)));
+            $value = false === $colon ? '' : trim(substr($declaration, $colon + 1));
+            if ( '' === $name || false === $colon ) {
                 $control[] = $declaration;
                 continue;
             }
-            if ( $this->isButtonWrapperLayoutProperty($name) ) {
+            if ( $this->isButtonWrapperLayoutProperty($name) && ! $this->isButtonControlBoxSize($name, $value) ) {
                 $layout[] = $declaration;
             } else {
                 $control[] = $declaration;
@@ -2157,6 +2163,21 @@ final class HtmlTransformer
         }
 
         return array( implode(';', $layout), implode(';', $control) );
+    }
+
+    /**
+     * Keyword sizes describe the control's box. On `.wp-block-buttons` they
+     * shrink-wrap the flex wrapper and override a definite source width.
+     */
+    private function isButtonControlBoxSize(string $property, string $value): bool
+    {
+        if ( ! in_array($property, array( 'width', 'min-width', 'max-width', 'height', 'min-height', 'max-height' ), true) ) {
+            return false;
+        }
+
+        $value = strtolower(trim((string) preg_replace('/\s*!\s*important\s*$/i', '', $value)));
+
+        return in_array($value, array( 'min-content', 'max-content', 'fit-content', 'content' ), true);
     }
 
     private function isButtonWrapperLayoutProperty(string $property): bool

--- a/php-transformer/tests/unit/button-wrapper-keyword-width.php
+++ b/php-transformer/tests/unit/button-wrapper-keyword-width.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Keyword widths must not land on `.wp-block-buttons` and override a definite
+ * source width (issue #1299).
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$failures = 0;
+$passes   = 0;
+$assert = static function (bool $condition, string $message, string $detail = '') use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ( '' !== $detail ? ' - ' . $detail : '' ) . PHP_EOL);
+};
+
+$out = ( new HtmlTransformer() )->transform(
+    '<style>.cta{width:7.82%;margin-left:89%}.cta{width:min-content}</style>'
+    . '<main><button class="cta" type="button">Contacts</button></main>'
+)->toArray();
+$css = '';
+foreach ( $out['assets'] ?? array() as $asset ) {
+    if ( is_array($asset) && 'css' === ( $asset['kind'] ?? '' ) ) {
+        $css .= (string) ( $asset['content'] ?? '' );
+    }
+}
+
+$assert(str_contains((string) ( $out['serialized_blocks'] ?? '' ), 'wp:buttons'), '1: source button becomes core/buttons', (string) ( $out['serialized_blocks'] ?? '' ));
+$assert(
+    str_contains($css, '7.82%') && (bool) preg_match('/wp-block-buttons[^{]*\{[^}]*7\.82%/', $css),
+    '2: definite source width stays on the buttons wrapper',
+    $css
+);
+$assert(
+    ! preg_match('/wp-block-buttons[^{]*\{[^}]*min-content/', $css),
+    '3: min-content does not shrink-wrap the buttons wrapper',
+    $css
+);
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, PHP_EOL . "button wrapper keyword width tests: {$passes} passed, {$failures} FAILED" . PHP_EOL);
+    exit(1);
+}
+fwrite(STDOUT, "button wrapper keyword width tests: {$passes} passed" . PHP_EOL);


### PR DESCRIPTION
Closes #1299.

## Problem

Header Contacts on Nimbus renders 7.2×88px (one letter per line). Source is 113×47.

Author CSS has both `width: 7.82%` (113px at 1440) and `width: min-content`. Both were classified as wrapper layout and applied to `.wp-block-buttons`. `min-content` shrink-wraps the Gutenberg flex wrapper; the inner link wraps character-by-character.

## Change

Definite widths stay on `.wp-block-buttons`. Keyword sizes (`min-content`, `max-content`, `fit-content`, `content`) go to the inner control.

## Coverage

`tests/unit/button-wrapper-keyword-width.php`. Fails on trunk (`width:min-content` on `.wp-block-buttons`); passes with this change. `composer test` exits 0.

Hash navigation from #1291 is verified on a re-import (Features click → `scrollY` 787). Header chrome height/background remains a separate issue.

## AI assistance

Claude Sonnet 4.5 via OpenCode measured the imported Contacts control, traced author CSS split onto `.wp-block-buttons`, and implemented the splitter. Chris Huber reviewed.