### PR TITLE
Coalesce redundant nested flex/grid wrappers

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -4982,6 +4982,12 @@ if ( 'svg' === $tagName ) {
     private function authorLayoutBlockFromElement(DOMElement $element, array &$fallbacks): array
     {
         $children = $this->convertChildren($element, $fallbacks, true);
+        if ( 1 === count($children) ) {
+            $coalesced = $this->coalescedSingleGroupWrapper($element, $children[0]);
+            if ( null !== $coalesced ) {
+                return $coalesced;
+            }
+        }
         if ( $this->isAuthorOwnedLayout($element) ) {
             $this->transformationEvidence()->recordAuthorLayoutTopology(
                 $this->elementSelector($element),
@@ -6185,6 +6191,7 @@ if ( 'svg' === $tagName ) {
     {
         $proof = $this->layoutGeometryProofFor($element);
         $fullWidthTransparentShell = $this->hasOnlyFullWidthTransparentInlineGeometry($element);
+        $redundantNestedLayout = $this->isRedundantNestedLayoutWrapper($element, $childBlock);
         if ( 'div' !== strtolower($element->tagName)
             || ! in_array($childBlock['blockName'] ?? null, array('core/group', 'core/image'), true)
             || ($fullWidthTransparentShell && 'core/group' !== ($childBlock['blockName'] ?? null))
@@ -6192,17 +6199,17 @@ if ( 'svg' === $tagName ) {
             || (null === $proof && $this->isDirectChildOfStructuralLayout($element))
             || '' !== trim($this->attr($element, 'id'))
             || '' !== trim($this->attr($element, 'role'))
-            || (null === $proof && ! $fullWidthTransparentShell && ! $this->hasOnlyRenderNeutralInlineGeometry($element))
+            || (null === $proof && ! $fullWidthTransparentShell && ! $this->hasOnlyRenderNeutralInlineGeometry($element) && ! $redundantNestedLayout)
             || array() !== $this->interactiveAttributes($element)
             || (null === $proof && array() !== $this->safeDataAttributes($element))
-            || (null === $proof && array() !== $this->structureSignals($element, array()))
+            || (null === $proof && array() !== $this->structureSignals($element, array()) && ! $redundantNestedLayout)
             || $this->hasMotionStructureToken($element)
         ) {
             return null;
         }
 
         $attrs = $this->presentationAttributes($element);
-        if ( array_diff(array_keys($attrs), array( 'className', 'style' )) ) {
+        if ( ! $redundantNestedLayout && array_diff(array_keys($attrs), array( 'className', 'style' )) ) {
             return null;
         }
 
@@ -6212,9 +6219,9 @@ if ( 'svg' === $tagName ) {
         if ( ! $sourceChild instanceof DOMElement
             || ('core/image' === ($childBlock['blockName'] ?? null) && ! in_array(strtolower($sourceChild->tagName), array( 'img', 'svg' ), true) && ! str_contains($sourceChild->tagName, '-'))
             || $this->hasMotionStructureToken($sourceChild)
-            || (null === $proof && ($fullWidthTransparentShell ? ! $this->hasOnlyFullWidthTransparentBoxAffectingDeclarations($element) : ! $this->hasOnlyRenderNeutralBoxAffectingDeclarations($element)))
+            || (null === $proof && ! $redundantNestedLayout && ($fullWidthTransparentShell ? ! $this->hasOnlyFullWidthTransparentBoxAffectingDeclarations($element) : ! $this->hasOnlyRenderNeutralBoxAffectingDeclarations($element)))
             || (null === $proof && $fullWidthTransparentShell && ! $this->isNormalFlowFullWidthShellChild($sourceChild))
-            || ('core/image' !== ($childBlock['blockName'] ?? null) && $this->hasContainingBlockDependentAuthorDeclarations($sourceChild))
+            || ('core/image' !== ($childBlock['blockName'] ?? null) && ! $redundantNestedLayout && $this->hasContainingBlockDependentAuthorDeclarations($sourceChild))
             || (null === $proof && ! $this->syntheticImageGeometryLeaf($childBlock) && ! $this->selectorMatchingSurvivesWrapperCoalescing($element, $sourceChild, $fullWidthTransparentShell))
         ) {
             return null;
@@ -6436,6 +6443,47 @@ if ( 'svg' === $tagName ) {
             return false;
         }
         return 1 === preg_match('/^(?:align-|appearance|aspect-ratio|background|border|bottom|box-shadow|column|contain|cursor|display|filter|flex|gap|grid|height|inset|isolation|left|margin|max-|min-|opacity|outline|overflow|padding|perspective|position|right|row-gap|table-layout|top|transform|vertical-align|width|z-index)/', $property);
+    }
+
+    /**
+     * A sole nested flex/grid wrapper is redundant when it only restates display
+     * and the child group already carries its own geometry carrier.
+     *
+     * @param array<string, mixed> $childBlock
+     */
+    private function isRedundantNestedLayoutWrapper(DOMElement $element, array $childBlock): bool
+    {
+        if ( 'core/group' !== ($childBlock['blockName'] ?? null) ) {
+            return false;
+        }
+
+        $childClass = (string) ($childBlock['attrs']['className'] ?? '');
+        if ( ! str_contains($childClass, 'blocks-engine-css-owned-layout')
+            || ! (bool) preg_match('/(?:^|\s)be-inline-geometry-[a-f0-9-]+(?:\s|$)/', $childClass)
+        ) {
+            return false;
+        }
+
+        if ( '' !== trim($this->attr($element, 'class')) ) {
+            return false;
+        }
+
+        $declarations = $this->cssDeclarations($this->attr($element, 'style'));
+        $display = strtolower(trim($this->cssValueWithoutImportant((string) ($declarations['display'] ?? ''))));
+        if ( ! in_array($display, array( 'flex', 'inline-flex', 'grid', 'inline-grid' ), true) ) {
+            return false;
+        }
+
+        unset($declarations['display']);
+        foreach ( $declarations as $property => $value ) {
+            if ( ! $this->isRenderNeutralGeometryDeclaration($property, $value) ) {
+                return false;
+            }
+        }
+
+        return $this->hasOnlyRenderNeutralBoxAffectingDeclarationMap(
+            array_diff_key($this->matchingAuthorDeclarations($element), array( 'display' => true ))
+        );
     }
 
     private function hasOnlyRenderNeutralInlineGeometry(DOMElement $element): bool

--- a/php-transformer/tests/unit/author-selector-semantics.php
+++ b/php-transformer/tests/unit/author-selector-semantics.php
@@ -597,7 +597,17 @@ $commentAnnotatedGroupChainMarkup = (string) ($commentAnnotatedGroupChain['seria
 $assert(1 === substr_count($commentAnnotatedGroupChainMarkup, '<!-- wp:group') && str_contains($commentAnnotatedGroupChainMarkup, 'outer content'), 'comment-annotated neutral Group wrappers coalesce because comments are semantically transparent');
 
 $sameSourceGroupChainSelectorEdge = $transform('<style>.outer > .middle{color:red}</style><div class="outer"><div class="middle"><div class="content"><p>Copy</p></div></div></div>');
-$assert(2 === substr_count((string) ($sameSourceGroupChainSelectorEdge['serialized_blocks'] ?? ''), '<!-- wp:group'), 'same-source Group chains retain the outer boundary when an author selector matches a removed chain node');
+	$assert(2 === substr_count((string) ($sameSourceGroupChainSelectorEdge['serialized_blocks'] ?? ''), '<!-- wp:group'), 'same-source Group chains retain the outer boundary when an author selector matches a removed chain node');
+
+$nestedFlex = $transform('<div style="display:flex"><div style="display:flex"><p>A</p><p>B</p></div></div>');
+$nestedFlexMarkup = (string) ($nestedFlex['serialized_blocks'] ?? '');
+$assert(1 === substr_count($nestedFlexMarkup, '<!-- wp:group') && str_contains($nestedFlexMarkup, 'blocks-engine-css-owned-layout'), 'redundant nested flex wrappers coalesce to the child geometry group');
+
+$flexItemGroup = $transform('<div style="display:flex"><div><p>A</p><p>B</p></div></div>');
+$assert(2 === substr_count((string) ($flexItemGroup['serialized_blocks'] ?? ''), '<!-- wp:group'), 'a flex item Group around stacked content is not coalesced into the flex container');
+
+$namedFlex = $transform('<style>.shell{display:flex}</style><div class="shell"><div style="display:flex"><p>A</p><p>B</p></div></div>');
+$assert(2 === substr_count((string) ($namedFlex['serialized_blocks'] ?? ''), '<!-- wp:group') && str_contains((string) ($namedFlex['serialized_blocks'] ?? ''), 'shell'), 'author-named flex shells remain distinct from nested layout wrappers');
 
 if ( $failures > 0 ) {
     fwrite(STDERR, "Author selector semantics unit tests: {$failures} failed, {$passes} passed\n");


### PR DESCRIPTION
Fixes https://github.com/Automattic/blocks-engine/issues/905

Next conservative same-source Group reduction: a wrapper whose only non-neutral geometry is `display:flex`/`grid`, with no author class, and whose sole child is already a css-owned geometry group, is redundant.

Author-owned layout used to skip coalescing entirely. It now tries `coalescedSingleGroupWrapper` for a single child.

Preserved:
- Flex-item Groups around stacked content (`[flex [group [p][p]]]`)
- Author-named flex shells (`.shell`)

## Test
`php tests/unit/author-selector-semantics.php` (99 passed) and `php tests/contract/run.php`

## AI assistance
Grok 4.6 through OpenCode diagnosed leftover engine-only Group chains on the tasteandtravelitaly import and implemented this slice of #905.
