### PR TITLE
Default icon-font social clusters to compact core size

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/SocialLinksPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/SocialLinksPattern.php
@@ -78,10 +78,7 @@ final class SocialLinksPattern implements PatternRecognizerInterface
         }
         if ( $iconOnly ) {
             $attrs['className'] = trim((string) ($attrs['className'] ?? '') . ' is-style-logos-only');
-            $size = $this->iconSize($anchors);
-            if ( null !== $size ) {
-                $attrs['size'] = $size;
-            }
+            $attrs['size'] = $this->iconSize($anchors) ?? 'small';
         }
         if ( $structuralItems ) {
             $attrs['className'] = trim((string) ($attrs['className'] ?? '') . ' blocks-engine-source-social-item-spacing');

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -572,6 +572,7 @@ $spanSocialServices = array_map(static fn(array $link): string => (string) ($lin
 $assert('core/social-links' === ($spanSocialBlock['blockName'] ?? null), 'inline social clusters convert to core/social-links instead of empty mark hooks');
 $assert(array( 'facebook', 'instagram', 'mail' ) === $spanSocialServices, 'placeholder social hrefs are skipped and mailto maps to the mail service', json_encode($spanSocialServices));
 $assert(str_contains((string) ($spanSocialBlock['attrs']['className'] ?? ''), 'is-style-logos-only'), 'empty generated-content inners count as icon-only social presentation');
+$assert('small' === ($spanSocialBlock['attrs']['size'] ?? null), 'icon-font social clusters default to compact core size when source icons are not measured bitmaps');
 $assert(! str_contains((string) ($spanSocialResult['serialized_blocks'] ?? ''), '<mark'), 'icon-font inner spans are not lowered to mark');
 
 $ordinaryFooterLinks = ( new HtmlTransformer() )->transform('<nav aria-label="Company"><a href="/about">About</a><a href="/contact">Contact</a></nav>')->toArray();


### PR DESCRIPTION
Fixes https://github.com/Automattic/blocks-engine/issues/1301

Icon-font social rows become `is-style-logos-only` with no `size` when source icons are empty spans. Gutenberg then paints large defaults. Icon-only clusters without measured SVG/img dimensions now default to `small`.

Measured SVG clusters (22px → `normal`) are unchanged.

## Test
`php tests/contract/run.php` — span social cluster asserts `size: small`.

## AI assistance
Grok 4.6 through OpenCode inspected the tasteandtravelitaly footer socials and implemented this fix.
