### PR TITLE
Place button wrappers as the grid item

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -129,6 +129,7 @@
       "php tests/unit/button-wrapper-keyword-width.php",
       "php tests/unit/button-wrapper-inner-fill.php",
       "php tests/unit/button-wrapper-fill-selector-list.php",
+      "php tests/unit/button-grid-item-placement.php",
       "php tests/unit/corpus-detectors.php",
       "php tests/unit/live-wp-parity-runner.php",
       "php tests/unit/deterministic-row-deduplicator.php",

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2154,7 +2154,18 @@ final class HtmlTransformer
             $colon = strpos($declaration, ':');
             $name = strtolower(trim(false === $colon ? $declaration : substr($declaration, 0, $colon)));
             $value = false === $colon ? '' : trim(substr($declaration, $colon + 1));
-            if ( '' !== $name && false !== $colon && in_array($name, array( 'position', 'top', 'right', 'bottom', 'left', 'z-index', 'width', 'min-width', 'max-width', 'height', 'min-height', 'max-height' ), true)
+            // The buttons wrapper is the source control's box in the parent
+            // layout: it is the grid/flex item. Placement and self-alignment
+            // belong there, not on the inner control, which would leave the
+            // wrapper unplaced and push it into normal flow.
+            $wrapperOwned = array(
+                'position', 'top', 'right', 'bottom', 'left', 'z-index',
+                'width', 'min-width', 'max-width', 'height', 'min-height', 'max-height',
+                'grid-area', 'grid-column', 'grid-row',
+                'grid-column-start', 'grid-column-end', 'grid-row-start', 'grid-row-end',
+                'align-self', 'justify-self', 'order',
+            );
+            if ( '' !== $name && false !== $colon && in_array($name, $wrapperOwned, true)
                 && ! $this->isButtonControlBoxSize($name, $value)
             ) {
                 $geometry[] = $declaration;

--- a/php-transformer/tests/unit/button-grid-item-placement.php
+++ b/php-transformer/tests/unit/button-grid-item-placement.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * The buttons wrapper is the source control's box in the parent layout, so
+ * grid placement and self-alignment belong on it, not the inner control.
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$failures = 0;
+$passes   = 0;
+$assert = static function (bool $condition, string $message, string $detail = '') use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ( '' !== $detail ? ' - ' . $detail : '' ) . PHP_EOL);
+};
+
+$out = ( new HtmlTransformer() )->transform(
+    '<style>#wrap{display:grid}.cta{grid-area:1/1/2/2;align-self:start;justify-self:start;position:relative;width:7.82%}</style>'
+    . '<main><div id="wrap"><button class="cta" type="button">Contacts</button></div></main>'
+)->toArray();
+$css = '';
+foreach ( $out['assets'] ?? array() as $asset ) {
+    if ( is_array($asset) && 'css' === ( $asset['kind'] ?? '' ) ) {
+        $css .= (string) ( $asset['content'] ?? '' );
+    }
+}
+
+$assert(
+    (bool) preg_match('/wp-block-buttons\)?\{[^}]*grid-area/', $css),
+    '1: grid placement lands on the buttons wrapper',
+    $css
+);
+$assert(
+    ! preg_match('/wp-block-button__link\)?\{[^}]*grid-area/', $css),
+    '2: grid placement does not land on the inner control',
+    $css
+);
+$assert(
+    (bool) preg_match('/wp-block-buttons\)?\{[^}]*align-self/', $css)
+        && (bool) preg_match('/wp-block-buttons\)?\{[^}]*justify-self/', $css),
+    '3: self-alignment travels with the placement',
+    $css
+);
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, PHP_EOL . "button grid-item placement tests: {$passes} passed, {$failures} FAILED" . PHP_EOL);
+    exit(1);
+}
+fwrite(STDOUT, "button grid-item placement tests: {$passes} passed" . PHP_EOL);


### PR DESCRIPTION
Closes #1313.

## Problem

Grid placement from a source control landed on the inner `.wp-block-button__link`. `.wp-block-buttons` is the grid item, so it was never placed in its cell, fell into normal flow, and stretched its container.

Nimbus header: source grid row 96.95px, import 158.22px. Contacts at y=27 in the source, y=124 in the import.

## Change

Route `grid-area`, `grid-column`, `grid-row` (and start/end longhands), `align-self`, `justify-self`, and `order` to the wrapper, alongside the existing position and size properties. `display` stays on the control — it describes the control's own box.

## Coverage

`tests/unit/button-grid-item-placement.php`. All three assertions fail on trunk (placement absent from the wrapper, present on the link); pass with this change. `composer test` exits 0.

## AI assistance

Claude Sonnet 4.5 via OpenCode measured the header geometry against the live source, traced `splitDirectButtonGeometryDeclarations()`, implemented the routing, and ran verification. Chris Huber reviewed and is responsible for the submitted change.