### PR TITLE
Fill inner core/button when the wrapper has a definite width

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -127,6 +127,7 @@
       "php tests/unit/form-associated-label-submit.php",
       "php tests/unit/named-fragment-target-geometry.php",
       "php tests/unit/button-wrapper-keyword-width.php",
+      "php tests/unit/button-wrapper-inner-fill.php",
       "php tests/unit/corpus-detectors.php",
       "php tests/unit/live-wp-parity-runner.php",
       "php tests/unit/deterministic-row-deduplicator.php",

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2033,7 +2033,7 @@ final class HtmlTransformer
             if ( '' === $directWrapperPrelude || '' === $geometry ) {
                 return $projectedPrelude . '{' . $body . '}';
             }
-            return $directWrapperPrelude . '{' . $geometry . '}' . ('' === $inner ? '' : $projectedPrelude . '{' . $inner . '}');
+            return $this->withButtonWrapperInnerFill($directWrapperPrelude, $geometry, '' === $inner ? '' : $projectedPrelude . '{' . $inner . '}');
         }
 
         [ $layout, $control ] = $this->splitButtonPresentationDeclarations($body);
@@ -2041,10 +2041,10 @@ final class HtmlTransformer
             return $projectedPrelude . '{' . $body . '}';
         }
         if ( '' === $control ) {
-            return $wrapperPrelude . '{' . $body . '}';
+            return $this->withButtonWrapperInnerFill($wrapperPrelude, $body);
         }
 
-        return $wrapperPrelude . '{' . $layout . '}' . $projectedPrelude . '{' . $control . '}';
+        return $this->withButtonWrapperInnerFill($wrapperPrelude, $layout, $projectedPrelude . '{' . $control . '}');
     }
 
     private function buttonPresentationWrapperPrelude(string $prelude): string
@@ -2166,6 +2166,44 @@ final class HtmlTransformer
         }
 
         return array( implode(';', $layout), implode(';', $control) );
+    }
+
+    /**
+     * When the buttons wrapper carries a definite width, the inner Gutenberg
+     * button and link must fill it. Otherwise they shrink-wrap and wrap text
+     * into a one-character column.
+     */
+    private function withButtonWrapperInnerFill(string $wrapperPrelude, string $layoutCss, string $rest = ''): string
+    {
+        $css = $wrapperPrelude . '{' . $layoutCss . '}';
+        if ( $this->cssHasDefiniteWidth($layoutCss) ) {
+            $css .= $wrapperPrelude . '> :where(.wp-block-button){width:100%!important;box-sizing:border-box}'
+                . $wrapperPrelude . '> :where(.wp-block-button)> :where(.wp-block-button__link){width:100%!important;max-width:100%!important;box-sizing:border-box}';
+        }
+
+        return $css . $rest;
+    }
+
+    private function cssHasDefiniteWidth(string $css): bool
+    {
+        foreach ( CssValueSplitter::splitTopLevel($css, array( ';' )) as $declaration ) {
+            $colon = strpos($declaration, ':');
+            if ( false === $colon ) {
+                continue;
+            }
+            $name = strtolower(trim(substr($declaration, 0, $colon)));
+            if ( 'width' !== $name && 'min-width' !== $name ) {
+                continue;
+            }
+            $value = strtolower(trim((string) preg_replace('/\s*!\s*important\s*$/i', '', trim(substr($declaration, $colon + 1)))));
+            if ( '' === $value || in_array($value, array( 'auto', 'inherit', 'initial', 'unset', 'none', 'min-content', 'max-content', 'fit-content', 'content' ), true) ) {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/php-transformer/tests/unit/button-wrapper-inner-fill.php
+++ b/php-transformer/tests/unit/button-wrapper-inner-fill.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * A definite width on `.wp-block-buttons` must fill the inner link (issue #1303).
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$failures = 0;
+$passes   = 0;
+$assert = static function (bool $condition, string $message, string $detail = '') use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ( '' !== $detail ? ' - ' . $detail : '' ) . PHP_EOL);
+};
+
+$out = ( new HtmlTransformer() )->transform(
+    '<style>.cta{width:7.82%;margin-left:89%}.cta{width:min-content}</style>'
+    . '<main><button class="cta" type="button">Contacts</button></main>'
+)->toArray();
+$css = '';
+foreach ( $out['assets'] ?? array() as $asset ) {
+    if ( is_array($asset) && 'css' === ( $asset['kind'] ?? '' ) ) {
+        $css .= (string) ( $asset['content'] ?? '' );
+    }
+}
+
+$assert(
+    (bool) preg_match('/wp-block-buttons[^{]*\{[^}]*7\.82%/', $css),
+    '1: wrapper keeps the definite source width',
+    $css
+);
+$assert(
+    str_contains($css, 'wp-block-button__link){width:100%!important'),
+    '2: inner link fills the sized wrapper',
+    $css
+);
+$assert(
+    ! preg_match('/wp-block-buttons[^{]*\{[^}]*min-content/', $css),
+    '3: min-content still stays off the wrapper',
+    $css
+);
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, PHP_EOL . "button wrapper inner fill tests: {$passes} passed, {$failures} FAILED" . PHP_EOL);
+    exit(1);
+}
+fwrite(STDOUT, "button wrapper inner fill tests: {$passes} passed" . PHP_EOL);

--- a/php-transformer/tests/unit/engine-support-css-asset.php
+++ b/php-transformer/tests/unit/engine-support-css-asset.php
@@ -54,7 +54,7 @@ $authorAssets = $sourceAssets($authorOrder, 'author-css');
 $assert(1 === count($authorAssets), 'G2: transform emits exactly one author-css asset');
 $normalizedAuthorCss = preg_replace('/\s+/', '', (string) ($authorAssets[0]['content'] ?? '')) ?? '';
 $assert(
-    '@layercontract;.contract-author-only{color:#123456}.desktop-nava{color:#fff}:where(.blocks-engine-control-6494fb2a0d77-3):where(.wp-block-buttons){width:100%}:where(.blocks-engine-control-6494fb2a0d77-3):not(.blocks-engine-specificity-class-6494fb2a0d77-1)>:where(.wp-block-button__link){display:inline-flex;padding:1rem;background:#123456}@media(max-width:700px){.desktop-nav{display:none}.mobile-nav{background:rgba(0,0,0,.9)}}' === $normalizedAuthorCss,
+    '@layercontract;.contract-author-only{color:#123456}.desktop-nava{color:#fff}:where(.blocks-engine-control-6494fb2a0d77-3):where(.wp-block-buttons){width:100%}:where(.blocks-engine-control-6494fb2a0d77-3):where(.wp-block-buttons)>:where(.wp-block-button){width:100%!important;box-sizing:border-box}:where(.blocks-engine-control-6494fb2a0d77-3):where(.wp-block-buttons)>:where(.wp-block-button)>:where(.wp-block-button__link){width:100%!important;max-width:100%!important;box-sizing:border-box}:where(.blocks-engine-control-6494fb2a0d77-3):not(.blocks-engine-specificity-class-6494fb2a0d77-1)>:where(.wp-block-button__link){display:inline-flex;padding:1rem;background:#123456}@media(max-width:700px){.desktop-nav{display:none}.mobile-nav{background:rgba(0,0,0,.9)}}' === $normalizedAuthorCss,
     'G2: author-css contains only its leading at-rule preamble and rewritten author stylesheet'
 );
 $assert('author' === ($authorAssets[0]['stylesheet_placement'] ?? ''), 'G4: author-css record declares author placement');


### PR DESCRIPTION
Closes #1303.

## Problem

After #1300, Nimbus Contacts `.wp-block-buttons` is correctly 112.6px at x=1283. The inner `.wp-block-button` / `__link` stay 7.2×88px, so it still reads as a vertical stack of letters.

Author CSS sizes the wrapper. Gutenberg's inner link does not fill it. `display:flex` plus a cyclic inner size collapses the text.

## Change

When wrapper layout includes a definite width, also emit:

```css
.wrapper > .wp-block-button { width: 100% !important; }
.wrapper > .wp-block-button > .wp-block-button__link { width: 100% !important; }
```

`!important` is required so this wins over a later `width: min-content` on the link (`:not(.specificity-class)` has higher specificity than `:where()`). Same pattern as existing `buttonWidthStyleRule()`.

## Coverage

`tests/unit/button-wrapper-inner-fill.php` fails on trunk, passes here. Engine-support CSS contract updated for the extra fill rules. `composer test` exits 0.

## AI assistance

Claude Sonnet 4.5 via OpenCode measured the v7 import after #1300, traced the inner 7px link, and implemented the fill. Chris Huber reviewed.