### PR TITLE
Extract text-leaf element conversion out of convertElement (#242)

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -141,7 +141,8 @@
       "php tests/unit/geometry-chain-coalescing.php",
       "php tests/unit/pattern-recursive-converter.php",
       "php tests/unit/pattern-recognizer-registry.php",
-      "php tests/unit/pattern-registry-staged-dispatch.php"
+      "php tests/unit/pattern-registry-staged-dispatch.php",
+            "php tests/unit/text-leaf-element-converter.php"
     ],
     "test:parity": "php tests/parity/run.php",
     "test:migration:examples": "php tests/migration/examples.php",

--- a/php-transformer/src/HtmlToBlocks/Elements/ConversionOutcome.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/ConversionOutcome.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+/**
+ * Result of an element converter.
+ *
+ * The transformer's dispatch chain uses `null` for two different outcomes:
+ * "this element intentionally produces no block" (`br`, suppressed controls)
+ * and "this branch did not apply, keep dispatching". Collapsing both into a
+ * bare `?array` return is what forces converters to stay inline in the chain.
+ * This type keeps them distinct so a converter can be consulted and then
+ * skipped without changing behavior.
+ */
+final class ConversionOutcome
+{
+    /**
+     * @param array<string, mixed>|null $block
+     */
+    private function __construct(
+        public readonly bool $handled,
+        public readonly ?array $block
+    ) {
+    }
+
+    /**
+     * The converter owned this element. `$block` may still be null when the
+     * element intentionally converts to nothing.
+     *
+     * @param array<string, mixed>|null $block
+     */
+    public static function handled(?array $block): self
+    {
+        return new self(true, $block);
+    }
+
+    /**
+     * The converter did not own this element; dispatch continues.
+     */
+    public static function unhandled(): self
+    {
+        return new self(false, null);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Elements/TextLeafElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/TextLeafElementContext.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Closure;
+use DOMElement;
+
+/**
+ * Explicit collaborator surface for {@see TextLeafElementConverter}.
+ *
+ * Mirrors {@see \Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext}:
+ * the transformer hands over exactly the operations a converter needs, so the
+ * converter has no `$this` access to transformer state and its inputs are
+ * enumerable at the call site.
+ */
+final class TextLeafElementContext
+{
+    /**
+     * @param Closure(DOMElement, array<int, string>, array<int, string>): array<string, mixed> $presentationAttributes
+     * @param Closure(DOMElement): string                                                      $innerHtml
+     * @param Closure(DOMElement): string                                                      $innerHtmlPreservingWhitespace
+     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
+     * @param Closure(DOMElement, array<int, string>): string                                  $richTextContent
+     * @param Closure(string): string                                                          $stripAllTags
+     * @param Closure(string): string                                                          $escapeHtml
+     * @param Closure(DOMElement, string): ?DOMElement                                         $firstChildElement
+     * @param Closure(DOMElement, DOMElement): array<string, mixed>                            $codePresentationAttributes
+     * @param Closure(DOMElement): string                                                      $codeContent
+     * @param Closure(DOMElement): bool                                                        $hasBlockContentChildren
+     * @param Closure(DOMElement, array<int, array<string, mixed>>, bool): array<int, array<string, mixed>> $convertChildren
+     */
+    public function __construct(
+        private readonly Closure $presentationAttributes,
+        private readonly Closure $innerHtml,
+        private readonly Closure $innerHtmlPreservingWhitespace,
+        private readonly Closure $createBlock,
+        private readonly Closure $richTextContent,
+        private readonly Closure $stripAllTags,
+        private readonly Closure $escapeHtml,
+        private readonly Closure $firstChildElement,
+        private readonly Closure $codePresentationAttributes,
+        private readonly Closure $codeContent,
+        private readonly Closure $hasBlockContentChildren,
+        private readonly Closure $convertChildren
+    ) {
+    }
+
+    /**
+     * @param array<int, string> $excludedProperties
+     * @param array<int, string> $excludedGeometryProperties
+     * @return array<string, mixed>
+     */
+    public function presentationAttributes(DOMElement $element, array $excludedProperties = array(), array $excludedGeometryProperties = array()): array
+    {
+        return ($this->presentationAttributes)($element, $excludedProperties, $excludedGeometryProperties);
+    }
+
+    public function innerHtml(DOMElement $element): string
+    {
+        return ($this->innerHtml)($element);
+    }
+
+    public function innerHtmlPreservingWhitespace(DOMElement $element): string
+    {
+        return ($this->innerHtmlPreservingWhitespace)($element);
+    }
+
+    /**
+     * @param array<string, mixed>                  $attributes
+     * @param array<int, array<string, mixed>>      $innerBlocks
+     * @return array<string, mixed>
+     */
+    public function createBlock(string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array
+    {
+        return ($this->createBlock)($name, $attributes, $innerBlocks, $sourceElement);
+    }
+
+    /**
+     * @param array<int, string> $excludedTags
+     */
+    public function richTextContent(DOMElement $element, array $excludedTags = array()): string
+    {
+        return ($this->richTextContent)($element, $excludedTags);
+    }
+
+    public function stripAllTags(string $html): string
+    {
+        return ($this->stripAllTags)($html);
+    }
+
+    public function escapeHtml(string $text): string
+    {
+        return ($this->escapeHtml)($text);
+    }
+
+    public function firstChildElement(DOMElement $element, string $tagName): ?DOMElement
+    {
+        return ($this->firstChildElement)($element, $tagName);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function codePresentationAttributes(DOMElement $pre, DOMElement $code): array
+    {
+        return ($this->codePresentationAttributes)($pre, $code);
+    }
+
+    public function codeContent(DOMElement $code): string
+    {
+        return ($this->codeContent)($code);
+    }
+
+    public function hasBlockContentChildren(DOMElement $element): bool
+    {
+        return ($this->hasBlockContentChildren)($element);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array<int, array<string, mixed>>
+     */
+    public function convertChildren(DOMElement $element, array &$fallbacks, bool $captureUnsupported = false): array
+    {
+        return ($this->convertChildren)($element, $fallbacks, $captureUnsupported);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Elements/TextLeafElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/TextLeafElementConverter.php
@@ -1,0 +1,196 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use DOMElement;
+
+/**
+ * Converts source tags whose block mapping depends only on the element's own
+ * text/markup content and presentation attributes.
+ *
+ * These branches previously lived inline in `HtmlTransformer::convertElement()`.
+ * They are extracted as a collaborator rather than a trait: a trait keeps every
+ * method in the transformer's `$this` scope, so it moves code across a file
+ * boundary without reducing the object surface. This class receives a
+ * {@see TextLeafElementContext} and can be exercised without constructing a
+ * transformer.
+ *
+ * Ordering note: the transformer's dispatch chain is order-sensitive. This
+ * converter is consulted at exactly the position the extracted branches
+ * occupied, and {@see handles()} matches the same tags those branches matched.
+ */
+final class TextLeafElementConverter
+{
+    /**
+     * Tags this converter owns, in the transformer's dispatch order.
+     *
+     * @var array<int, string>
+     */
+    private const TAGS = array('address', 'noscript', 'marquee', 'blink', 'pre', 'plaintext', 'hr', 'br');
+
+    public function __construct(private readonly TextLeafElementContext $context)
+    {
+    }
+
+    public function handles(string $tagName): bool
+    {
+        return in_array($tagName, self::TAGS, true);
+    }
+
+    /**
+     * Convert a text-leaf element.
+     *
+     * Returns a `ConversionOutcome` so a legitimate `null` block (the element
+     * intentionally produces nothing, e.g. `br`) stays distinguishable from
+     * "this converter does not own the tag".
+     */
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     */
+    public function convert(DOMElement $element, string $tagName, array &$fallbacks): ConversionOutcome
+    {
+        return match ($tagName) {
+            'address'          => ConversionOutcome::handled($this->convertAddress($element)),
+            'noscript'         => ConversionOutcome::handled($this->convertNoscript($element, $fallbacks)),
+            'marquee', 'blink' => ConversionOutcome::handled($this->convertMarquee($element, $fallbacks)),
+            'pre'              => ConversionOutcome::handled($this->convertPre($element)),
+            'plaintext'        => ConversionOutcome::handled($this->convertPlaintext($element)),
+            'hr'               => ConversionOutcome::handled($this->convertSeparator($element)),
+            'br'               => ConversionOutcome::handled(null),
+            default            => ConversionOutcome::unhandled(),
+        };
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function convertAddress(DOMElement $element): ?array
+    {
+        $content = $this->context->richTextContent($element);
+        if ( '' === trim($this->context->stripAllTags($content)) ) {
+            return null;
+        }
+
+        return $this->context->createBlock(
+            'core/paragraph',
+            array_merge($this->context->presentationAttributes($element), array( 'content' => $content )),
+            array(),
+            $element
+        );
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array<string, mixed>|null
+     */
+    private function convertNoscript(DOMElement $element, array &$fallbacks): ?array
+    {
+        $children = $this->context->convertChildren($element, $fallbacks, true);
+        if ( array() === $children ) {
+            $content = $this->context->innerHtml($element);
+            if ( '' === trim($this->context->stripAllTags($content)) ) {
+                return null;
+            }
+
+            return $this->context->createBlock(
+                'core/paragraph',
+                array_merge($this->context->presentationAttributes($element), array( 'content' => $content )),
+                array(),
+                $element
+            );
+        }
+
+        if ( 1 === count($children) && array() === $this->context->presentationAttributes($element) ) {
+            return $children[0];
+        }
+
+        return $this->context->createBlock('core/group', $this->context->presentationAttributes($element), $children, $element);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array<string, mixed>|null
+     */
+    private function convertMarquee(DOMElement $element, array &$fallbacks): ?array
+    {
+        if ( $this->context->hasBlockContentChildren($element) ) {
+            $children = $this->context->convertChildren($element, $fallbacks, true);
+            if ( array() === $children ) {
+                return null;
+            }
+
+            if ( 1 === count($children) && array() === $this->context->presentationAttributes($element) ) {
+                return $children[0];
+            }
+
+            return $this->context->createBlock('core/group', $this->context->presentationAttributes($element), $children, $element);
+        }
+
+        $content = $this->context->innerHtml($element);
+        if ( '' === trim($this->context->stripAllTags($content)) ) {
+            return null;
+        }
+
+        return $this->context->createBlock(
+            'core/paragraph',
+            array_merge($this->context->presentationAttributes($element), array( 'content' => $content )),
+            array(),
+            $element
+        );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function convertPre(DOMElement $element): ?array
+    {
+        $code = $this->context->firstChildElement($element, 'code');
+        if ( $code instanceof DOMElement ) {
+            return $this->context->createBlock(
+                'core/code',
+                array_merge($this->context->codePresentationAttributes($element, $code), array( 'content' => $this->context->codeContent($code) )),
+                array(),
+                $element
+            );
+        }
+
+        return $this->context->createBlock(
+            'core/preformatted',
+            array_merge($this->context->presentationAttributes($element), array( 'content' => $this->context->innerHtmlPreservingWhitespace($element) )),
+            array(),
+            $element
+        );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function convertPlaintext(DOMElement $element): ?array
+    {
+        $content = $this->context->escapeHtml($element->textContent ?? '');
+        if ( '' === trim($content) ) {
+            return null;
+        }
+
+        return $this->context->createBlock(
+            'core/preformatted',
+            array_merge($this->context->presentationAttributes($element), array( 'content' => $content )),
+            array(),
+            $element
+        );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function convertSeparator(DOMElement $element): ?array
+    {
+        return $this->context->createBlock(
+            'core/separator',
+            $this->context->presentationAttributes($element, array(), array( 'margin-left', 'margin-right' )),
+            array(),
+            $element
+        );
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -26,6 +26,8 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\DescriptionLi
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\LayoutShellBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\ResponsiveLayoutBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\ResponsiveMediaBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TextLeafElementContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TextLeafElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackDiagnostic;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\TypographyParityAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\DiagnosticsCollector;
@@ -235,6 +237,8 @@ final class HtmlTransformer
 
     private readonly PatternRecognizerRegistry $patternRecognizers;
 
+    private readonly TextLeafElementConverter $textLeafConverter;
+
     private readonly PatternContext $patternContext;
 
     private readonly PatternContext $patternContextWithoutRuntimeDomTarget;
@@ -345,6 +349,32 @@ final class HtmlTransformer
         $this->patternContext = $this->createPatternContext(true);
         $this->patternContextWithoutRuntimeDomTarget = $this->createPatternContext(false);
         $this->patternProbeContext = $this->createProbePatternContext();
+        $this->textLeafConverter = new TextLeafElementConverter($this->createTextLeafElementContext());
+    }
+
+    /**
+     * Collaborator surface for {@see TextLeafElementConverter}. Enumerating the
+     * operations here is the point: the converter cannot reach transformer
+     * state that is not listed.
+     */
+    private function createTextLeafElementContext(): TextLeafElementContext
+    {
+        return new TextLeafElementContext(
+            fn (DOMElement $element, array $excludedProperties, array $excludedGeometryProperties): array => $this->presentationAttributes($element, $excludedProperties, $excludedGeometryProperties),
+            fn (DOMElement $element): string => $this->innerHtml($element),
+            fn (DOMElement $element): string => $this->innerHtmlPreservingWhitespace($element),
+            fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
+            fn (DOMElement $element, array $excludedTags): string => $this->richTextContentWithMaterializedInlineStyles($element, $excludedTags),
+            fn (string $html): string => $this->runtime->stripAllTags($html),
+            fn (string $text): string => $this->runtime->escapeHtml($text),
+            fn (DOMElement $element, string $tagName): ?DOMElement => $this->firstChildElement($element, $tagName),
+            fn (DOMElement $pre, DOMElement $code): array => $this->codePresentationAttributes($pre, $code),
+            fn (DOMElement $code): string => $this->codeContent($code),
+            fn (DOMElement $element): bool => $this->hasBlockContentChildren($element),
+            function (DOMElement $element, array &$fallbacks, bool $captureUnsupported): array {
+                return $this->convertChildren($element, $fallbacks, $captureUnsupported);
+            }
+        );
     }
 
     private function authorStyles(): AuthorStyleAnalysis
@@ -3448,12 +3478,7 @@ final class HtmlTransformer
         }
 
         if ( 'address' === $tagName ) {
-            $content = $this->richTextContentWithMaterializedInlineStyles($element);
-            if ( '' === trim($this->runtime->stripAllTags($content)) ) {
-                return null;
-            }
-
-            return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
+            return $this->textLeafConverter->convert($element, $tagName, $fallbacks)->block;
         }
 
         if ( $this->session->preservesShellLandmarks() && (in_array($tagName, array('header', 'footer'), true) || in_array(strtolower($this->attr($element, 'role')), array('banner', 'contentinfo'), true)) && ('body' === strtolower($element->parentNode?->nodeName ?? '') || $this->hasAncestorTag($element, array('article'))) ) {
@@ -3525,65 +3550,19 @@ if ( $this->isInlineContentElement($tagName) ) {
         }
 
         if ( 'noscript' === $tagName ) {
-            $children = $this->convertChildren($element, $fallbacks, true);
-            if ( array() === $children ) {
-                $content = $this->innerHtml($element);
-                if ( '' === trim($this->runtime->stripAllTags($content)) ) {
-                    return null;
-                }
-
-                return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
-            }
-
-            if ( 1 === count($children) && array() === $this->presentationAttributes($element) ) {
-                return $children[0];
-            }
-
-            return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
+            return $this->textLeafConverter->convert($element, $tagName, $fallbacks)->block;
         }
 
         if ( 'marquee' === $tagName || 'blink' === $tagName ) {
-            if ( $this->hasBlockContentChildren($element) ) {
-                $children = $this->convertChildren($element, $fallbacks, true);
-                if ( array() === $children ) {
-                    return null;
-                }
-
-                if ( 1 === count($children) && array() === $this->presentationAttributes($element) ) {
-                    return $children[0];
-                }
-
-                return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
-            }
-
-            $content = $this->innerHtml($element);
-            if ( '' === trim($this->runtime->stripAllTags($content)) ) {
-                return null;
-            }
-
-            return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
+            return $this->textLeafConverter->convert($element, $tagName, $fallbacks)->block;
         }
 
         if ( 'label' === $tagName ) {
             return $this->readableFormControlBlockFromElement($element);
         }
 
-        if ( 'pre' === $tagName ) {
-            $code = $this->firstChildElement($element, 'code');
-            if ( $code instanceof DOMElement ) {
-                return $this->createBlock('core/code', array_merge($this->codePresentationAttributes($element, $code), array( 'content' => $this->codeContent($code) )), array(), $element);
-            }
-
-            return $this->createBlock('core/preformatted', array_merge($this->presentationAttributes($element), array( 'content' => $this->innerHtmlPreservingWhitespace($element) )), array(), $element);
-        }
-
-        if ( 'plaintext' === $tagName ) {
-            $content = $this->runtime->escapeHtml($element->textContent ?? '');
-            if ( '' === trim($content) ) {
-                return null;
-            }
-
-            return $this->createBlock('core/preformatted', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
+        if ( 'pre' === $tagName || 'plaintext' === $tagName ) {
+            return $this->textLeafConverter->convert($element, $tagName, $fallbacks)->block;
         }
 
         if ( 'table' === $tagName ) {
@@ -3608,12 +3587,8 @@ if ( $this->isInlineContentElement($tagName) ) {
             return $parameterTable;
         }
 
-        if ( 'hr' === $tagName ) {
-            return $this->createBlock('core/separator', $this->presentationAttributes($element, array(), array( 'margin-left', 'margin-right' )), array(), $element);
-        }
-
-        if ( 'br' === $tagName ) {
-            return null;
+        if ( 'hr' === $tagName || 'br' === $tagName ) {
+            return $this->textLeafConverter->convert($element, $tagName, $fallbacks)->block;
         }
 
         if ( 'details' === $tagName ) {

--- a/php-transformer/tests/unit/text-leaf-element-converter.php
+++ b/php-transformer/tests/unit/text-leaf-element-converter.php
@@ -1,0 +1,167 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * TextLeafElementConverter is exercised without constructing an HtmlTransformer.
+ *
+ * That is the point of the extraction: these branches used to live inside
+ * `HtmlTransformer::convertElement()`, so covering them required building a
+ * transformer and driving a full document through it. Here the collaborator
+ * surface is supplied directly.
+ */
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TextLeafElementContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TextLeafElementConverter;
+
+$assertions = 0;
+$failures   = array();
+$assert     = static function (bool $condition, string $label, string $detail = '') use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']' . ('' !== $detail ? ': ' . $detail : '');
+    }
+};
+
+/** Build a converter over a minimal, fully explicit collaborator surface. */
+$makeConverter = static function (array $overrides = array()): TextLeafElementConverter {
+    $defaults = array(
+        'presentationAttributes'        => static fn (DOMElement $e, array $p, array $g): array => array(),
+        'innerHtml'                     => static fn (DOMElement $e): string => (string) $e->textContent,
+        'innerHtmlPreservingWhitespace' => static fn (DOMElement $e): string => (string) $e->textContent,
+        'createBlock'                   => static fn (string $n, array $a, array $i, ?DOMElement $s): array => array(
+            'blockName'   => $n,
+            'attrs'       => $a,
+            'innerBlocks' => $i,
+        ),
+        'richTextContent'               => static fn (DOMElement $e, array $x): string => (string) $e->textContent,
+        'stripAllTags'                  => static fn (string $h): string => strip_tags($h),
+        'escapeHtml'                    => static fn (string $t): string => htmlspecialchars($t, ENT_QUOTES),
+        'firstChildElement'             => static function (DOMElement $e, string $tag): ?DOMElement {
+            foreach ($e->childNodes as $child) {
+                if ($child instanceof DOMElement && strtolower($child->tagName) === $tag) {
+                    return $child;
+                }
+            }
+            return null;
+        },
+        'codePresentationAttributes'    => static fn (DOMElement $pre, DOMElement $code): array => array('code' => true),
+        'codeContent'                   => static fn (DOMElement $c): string => (string) $c->textContent,
+        'hasBlockContentChildren'       => static fn (DOMElement $e): bool => false,
+        'convertChildren'               => static function (DOMElement $e, array &$f, bool $c): array {
+            return array();
+        },
+    );
+
+    $c = array_merge($defaults, $overrides);
+
+    return new TextLeafElementConverter(new TextLeafElementContext(
+        $c['presentationAttributes'],
+        $c['innerHtml'],
+        $c['innerHtmlPreservingWhitespace'],
+        $c['createBlock'],
+        $c['richTextContent'],
+        $c['stripAllTags'],
+        $c['escapeHtml'],
+        $c['firstChildElement'],
+        $c['codePresentationAttributes'],
+        $c['codeContent'],
+        $c['hasBlockContentChildren'],
+        $c['convertChildren']
+    ));
+};
+
+$elementFrom = static function (string $html): DOMElement {
+    $doc = new DOMDocument();
+    $doc->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+    $body = $doc->getElementsByTagName('body')->item(0);
+    foreach ($body->childNodes as $node) {
+        if ($node instanceof DOMElement) {
+            return $node;
+        }
+    }
+    throw new RuntimeException('No element parsed from: ' . $html);
+};
+
+// Ownership is explicit and closed.
+$converter = $makeConverter();
+foreach (array('address', 'noscript', 'marquee', 'blink', 'pre', 'plaintext', 'hr', 'br') as $tag) {
+    $assert($converter->handles($tag), 'handles-' . $tag);
+}
+foreach (array('p', 'div', 'h1', 'table', 'a', 'form') as $tag) {
+    $assert(! $converter->handles($tag), 'does-not-handle-' . $tag);
+}
+
+$fallbacks = array();
+
+// `br` converts to nothing, and that is distinguishable from "not handled".
+$outcome = $converter->convert($elementFrom('<br>'), 'br', $fallbacks);
+$assert($outcome->handled, 'br-is-handled');
+$assert(null === $outcome->block, 'br-produces-no-block');
+
+// An unowned tag reports unhandled so the transformer keeps dispatching.
+$assert(! $converter->convert($elementFrom('<div>x</div>'), 'div', $fallbacks)->handled, 'unowned-tag-unhandled');
+
+// Empty text leaves drop out instead of emitting empty blocks.
+$assert(null === $converter->convert($elementFrom('<address>   </address>'), 'address', $fallbacks)->block, 'empty-address-drops');
+$assert(null === $converter->convert($elementFrom('<plaintext>  </plaintext>'), 'plaintext', $fallbacks)->block, 'empty-plaintext-drops');
+
+// Address with content becomes a paragraph.
+$address = $converter->convert($elementFrom('<address>1 Main St</address>'), 'address', $fallbacks)->block;
+$assert('core/paragraph' === ($address['blockName'] ?? ''), 'address-is-paragraph');
+$assert('1 Main St' === ($address['attrs']['content'] ?? ''), 'address-carries-content');
+
+// `pre > code` becomes core/code and uses the code-specific attribute source.
+$pre = $converter->convert($elementFrom('<pre><code>echo 1;</code></pre>'), 'pre', $fallbacks)->block;
+$assert('core/code' === ($pre['blockName'] ?? ''), 'pre-code-is-core-code');
+$assert('echo 1;' === ($pre['attrs']['content'] ?? ''), 'pre-code-content');
+$assert(true === ($pre['attrs']['code'] ?? false), 'pre-code-uses-code-presentation-attributes');
+
+// `pre` without a code child stays preformatted.
+$bare = $converter->convert($elementFrom('<pre>raw  text</pre>'), 'pre', $fallbacks)->block;
+$assert('core/preformatted' === ($bare['blockName'] ?? ''), 'bare-pre-is-preformatted');
+
+// `hr` maps to a separator and excludes horizontal margins.
+$seenGeometry = array();
+$hrConverter  = $makeConverter(array(
+    'presentationAttributes' => static function (DOMElement $e, array $p, array $g) use (&$seenGeometry): array {
+        $seenGeometry = $g;
+        return array();
+    },
+));
+$hr = $hrConverter->convert($elementFrom('<hr>'), 'hr', $fallbacks)->block;
+$assert('core/separator' === ($hr['blockName'] ?? ''), 'hr-is-separator');
+$assert(array('margin-left', 'margin-right') === $seenGeometry, 'hr-excludes-horizontal-margins');
+
+// A marquee with block children groups them; a single child with no
+// presentation attributes is hoisted rather than wrapped.
+$marqueeConverter = $makeConverter(array(
+    'hasBlockContentChildren' => static fn (DOMElement $e): bool => true,
+    'convertChildren'         => static function (DOMElement $e, array &$f, bool $c): array {
+        return array(array('blockName' => 'core/paragraph'), array('blockName' => 'core/image'));
+    },
+));
+$grouped = $marqueeConverter->convert($elementFrom('<marquee><p>a</p><img src="x"></marquee>'), 'marquee', $fallbacks)->block;
+$assert('core/group' === ($grouped['blockName'] ?? ''), 'marquee-with-children-groups');
+$assert(2 === count($grouped['innerBlocks'] ?? array()), 'marquee-group-keeps-children');
+
+$singleChild = $makeConverter(array(
+    'hasBlockContentChildren' => static fn (DOMElement $e): bool => true,
+    'convertChildren'         => static function (DOMElement $e, array &$f, bool $c): array {
+        return array(array('blockName' => 'core/image'));
+    },
+));
+$hoisted = $singleChild->convert($elementFrom('<marquee><img src="x"></marquee>'), 'marquee', $fallbacks)->block;
+$assert('core/image' === ($hoisted['blockName'] ?? ''), 'single-child-marquee-is-hoisted');
+
+// noscript with no convertible children falls back to its own markup.
+$noscript = $converter->convert($elementFrom('<noscript>enable js</noscript>'), 'noscript', $fallbacks)->block;
+$assert('core/paragraph' === ($noscript['blockName'] ?? ''), 'noscript-without-children-is-paragraph');
+
+if ($failures) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Text leaf element converter tests: ' . $assertions . " passed\n";


### PR DESCRIPTION
First decomposition slice for #242, workstream 1.

## Why a collaborator and not a trait

The recent extractions moved code into traits that `HtmlTransformer` is the only consumer of. Measured on trunk before this PR: 8 of the 9 traits mixed into the transformer have exactly one consumer, totalling 8,887 lines. A single-consumer trait changes the file listing, not the `$this` surface — every method still shares one mutable object scope, so coupling, testability, and parallel-agent collision safety are unchanged.

`TextLeafElementConverter` is a plain object. It receives `TextLeafElementContext` (12 explicit operations, mirroring the existing `PatternContext` idiom) and has no access to transformer state that is not on that list.

## What moved

`address`, `noscript`, `marquee`/`blink`, `pre`, `plaintext`, `hr`, `br` — the branches in `convertElement()` whose mapping depends only on the element's own content and presentation attributes.

`ConversionOutcome` exists because the dispatch chain overloads `null` to mean both "this element intentionally produces no block" (`br`) and "this branch did not apply, keep dispatching". Collapsing those into a bare `?array` is part of what keeps branches pinned inline. Separating them is what let these leave the chain without reordering dispatch.

## Behavior preservation

The dispatch chain is order-sensitive, so each extracted branch is invoked from exactly the position it previously occupied.

Proof is a corpus hash diff, not just a green suite. Before any edit, every HTML fixture under `fixtures/` was transformed on clean `origin/trunk` and its `serializedBlocks` SHA-256 recorded alongside block/diagnostic/fallback counts. Same capture after:

```
corpus fixtures: 385   DIFFERING: 0   threw: 0
```

- `composer test` exit 0 — 289 parity fixtures, contract suite, unit suite, packaging proof.
- New `tests/unit/text-leaf-element-converter.php`: 31 assertions, registered in `test:unit`.

## Impact

| | before | after |
|---|---:|---:|
| `HtmlTransformer.php` | 12,633 | 12,608 |
| `convertElement()` | 441 | 387 |

The line delta is deliberately small — 54 lines of `convertElement()` and ~25 net off the class. What matters is that those conversions are no longer reachable through `$this`, and are now covered by a unit test that constructs no transformer. Previously, covering them required driving a full document through the pipeline.

## Scope

This is slice 1. `convertElement()` is still a 387-line ordered chain and `HtmlTransformer` is still ~12.6k lines. Follow-on slices in the same shape: the heading/paragraph rich-text branches (they need the richtext/SVG helper cluster), the table branch (`TableClassificationPolicy` is already a collaborator), and the terminal `captureUnsupported` fallback block.

Suggested metric for the remaining slices, per the audit comment above: count methods no longer reachable through `$this`, not lines removed from the file.

---

*AI assistance disclosure: implemented and drafted by Claude Sonnet 4.6 running in Claude Code, operated by @chubes4. The AI captured the pre-change corpus baseline, performed the extraction, verified byte-identical `serializedBlocks` output across 385 fixtures, and wrote the isolation test. Reviewed by a human before opening.*
