### PR TITLE
Extract heading and paragraph conversion out of convertElement (#242)

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -143,7 +143,8 @@
       "php tests/unit/pattern-recursive-converter.php",
       "php tests/unit/pattern-recognizer-registry.php",
       "php tests/unit/pattern-registry-staged-dispatch.php",
-            "php tests/unit/text-leaf-element-converter.php"
+            "php tests/unit/text-leaf-element-converter.php",
+            "php tests/unit/rich-text-element-converter.php"
     ],
     "test:parity": "php tests/parity/run.php",
     "test:migration:examples": "php tests/migration/examples.php",

--- a/php-transformer/src/HtmlToBlocks/Elements/RichTextElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/RichTextElementContext.php
@@ -1,0 +1,156 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Closure;
+use DOMElement;
+
+/**
+ * Explicit collaborator surface for {@see RichTextElementConverter}.
+ *
+ * Heading and paragraph conversion depends on the transformer's rich-text
+ * materialization cluster (inline styles, inline SVG image objects, the
+ * core/html fallback predicate) plus a small amount of layout inspection.
+ * Enumerating those operations here is the boundary: the converter cannot
+ * reach transformer state that is not on this list.
+ */
+final class RichTextElementContext
+{
+    /**
+     * @param Closure(DOMElement, array<int, string>, array<int, string>): array<string, mixed>              $presentationAttributes
+     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
+     * @param Closure(DOMElement, array<int, string>): string                                                $richTextContent
+     * @param Closure(string): string                                                                        $headingRichTextContent
+     * @param Closure(DOMElement, string): ?string                                                            $richTextWithMaterializedSvgImages
+     * @param Closure(string): bool                                                                          $requiresHtmlFallback
+     * @param Closure(string): bool                                                                          $containsNativeSvgImageObject
+     * @param Closure(DOMElement): array<string, mixed>                                                      $htmlPreservationBlock
+     * @param Closure(DOMElement): ?array<string, mixed>                                                     $authoredMarqueeBlock
+     * @param Closure(DOMElement): bool                                                                      $hasEmptyVisualInlineChild
+     * @param Closure(DOMElement): bool                                                                      $hasBoxChromeWrapperStyling
+     * @param Closure(DOMElement): bool                                                                      $isRuntimeDomTarget
+     * @param Closure(string): array<int, array<string, mixed>>                                              $convertText
+     * @param Closure(string): string                                                                        $stripAllTags
+     * @param Closure(DOMElement, array<int, array<string, mixed>>, bool): array<int, array<string, mixed>>   $convertChildren
+     */
+    public function __construct(
+        private readonly Closure $presentationAttributes,
+        private readonly Closure $createBlock,
+        private readonly Closure $richTextContent,
+        private readonly Closure $headingRichTextContent,
+        private readonly Closure $richTextWithMaterializedSvgImages,
+        private readonly Closure $requiresHtmlFallback,
+        private readonly Closure $containsNativeSvgImageObject,
+        private readonly Closure $htmlPreservationBlock,
+        private readonly Closure $authoredMarqueeBlock,
+        private readonly Closure $hasEmptyVisualInlineChild,
+        private readonly Closure $hasBoxChromeWrapperStyling,
+        private readonly Closure $isRuntimeDomTarget,
+        private readonly Closure $convertText,
+        private readonly Closure $stripAllTags,
+        private readonly Closure $convertChildren
+    ) {
+    }
+
+    /**
+     * @param array<int, string> $excludedProperties
+     * @param array<int, string> $excludedGeometryProperties
+     * @return array<string, mixed>
+     */
+    public function presentationAttributes(DOMElement $element, array $excludedProperties = array(), array $excludedGeometryProperties = array()): array
+    {
+        return ($this->presentationAttributes)($element, $excludedProperties, $excludedGeometryProperties);
+    }
+
+    /**
+     * @param array<string, mixed>             $attributes
+     * @param array<int, array<string, mixed>> $innerBlocks
+     * @return array<string, mixed>
+     */
+    public function createBlock(string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array
+    {
+        return ($this->createBlock)($name, $attributes, $innerBlocks, $sourceElement);
+    }
+
+    /**
+     * @param array<int, string> $excludedTags
+     */
+    public function richTextContent(DOMElement $element, array $excludedTags = array()): string
+    {
+        return ($this->richTextContent)($element, $excludedTags);
+    }
+
+    public function headingRichTextContent(string $content): string
+    {
+        return ($this->headingRichTextContent)($content);
+    }
+
+    public function richTextWithMaterializedSvgImages(DOMElement $element, string $content): ?string
+    {
+        return ($this->richTextWithMaterializedSvgImages)($element, $content);
+    }
+
+    public function requiresHtmlFallback(string $content): bool
+    {
+        return ($this->requiresHtmlFallback)($content);
+    }
+
+    public function containsNativeSvgImageObject(string $content): bool
+    {
+        return ($this->containsNativeSvgImageObject)($content);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function htmlPreservationBlock(DOMElement $element): array
+    {
+        return ($this->htmlPreservationBlock)($element);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function authoredMarqueeBlock(DOMElement $element): ?array
+    {
+        return ($this->authoredMarqueeBlock)($element);
+    }
+
+    public function hasEmptyVisualInlineChild(DOMElement $element): bool
+    {
+        return ($this->hasEmptyVisualInlineChild)($element);
+    }
+
+    public function hasBoxChromeWrapperStyling(DOMElement $element): bool
+    {
+        return ($this->hasBoxChromeWrapperStyling)($element);
+    }
+
+    public function isRuntimeDomTarget(DOMElement $element): bool
+    {
+        return ($this->isRuntimeDomTarget)($element);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function convertText(string $text): array
+    {
+        return ($this->convertText)($text);
+    }
+
+    public function stripAllTags(string $html): string
+    {
+        return ($this->stripAllTags)($html);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array<int, array<string, mixed>>
+     */
+    public function convertChildren(DOMElement $element, array &$fallbacks, bool $captureUnsupported = false): array
+    {
+        return ($this->convertChildren)($element, $fallbacks, $captureUnsupported);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Elements/RichTextElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/RichTextElementConverter.php
@@ -1,0 +1,129 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use DOMElement;
+
+/**
+ * Converts `h1`-`h6` and `p` into their native rich-text blocks.
+ *
+ * These are the two highest-traffic branches of the transformer's dispatch
+ * chain and they share one decision shape: materialize rich-text content, decide
+ * whether that content still needs a core/html fallback, then either drop the
+ * element, lower it to a group, or emit the native block.
+ *
+ * Extracted as a collaborator rather than a trait. A single-consumer trait keeps
+ * every method in the transformer's `$this` scope, so it relocates code without
+ * shrinking the object surface. This class receives a
+ * {@see RichTextElementContext} and is exercised without a transformer.
+ */
+final class RichTextElementConverter
+{
+    private const HEADING_PATTERN = '/^h([1-6])$/';
+
+    public function __construct(private readonly RichTextElementContext $context)
+    {
+    }
+
+    public function handles(string $tagName): bool
+    {
+        return 'p' === $tagName || 1 === preg_match(self::HEADING_PATTERN, $tagName);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     */
+    public function convert(DOMElement $element, string $tagName, array &$fallbacks): ConversionOutcome
+    {
+        if ( preg_match(self::HEADING_PATTERN, $tagName, $matches) ) {
+            return ConversionOutcome::handled($this->convertHeading($element, (int) $matches[1]));
+        }
+
+        if ( 'p' === $tagName ) {
+            return ConversionOutcome::handled($this->convertParagraph($element, $fallbacks));
+        }
+
+        return ConversionOutcome::unhandled();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function convertHeading(DOMElement $element, int $level): ?array
+    {
+        $content = $this->context->headingRichTextContent($this->context->richTextContent($element));
+
+        if ( $this->context->requiresHtmlFallback($content) ) {
+            return $this->context->htmlPreservationBlock($element);
+        }
+
+        if ( '' === trim($this->context->stripAllTags($content)) ) {
+            return null;
+        }
+
+        return $this->context->createBlock(
+            'core/heading',
+            array_merge(
+                $this->context->presentationAttributes($element),
+                array(
+                    'content' => $content,
+                    'level'   => $level,
+                )
+            ),
+            array(),
+            $element
+        );
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array<string, mixed>|null
+     */
+    private function convertParagraph(DOMElement $element, array &$fallbacks): ?array
+    {
+        $marquee = $this->context->authoredMarqueeBlock($element);
+        if ( null !== $marquee ) {
+            return $marquee;
+        }
+
+        $content         = $this->context->richTextContent($element);
+        $withInlineSvg   = $this->context->richTextWithMaterializedSvgImages($element, $content);
+        if ( null !== $withInlineSvg ) {
+            $content = $withInlineSvg;
+        }
+
+        if ( $this->context->requiresHtmlFallback($content) ) {
+            return $this->context->htmlPreservationBlock($element);
+        }
+
+        // A paragraph carrying box chrome around an empty inline child is a
+        // styled container, not text. Lower it to a group so the chrome
+        // survives as layout instead of an empty paragraph.
+        if ( $this->context->hasEmptyVisualInlineChild($element) && $this->context->hasBoxChromeWrapperStyling($element) ) {
+            $children = $this->context->convertChildren($element, $fallbacks, true);
+            if ( array() !== $children ) {
+                return $this->context->createBlock('core/group', $this->context->presentationAttributes($element), $children, $element);
+            }
+        }
+
+        if ( '' === trim($this->context->stripAllTags($content)) && ! $this->context->containsNativeSvgImageObject($content) ) {
+            // An empty paragraph that scripts address by selector must keep a
+            // block at that position, otherwise the runtime target disappears.
+            if ( $this->context->isRuntimeDomTarget($element) ) {
+                return $this->context->createBlock('core/group', $this->context->presentationAttributes($element), array(), $element);
+            }
+
+            $textBlocks = $this->context->convertText(trim($element->textContent ?? ''));
+
+            return $textBlocks[0] ?? null;
+        }
+
+        return $this->context->createBlock(
+            'core/paragraph',
+            array_merge($this->context->presentationAttributes($element), array( 'content' => $content )),
+            array(),
+            $element
+        );
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -26,6 +26,8 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\DescriptionLi
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\LayoutShellBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\ResponsiveLayoutBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\ResponsiveMediaBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RichTextElementContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RichTextElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TextLeafElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TextLeafElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackDiagnostic;
@@ -239,6 +241,8 @@ final class HtmlTransformer
 
     private readonly TextLeafElementConverter $textLeafConverter;
 
+    private readonly RichTextElementConverter $richTextConverter;
+
     private readonly PatternContext $patternContext;
 
     private readonly PatternContext $patternContextWithoutRuntimeDomTarget;
@@ -350,6 +354,33 @@ final class HtmlTransformer
         $this->patternContextWithoutRuntimeDomTarget = $this->createPatternContext(false);
         $this->patternProbeContext = $this->createProbePatternContext();
         $this->textLeafConverter = new TextLeafElementConverter($this->createTextLeafElementContext());
+        $this->richTextConverter = new RichTextElementConverter($this->createRichTextElementContext());
+    }
+
+    /**
+     * Collaborator surface for {@see RichTextElementConverter}.
+     */
+    private function createRichTextElementContext(): RichTextElementContext
+    {
+        return new RichTextElementContext(
+            fn (DOMElement $element, array $excludedProperties, array $excludedGeometryProperties): array => $this->presentationAttributes($element, $excludedProperties, $excludedGeometryProperties),
+            fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
+            fn (DOMElement $element, array $excludedTags): string => $this->richTextContentWithMaterializedInlineStyles($element, $excludedTags),
+            fn (string $content): string => $this->headingRichTextContent($content),
+            fn (DOMElement $element, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($element, $content),
+            fn (string $content): bool => $this->richTextRequiresHtmlFallbackWithoutNativeSvgImageObjects($content),
+            fn (string $content): bool => $this->richTextContainsNativeSvgImageObject($content),
+            fn (DOMElement $element): array => $this->htmlPreservationBlock($element),
+            fn (DOMElement $element): ?array => $this->authoredMarqueeBlock($element),
+            fn (DOMElement $element): bool => $this->hasEmptyVisualInlineChild($element),
+            fn (DOMElement $element): bool => $this->hasBoxChromeWrapperStyling($element),
+            fn (DOMElement $element): bool => $this->isRuntimeDomTarget($element),
+            fn (string $text): array => $this->convertText($text),
+            fn (string $html): string => $this->runtime->stripAllTags($html),
+            function (DOMElement $element, array &$fallbacks, bool $captureUnsupported): array {
+                return $this->convertChildren($element, $fallbacks, $captureUnsupported);
+            }
+        );
     }
 
     /**
@@ -3436,50 +3467,8 @@ final class HtmlTransformer
             return $mathBlock;
         }
 
-        if ( preg_match('/^h([1-6])$/', $tagName, $matches) ) {
-            $content = $this->richTextContentWithMaterializedInlineStyles($element);
-            $content = $this->headingRichTextContent($content);
-            if ( $this->richTextRequiresHtmlFallbackWithoutNativeSvgImageObjects($content) ) {
-                return $this->htmlPreservationBlock($element);
-            }
-            if ( '' === trim($this->runtime->stripAllTags($content)) ) {
-                return null;
-            }
-
-            return $this->createBlock('core/heading', array_merge($this->presentationAttributes($element), array(
-                'content' => $content,
-                'level'   => (int) $matches[1],
-            )), array(), $element);
-        }
-
-        if ( 'p' === $tagName ) {
-            $marquee = $this->authoredMarqueeBlock($element);
-            if ( null !== $marquee ) {
-                return $marquee;
-            }
-            $content = $this->richTextContentWithMaterializedInlineStyles($element);
-            $inlineSvgContent = $this->richTextContentWithMaterializedSvgImages($element, $content);
-            if ( null !== $inlineSvgContent ) {
-                $content = $inlineSvgContent;
-            }
-            if ( $this->richTextRequiresHtmlFallbackWithoutNativeSvgImageObjects($content) ) {
-                return $this->htmlPreservationBlock($element);
-            }
-            if ( $this->hasEmptyVisualInlineChild($element) && $this->hasBoxChromeWrapperStyling($element) ) {
-                $children = $this->convertChildren($element, $fallbacks, true);
-                if ( array() !== $children ) {
-                    return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
-                }
-            }
-            if ( '' === trim($this->runtime->stripAllTags($content)) && ! $this->richTextContainsNativeSvgImageObject($content) ) {
-                if ( $this->isRuntimeDomTarget($element) ) {
-                    return $this->createBlock('core/group', $this->presentationAttributes($element), array(), $element);
-                }
-                $textBlocks = $this->convertText(trim($element->textContent ?? ''));
-                return $textBlocks[0] ?? null;
-            }
-
-            return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
+        if ( $this->richTextConverter->handles($tagName) ) {
+            return $this->richTextConverter->convert($element, $tagName, $fallbacks)->block;
         }
 
         if ( 'address' === $tagName ) {

--- a/php-transformer/tests/unit/rich-text-element-converter.php
+++ b/php-transformer/tests/unit/rich-text-element-converter.php
@@ -1,0 +1,178 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * RichTextElementConverter is exercised without constructing an HtmlTransformer.
+ *
+ * Heading and paragraph conversion previously lived inside
+ * `HtmlTransformer::convertElement()`, so covering a decision like "empty
+ * paragraph that is a runtime DOM target becomes a group" required driving a
+ * full document through the pipeline with the right stylesheet and script
+ * evidence attached. Here the deciding inputs are supplied directly.
+ */
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RichTextElementContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RichTextElementConverter;
+
+$assertions = 0;
+$failures   = array();
+$assert     = static function (bool $condition, string $label, string $detail = '') use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']' . ('' !== $detail ? ': ' . $detail : '');
+    }
+};
+
+$makeConverter = static function (array $overrides = array()): RichTextElementConverter {
+    $defaults = array(
+        'presentationAttributes'            => static fn (DOMElement $e, array $p, array $g): array => array(),
+        'createBlock'                       => static fn (string $n, array $a, array $i, ?DOMElement $s): array => array(
+            'blockName'   => $n,
+            'attrs'       => $a,
+            'innerBlocks' => $i,
+        ),
+        'richTextContent'                   => static fn (DOMElement $e, array $x): string => (string) $e->textContent,
+        'headingRichTextContent'            => static fn (string $c): string => $c,
+        'richTextWithMaterializedSvgImages' => static fn (DOMElement $e, string $c): ?string => null,
+        'requiresHtmlFallback'              => static fn (string $c): bool => false,
+        'containsNativeSvgImageObject'      => static fn (string $c): bool => false,
+        'htmlPreservationBlock'             => static fn (DOMElement $e): array => array('blockName' => 'core/html'),
+        'authoredMarqueeBlock'              => static fn (DOMElement $e): ?array => null,
+        'hasEmptyVisualInlineChild'         => static fn (DOMElement $e): bool => false,
+        'hasBoxChromeWrapperStyling'        => static fn (DOMElement $e): bool => false,
+        'isRuntimeDomTarget'                => static fn (DOMElement $e): bool => false,
+        'convertText'                       => static fn (string $t): array => '' === $t ? array() : array(array('blockName' => 'core/paragraph', 'attrs' => array('content' => $t))),
+        'stripAllTags'                      => static fn (string $h): string => strip_tags($h),
+        'convertChildren'                   => static function (DOMElement $e, array &$f, bool $c): array {
+            return array();
+        },
+    );
+
+    $c = array_merge($defaults, $overrides);
+
+    return new RichTextElementConverter(new RichTextElementContext(
+        $c['presentationAttributes'],
+        $c['createBlock'],
+        $c['richTextContent'],
+        $c['headingRichTextContent'],
+        $c['richTextWithMaterializedSvgImages'],
+        $c['requiresHtmlFallback'],
+        $c['containsNativeSvgImageObject'],
+        $c['htmlPreservationBlock'],
+        $c['authoredMarqueeBlock'],
+        $c['hasEmptyVisualInlineChild'],
+        $c['hasBoxChromeWrapperStyling'],
+        $c['isRuntimeDomTarget'],
+        $c['convertText'],
+        $c['stripAllTags'],
+        $c['convertChildren']
+    ));
+};
+
+$elementFrom = static function (string $html): DOMElement {
+    $doc = new DOMDocument();
+    $doc->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+    foreach ($doc->getElementsByTagName('body')->item(0)->childNodes as $node) {
+        if ($node instanceof DOMElement) {
+            return $node;
+        }
+    }
+    throw new RuntimeException('No element parsed from: ' . $html);
+};
+
+$fallbacks = array();
+$converter = $makeConverter();
+
+// Ownership is closed and covers every heading level.
+foreach (array('h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p') as $tag) {
+    $assert($converter->handles($tag), 'handles-' . $tag);
+}
+foreach (array('h7', 'div', 'span', 'address', 'pre', 'hr') as $tag) {
+    $assert(! $converter->handles($tag), 'does-not-handle-' . $tag);
+}
+$assert(! $converter->convert($elementFrom('<div>x</div>'), 'div', $fallbacks)->handled, 'unowned-tag-unhandled');
+
+// Heading level is read from the tag, not guessed.
+foreach (array(1, 2, 3, 4, 5, 6) as $level) {
+    $block = $converter->convert($elementFrom("<h{$level}>Title</h{$level}>"), "h{$level}", $fallbacks)->block;
+    $assert('core/heading' === ($block['blockName'] ?? ''), "h{$level}-is-heading");
+    $assert($level === ($block['attrs']['level'] ?? null), "h{$level}-level");
+}
+
+// Empty rich text drops out rather than emitting an empty block.
+$assert(null === $converter->convert($elementFrom('<h2>   </h2>'), 'h2', $fallbacks)->block, 'empty-heading-drops');
+
+// Content that cannot survive as rich text falls back to core/html.
+$fallbackConverter = $makeConverter(array('requiresHtmlFallback' => static fn (string $c): bool => true));
+$assert('core/html' === ($fallbackConverter->convert($elementFrom('<h2>x</h2>'), 'h2', $fallbacks)->block['blockName'] ?? ''), 'heading-html-fallback');
+$assert('core/html' === ($fallbackConverter->convert($elementFrom('<p>x</p>'), 'p', $fallbacks)->block['blockName'] ?? ''), 'paragraph-html-fallback');
+
+// Heading content passes through the heading-specific normalizer.
+$headingNormalized = $makeConverter(array('headingRichTextContent' => static fn (string $c): string => 'NORMALIZED:' . $c));
+$assert('NORMALIZED:Title' === ($headingNormalized->convert($elementFrom('<h3>Title</h3>'), 'h3', $fallbacks)->block['attrs']['content'] ?? ''), 'heading-uses-heading-normalizer');
+
+// A paragraph recognized as an authored marquee short-circuits everything else.
+$marquee = $makeConverter(array('authoredMarqueeBlock' => static fn (DOMElement $e): ?array => array('blockName' => 'blocks-engine/marquee')));
+$assert('blocks-engine/marquee' === ($marquee->convert($elementFrom('<p>scroll</p>'), 'p', $fallbacks)->block['blockName'] ?? ''), 'paragraph-marquee-short-circuits');
+
+// Materialized inline SVG replaces the plain rich-text content. The materialized
+// markup strips to an empty string, so it only survives as a paragraph because
+// the native-SVG-image predicate claims it — the two travel together.
+$svg = $makeConverter(array(
+    'richTextWithMaterializedSvgImages' => static fn (DOMElement $e, string $c): ?string => '<img src="x.svg">',
+    'containsNativeSvgImageObject'      => static fn (string $c): bool => str_contains($c, '.svg'),
+));
+$svgBlock = $svg->convert($elementFrom('<p>icon</p>'), 'p', $fallbacks)->block;
+$assert('core/paragraph' === ($svgBlock['blockName'] ?? ''), 'materialized-svg-paragraph-survives');
+$assert('<img src="x.svg">' === ($svgBlock['attrs']['content'] ?? ''), 'paragraph-uses-materialized-svg-content');
+
+// Without that claim the same materialized markup is treated as empty and the
+// converter falls back to the element's own text.
+$svgUnclaimed = $makeConverter(array('richTextWithMaterializedSvgImages' => static fn (DOMElement $e, string $c): ?string => '<img src="x.svg">'));
+$assert('icon' === ($svgUnclaimed->convert($elementFrom('<p>icon</p>'), 'p', $fallbacks)->block['attrs']['content'] ?? ''), 'unclaimed-svg-markup-falls-back-to-text');
+
+// Box chrome around an empty inline child lowers to a group carrying children.
+$chrome = $makeConverter(array(
+    'richTextContent'            => static fn (DOMElement $e, array $x): string => '',
+    'hasEmptyVisualInlineChild'  => static fn (DOMElement $e): bool => true,
+    'hasBoxChromeWrapperStyling' => static fn (DOMElement $e): bool => true,
+    'convertChildren'            => static function (DOMElement $e, array &$f, bool $c): array {
+        return array(array('blockName' => 'core/spacer'));
+    },
+));
+$chromeBlock = $chrome->convert($elementFrom('<p><span></span></p>'), 'p', $fallbacks)->block;
+$assert('core/group' === ($chromeBlock['blockName'] ?? ''), 'box-chrome-paragraph-is-group');
+$assert(1 === count($chromeBlock['innerBlocks'] ?? array()), 'box-chrome-group-keeps-children');
+
+// An empty paragraph that scripts address by selector keeps a block in place.
+$runtimeTarget = $makeConverter(array(
+    'richTextContent'    => static fn (DOMElement $e, array $x): string => '',
+    'isRuntimeDomTarget' => static fn (DOMElement $e): bool => true,
+));
+$assert('core/group' === ($runtimeTarget->convert($elementFrom('<p id="mount"></p>'), 'p', $fallbacks)->block['blockName'] ?? ''), 'empty-runtime-target-paragraph-is-group');
+
+// An empty paragraph with no runtime claim produces nothing.
+$emptyParagraph = $makeConverter(array('richTextContent' => static fn (DOMElement $e, array $x): string => ''));
+$assert(null === $emptyParagraph->convert($elementFrom('<p></p>'), 'p', $fallbacks)->block, 'empty-paragraph-drops');
+
+// Empty rich text that still carries a native SVG image object stays a paragraph.
+$svgOnly = $makeConverter(array(
+    'richTextContent'              => static fn (DOMElement $e, array $x): string => '<img src="i.svg">',
+    'stripAllTags'                 => static fn (string $h): string => '',
+    'containsNativeSvgImageObject' => static fn (string $c): bool => true,
+));
+$assert('core/paragraph' === ($svgOnly->convert($elementFrom('<p><svg></svg></p>'), 'p', $fallbacks)->block['blockName'] ?? ''), 'svg-only-paragraph-survives');
+
+// Plain text paragraph.
+$plain = $converter->convert($elementFrom('<p>Hello</p>'), 'p', $fallbacks)->block;
+$assert('core/paragraph' === ($plain['blockName'] ?? ''), 'plain-paragraph');
+$assert('Hello' === ($plain['attrs']['content'] ?? ''), 'plain-paragraph-content');
+
+if ($failures) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Rich text element converter tests: ' . $assertions . " passed\n";


### PR DESCRIPTION
Slice 2 for #242, workstream 1. Follows #1310.

## What moved

`h1`-`h6` and `p` — the two highest-traffic branches in `convertElement()`. They share one decision shape:

1. materialize rich-text content (inline styles, then inline SVG image objects for `p`)
2. decide whether that content still needs a `core/html` fallback
3. drop the element, lower it to a group, or emit the native block

`RichTextElementConverter` takes a `RichTextElementContext` of 15 explicit operations and has no `$this` access to the transformer — same shape as `TextLeafElementConverter` in #1310, and for the same reason: a single-consumer trait relocates code without shrinking the object scope this epic is about.

## Behavior preservation

Corpus hash diff, captured on clean `trunk` before any edit and again after. Every HTML fixture under `fixtures/`, hashing `serializedBlocks` plus block/diagnostic/fallback counts:

```
385 fixtures — DIFFERING: 0 — threw: 0
```

`composer test` exit 0 — 289 parity fixtures, contract suite, unit suite, packaging proof.

## Coverage

New `tests/unit/rich-text-element-converter.php`, 41 assertions, constructs no transformer. It covers decisions that previously needed a full document driven through the pipeline with the right stylesheet and script evidence attached:

- empty paragraph that is a runtime DOM target stays a `core/group` so the selector target survives
- box chrome around an empty inline child lowers to a group instead of emitting an empty paragraph
- materialized inline SVG survives only when the native-SVG-image predicate claims it; without that claim the same markup strips to empty and the converter falls back to element text

That last pair is worth calling out — writing the test surfaced that `richTextWithMaterializedSvgImages` and `richTextContainsNativeSvgImageObject` are coupled: the materialized markup strips to an empty string, so the paragraph only survives because the second predicate claims it. That coupling was invisible while both were inline.

## Impact

| | trunk | after |
|---|---:|---:|
| `HtmlTransformer.php` | 12,617 | 12,606 |
| `convertElement()` | 387 | 349 |

Cumulative across #1310 and this: `convertElement()` 441 → 349.

## Scope

Still slice work. Remaining in the same shape: the `table` branch (`TableClassificationPolicy` is already a collaborator), and the terminal `captureUnsupported` fallback block.

---

*AI assistance disclosure: implemented and drafted by Claude Sonnet 4.6 running in Claude Code, operated by @chubes4. The AI captured the pre-change corpus baseline, performed the extraction, verified byte-identical `serializedBlocks` output across 385 fixtures, and wrote the isolation test. Reviewed by a human before opening.*
