### PR TITLE
Extract table routing and the unsupported-element fallback (#242)

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -144,7 +144,9 @@
       "php tests/unit/pattern-recognizer-registry.php",
       "php tests/unit/pattern-registry-staged-dispatch.php",
             "php tests/unit/text-leaf-element-converter.php",
-            "php tests/unit/rich-text-element-converter.php"
+            "php tests/unit/rich-text-element-converter.php",
+            "php tests/unit/table-element-converter.php",
+            "php tests/unit/unsupported-element-recorder.php"
     ],
     "test:parity": "php tests/parity/run.php",
     "test:migration:examples": "php tests/migration/examples.php",

--- a/php-transformer/src/HtmlToBlocks/Elements/TableElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/TableElementContext.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\TableClassificationPolicy;
+use Closure;
+use DOMElement;
+
+/**
+ * Explicit collaborator surface for {@see TableElementConverter}.
+ *
+ * The classification policy is already a first-class collaborator, so it is
+ * injected directly rather than wrapped in closures. Only the transformer-owned
+ * block builders are passed as closures.
+ */
+final class TableElementContext
+{
+    /**
+     * @param Closure(DOMElement, array<int, array<string, mixed>>): ?array<string, mixed>                    $nestedLayoutTableColumnsBlock
+     * @param Closure(DOMElement, array<int, array<string, mixed>>): ?array<string, mixed>                    $mediaLayoutTableColumnsBlock
+     * @param Closure(DOMElement): array<string, mixed>                                                       $htmlPreservationBlock
+     * @param Closure(DOMElement, array<int, string>, array<int, string>): array<string, mixed>               $presentationAttributes
+     * @param Closure(DOMElement): array<string, mixed>                                                       $tableAttributes
+     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
+     */
+    public function __construct(
+        private readonly TableClassificationPolicy $classificationPolicy,
+        private readonly Closure $nestedLayoutTableColumnsBlock,
+        private readonly Closure $mediaLayoutTableColumnsBlock,
+        private readonly Closure $htmlPreservationBlock,
+        private readonly Closure $presentationAttributes,
+        private readonly Closure $tableAttributes,
+        private readonly Closure $createBlock
+    ) {
+    }
+
+    public function classificationPolicy(): TableClassificationPolicy
+    {
+        return $this->classificationPolicy;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array<string, mixed>|null
+     */
+    public function nestedLayoutTableColumnsBlock(DOMElement $element, array &$fallbacks): ?array
+    {
+        return ($this->nestedLayoutTableColumnsBlock)($element, $fallbacks);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array<string, mixed>|null
+     */
+    public function mediaLayoutTableColumnsBlock(DOMElement $element, array &$fallbacks): ?array
+    {
+        return ($this->mediaLayoutTableColumnsBlock)($element, $fallbacks);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function htmlPreservationBlock(DOMElement $element): array
+    {
+        return ($this->htmlPreservationBlock)($element);
+    }
+
+    /**
+     * @param array<int, string> $excludedProperties
+     * @param array<int, string> $excludedGeometryProperties
+     * @return array<string, mixed>
+     */
+    public function presentationAttributes(DOMElement $element, array $excludedProperties = array(), array $excludedGeometryProperties = array()): array
+    {
+        return ($this->presentationAttributes)($element, $excludedProperties, $excludedGeometryProperties);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function tableAttributes(DOMElement $element): array
+    {
+        return ($this->tableAttributes)($element);
+    }
+
+    /**
+     * @param array<string, mixed>             $attributes
+     * @param array<int, array<string, mixed>> $innerBlocks
+     * @return array<string, mixed>
+     */
+    public function createBlock(string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array
+    {
+        return ($this->createBlock)($name, $attributes, $innerBlocks, $sourceElement);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Elements/TableElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/TableElementConverter.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use DOMElement;
+
+/**
+ * Routes a source `table` to a layout projection, a native `core/table`, or a
+ * preserved core/html block.
+ *
+ * The ordering is the contract: layout-table shapes are claimed before the
+ * element is offered to data-table classification, because a table used purely
+ * for layout must become columns rather than a semantic table.
+ */
+final class TableElementConverter
+{
+    public function __construct(private readonly TableElementContext $context)
+    {
+    }
+
+    public function handles(string $tagName): bool
+    {
+        return 'table' === $tagName;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     */
+    public function convert(DOMElement $element, string $tagName, array &$fallbacks): ConversionOutcome
+    {
+        if ( ! $this->handles($tagName) ) {
+            return ConversionOutcome::unhandled();
+        }
+
+        $policy = $this->context->classificationPolicy();
+
+        if ( $policy->isNestedLayoutTableMember($element) ) {
+            return ConversionOutcome::handled($this->context->nestedLayoutTableColumnsBlock($element, $fallbacks));
+        }
+
+        if ( $policy->isMediaLayoutTable($element) ) {
+            return ConversionOutcome::handled($this->context->mediaLayoutTableColumnsBlock($element, $fallbacks));
+        }
+
+        if ( $policy->isPercentLayoutTable($element) ) {
+            return ConversionOutcome::handled($this->context->nestedLayoutTableColumnsBlock($element, $fallbacks));
+        }
+
+        $classification = $policy->classify($element);
+        if ( ! $classification['representable'] ) {
+            return ConversionOutcome::handled($this->context->htmlPreservationBlock($element));
+        }
+
+        return ConversionOutcome::handled(
+            $this->context->createBlock(
+                'core/table',
+                array_merge($this->context->presentationAttributes($element), $this->context->tableAttributes($element)),
+                array(),
+                $element
+            )
+        );
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Elements/UnsupportedElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/UnsupportedElementContext.php
@@ -1,0 +1,122 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Closure;
+use DOMElement;
+
+/**
+ * Explicit collaborator surface for {@see UnsupportedElementRecorder}.
+ */
+final class UnsupportedElementContext
+{
+    /**
+     * @param Closure(DOMElement): ?array<string, mixed>  $maybeGenerateCustomBlock
+     * @param Closure(array<string, mixed>, DOMElement): array<string, mixed> $generatedComponentBlock
+     * @param Closure(DOMElement): string                 $elementSelector
+     * @param Closure(DOMElement): array<string, mixed>   $htmlAttributes
+     * @param Closure(DOMElement): array<string, mixed>   $sourceContext
+     * @param Closure(DOMElement): array<string, mixed>   $classifyFallbackSubtree
+     * @param Closure(DOMElement): array<string, mixed>   $eventMetadata
+     * @param Closure(DOMElement): int                    $childElementCount
+     * @param Closure(DOMElement): string                 $safeFallbackHtml
+     * @param Closure(DOMElement): array<string, mixed>   $formControlMetadata
+     * @param Closure(array<string, mixed>): array<string, mixed> $buildFallbackDiagnostic
+     */
+    public function __construct(
+        private readonly Closure $maybeGenerateCustomBlock,
+        private readonly Closure $generatedComponentBlock,
+        private readonly Closure $elementSelector,
+        private readonly Closure $htmlAttributes,
+        private readonly Closure $sourceContext,
+        private readonly Closure $classifyFallbackSubtree,
+        private readonly Closure $eventMetadata,
+        private readonly Closure $childElementCount,
+        private readonly Closure $safeFallbackHtml,
+        private readonly Closure $formControlMetadata,
+        private readonly Closure $buildFallbackDiagnostic
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function maybeGenerateCustomBlock(DOMElement $element): ?array
+    {
+        return ($this->maybeGenerateCustomBlock)($element);
+    }
+
+    /**
+     * @param array<string, mixed> $generated
+     * @return array<string, mixed>
+     */
+    public function generatedComponentBlock(array $generated, DOMElement $element): array
+    {
+        return ($this->generatedComponentBlock)($generated, $element);
+    }
+
+    public function elementSelector(DOMElement $element): string
+    {
+        return ($this->elementSelector)($element);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function htmlAttributes(DOMElement $element): array
+    {
+        return ($this->htmlAttributes)($element);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function sourceContext(DOMElement $element): array
+    {
+        return ($this->sourceContext)($element);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function classifyFallbackSubtree(DOMElement $element): array
+    {
+        return ($this->classifyFallbackSubtree)($element);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function eventMetadata(DOMElement $element): array
+    {
+        return ($this->eventMetadata)($element);
+    }
+
+    public function childElementCount(DOMElement $element): int
+    {
+        return ($this->childElementCount)($element);
+    }
+
+    public function safeFallbackHtml(DOMElement $element): string
+    {
+        return ($this->safeFallbackHtml)($element);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function formControlMetadata(DOMElement $element): array
+    {
+        return ($this->formControlMetadata)($element);
+    }
+
+    /**
+     * @param array<string, mixed> $fallback
+     * @return array<string, mixed>
+     */
+    public function buildFallbackDiagnostic(array $fallback): array
+    {
+        return ($this->buildFallbackDiagnostic)($fallback);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Elements/UnsupportedElementRecorder.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/UnsupportedElementRecorder.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use DOMElement;
+
+/**
+ * Terminal step of the element dispatch chain: the element mapped to nothing
+ * native, so either generate a static-render custom block for it or record a
+ * `html_unsupported_element` fallback diagnostic.
+ *
+ * Producer link (issue #497): this is the core/html fallback decision. When the
+ * structural classifier identifies the subtree as a high-confidence
+ * `custom_block`, a generated block is emitted instead of raw core/html.
+ */
+final class UnsupportedElementRecorder
+{
+    public function __construct(private readonly UnsupportedElementContext $context)
+    {
+    }
+
+    /**
+     * Record the unsupported element.
+     *
+     * Returns a generated component block when one could be produced, otherwise
+     * appends a fallback diagnostic and returns null so the caller drops the
+     * element.
+     *
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array<string, mixed>|null
+     */
+    public function record(DOMElement $element, string $tagName, array &$fallbacks): ?array
+    {
+        $generated = $this->context->maybeGenerateCustomBlock($element);
+        if ( null !== $generated ) {
+            return $this->context->generatedComponentBlock($generated, $element);
+        }
+
+        $fallbacks[] = $this->context->buildFallbackDiagnostic($this->fallbackRow($element, $tagName));
+
+        return null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fallbackRow(DOMElement $element, string $tagName): array
+    {
+        $fallback = array(
+            'type'            => 'unsupported_element',
+            'reason'          => 'unsupported_element',
+            'diagnostic_code' => 'html_unsupported_element',
+            'source_format'   => 'html',
+            'tag'             => $tagName,
+            'selector'        => $this->context->elementSelector($element),
+            'attributes'      => $this->context->htmlAttributes($element),
+            'context'         => $this->context->sourceContext($element),
+            'classification'  => $this->context->classifyFallbackSubtree($element),
+            'events'          => $this->context->eventMetadata($element),
+            'text_length'     => strlen(trim($element->textContent ?? '')),
+            'child_count'     => $this->context->childElementCount($element),
+            'html'            => $this->context->safeFallbackHtml($element),
+        );
+
+        $control = $this->context->formControlMetadata($element);
+        if ( array() !== $control ) {
+            $fallback['control'] = $control;
+        }
+
+        return $fallback;
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -26,6 +26,10 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\DescriptionLi
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\LayoutShellBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\ResponsiveLayoutBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\ResponsiveMediaBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TableElementContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TableElementConverter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\UnsupportedElementContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\UnsupportedElementRecorder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RichTextElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RichTextElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TextLeafElementContext;
@@ -243,6 +247,10 @@ final class HtmlTransformer
 
     private readonly RichTextElementConverter $richTextConverter;
 
+    private readonly TableElementConverter $tableConverter;
+
+    private readonly UnsupportedElementRecorder $unsupportedRecorder;
+
     private readonly PatternContext $patternContext;
 
     private readonly PatternContext $patternContextWithoutRuntimeDomTarget;
@@ -355,6 +363,48 @@ final class HtmlTransformer
         $this->patternProbeContext = $this->createProbePatternContext();
         $this->textLeafConverter = new TextLeafElementConverter($this->createTextLeafElementContext());
         $this->richTextConverter = new RichTextElementConverter($this->createRichTextElementContext());
+        $this->tableConverter = new TableElementConverter($this->createTableElementContext());
+        $this->unsupportedRecorder = new UnsupportedElementRecorder($this->createUnsupportedElementContext());
+    }
+
+    /**
+     * Collaborator surface for {@see TableElementConverter}.
+     */
+    private function createTableElementContext(): TableElementContext
+    {
+        return new TableElementContext(
+            $this->tableClassificationPolicy,
+            function (DOMElement $element, array &$fallbacks): ?array {
+                return $this->nestedLayoutTableColumnsBlock($element, $fallbacks);
+            },
+            function (DOMElement $element, array &$fallbacks): ?array {
+                return $this->mediaLayoutTableColumnsBlock($element, $fallbacks);
+            },
+            fn (DOMElement $element): array => $this->htmlPreservationBlock($element),
+            fn (DOMElement $element, array $excludedProperties, array $excludedGeometryProperties): array => $this->presentationAttributes($element, $excludedProperties, $excludedGeometryProperties),
+            fn (DOMElement $element): array => $this->tableAttributes($element),
+            fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement)
+        );
+    }
+
+    /**
+     * Collaborator surface for {@see UnsupportedElementRecorder}.
+     */
+    private function createUnsupportedElementContext(): UnsupportedElementContext
+    {
+        return new UnsupportedElementContext(
+            fn (DOMElement $element): ?array => $this->fallbackEmitter()->maybeGenerateCustomBlock($element, $this->generatedBlocks()),
+            fn (array $generated, DOMElement $element): array => $this->generatedComponentBlock($generated, $element),
+            fn (DOMElement $element): string => $this->elementSelector($element),
+            fn (DOMElement $element): array => $this->htmlAttributes($element),
+            fn (DOMElement $element): array => $this->sourceContext($element),
+            fn (DOMElement $element): array => $this->fallbackEmitter()->classifyFallbackSubtree($element),
+            fn (DOMElement $element): array => $this->eventMetadata($element),
+            fn (DOMElement $element): int => $this->childElementCount($element),
+            fn (DOMElement $element): string => $this->safeFallbackHtml($element),
+            fn (DOMElement $element): array => $this->formControlMetadata($element),
+            fn (array $fallback): array => FallbackDiagnostic::build($fallback, $this->transformationProvenance()->fallback())
+        );
     }
 
     /**
@@ -3559,25 +3609,8 @@ if ( $this->isInlineContentElement($tagName) ) {
             return $this->textLeafConverter->convert($element, $tagName, $fallbacks)->block;
         }
 
-        if ( 'table' === $tagName ) {
-            if ( $this->tableClassificationPolicy->isNestedLayoutTableMember($element) ) {
-                return $this->nestedLayoutTableColumnsBlock($element, $fallbacks);
-            }
-
-            if ( $this->tableClassificationPolicy->isMediaLayoutTable($element) ) {
-                return $this->mediaLayoutTableColumnsBlock($element, $fallbacks);
-            }
-
-            if ( $this->tableClassificationPolicy->isPercentLayoutTable($element) ) {
-                return $this->nestedLayoutTableColumnsBlock($element, $fallbacks);
-            }
-
-            $classification = $this->tableClassificationPolicy->classify($element);
-            if ( ! $classification['representable'] ) {
-                return $this->htmlPreservationBlock($element);
-            }
-
-            return $this->createBlock('core/table', array_merge($this->presentationAttributes($element), $this->tableAttributes($element)), array(), $element);
+        if ( $this->tableConverter->handles($tagName) ) {
+            return $this->tableConverter->convert($element, $tagName, $fallbacks)->block;
         }
 
         $parameterTable = $this->recognizePatterns($element, $fallbacks, array(ParameterTablePattern::class));
@@ -3689,38 +3722,7 @@ if ( 'svg' === $tagName ) {
         }
 
         if ( $captureUnsupported ) {
-            // Producer link (issue #497): this is a core/html fallback decision —
-            // the element mapped to nothing native/Automattic. If the structural
-            // classifier identifies it as a high-confidence custom_block, generate
-            // a static-render block and emit a self-closing reference instead of raw
-            // core/html. Otherwise keep the existing fallback diagnostic.
-            $generated = $this->fallbackEmitter()->maybeGenerateCustomBlock($element, $this->generatedBlocks());
-            if ( null !== $generated ) {
-                return $this->generatedComponentBlock($generated, $element);
-            }
-
-            $fallback = array(
-                'type'            => 'unsupported_element',
-                'reason'          => 'unsupported_element',
-                'diagnostic_code' => 'html_unsupported_element',
-                'source_format'   => 'html',
-                'tag'             => $tagName,
-                'selector'        => $this->elementSelector($element),
-                'attributes'      => $this->htmlAttributes($element),
-                'context'         => $this->sourceContext($element),
-                'classification'  => $this->fallbackEmitter()->classifyFallbackSubtree($element),
-                'events'          => $this->eventMetadata($element),
-                'text_length'     => strlen(trim($element->textContent ?? '')),
-                'child_count'     => $this->childElementCount($element),
-                'html'            => $this->safeFallbackHtml($element),
-            );
-
-            $control = $this->formControlMetadata($element);
-            if ( array() !== $control ) {
-                $fallback['control'] = $control;
-            }
-
-            $fallbacks[] = FallbackDiagnostic::build($fallback, $this->transformationProvenance()->fallback());
+            return $this->unsupportedRecorder->record($element, $tagName, $fallbacks);
         }
 
         return null;

--- a/php-transformer/tests/unit/table-element-converter.php
+++ b/php-transformer/tests/unit/table-element-converter.php
@@ -1,0 +1,118 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * TableElementConverter routing, exercised without an HtmlTransformer.
+ *
+ * The ordering here is the contract: layout-table shapes must be claimed before
+ * the element reaches data-table classification, otherwise a table used purely
+ * for layout would become a semantic core/table.
+ */
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TableElementContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TableElementConverter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\TableClassificationPolicy;
+
+$assertions = 0;
+$failures   = array();
+$assert     = static function (bool $condition, string $label, string $detail = '') use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']' . ('' !== $detail ? ': ' . $detail : '');
+    }
+};
+
+$elementFrom = static function (string $html): DOMElement {
+    $doc = new DOMDocument();
+    $doc->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+    foreach ($doc->getElementsByTagName('body')->item(0)->childNodes as $node) {
+        if ($node instanceof DOMElement) {
+            return $node;
+        }
+    }
+    throw new RuntimeException('No element parsed');
+};
+
+$makeConverter = static function (array $overrides = array()): TableElementConverter {
+    $defaults = array(
+        'nested'      => static function (DOMElement $e, array &$f): ?array {
+            return array('blockName' => 'core/columns', 'via' => 'nested');
+        },
+        'media'       => static function (DOMElement $e, array &$f): ?array {
+            return array('blockName' => 'core/columns', 'via' => 'media');
+        },
+        'preserve'    => static fn (DOMElement $e): array => array('blockName' => 'core/html'),
+        'presentation' => static fn (DOMElement $e, array $p, array $g): array => array('className' => 'pres'),
+        'tableAttrs'  => static fn (DOMElement $e): array => array('hasFixedLayout' => true),
+        'createBlock' => static fn (string $n, array $a, array $i, ?DOMElement $s): array => array('blockName' => $n, 'attrs' => $a),
+    );
+    $c = array_merge($defaults, $overrides);
+
+    return new TableElementConverter(new TableElementContext(
+        new TableClassificationPolicy(),
+        $c['nested'],
+        $c['media'],
+        $c['preserve'],
+        $c['presentation'],
+        $c['tableAttrs'],
+        $c['createBlock']
+    ));
+};
+
+$fallbacks = array();
+$converter = $makeConverter();
+
+$assert($converter->handles('table'), 'handles-table');
+foreach (array('tr', 'td', 'div', 'p') as $tag) {
+    $assert(! $converter->handles($tag), 'does-not-handle-' . $tag);
+}
+$assert(! $converter->convert($elementFrom('<div></div>'), 'div', $fallbacks)->handled, 'unowned-tag-unhandled');
+
+// A plain data table becomes a native core/table carrying both presentation and
+// table-specific attributes.
+$dataTable = $converter->convert(
+    $elementFrom('<table><thead><tr><th>H</th></tr></thead><tbody><tr><td>1</td></tr></tbody></table>'),
+    'table',
+    $fallbacks
+)->block;
+$assert('core/table' === ($dataTable['blockName'] ?? ''), 'data-table-is-core-table');
+$assert('pres' === ($dataTable['attrs']['className'] ?? ''), 'data-table-carries-presentation-attributes');
+$assert(true === ($dataTable['attrs']['hasFixedLayout'] ?? false), 'data-table-carries-table-attributes');
+
+// A layout table nested inside another table is projected to columns and never
+// reaches data-table classification.
+$nested = $converter->convert(
+    $elementFrom('<table><tr><td><table><tr><td>inner</td></tr></table></td></tr></table>')
+        ->getElementsByTagName('table')->item(0),
+    'table',
+    $fallbacks
+)->block;
+$assert('core/columns' === ($nested['blockName'] ?? ''), 'nested-layout-table-is-columns');
+$assert('nested' === ($nested['via'] ?? ''), 'nested-layout-table-uses-nested-projection');
+
+// A spanning table is not representable as core/table and is preserved rather
+// than lossily flattened.
+$spanning = $converter->convert(
+    $elementFrom('<table><tr><td colspan="2">x</td></tr><tr><td>y</td><td>z</td></tr></table>'),
+    'table',
+    $fallbacks
+)->block;
+$assert('core/html' === ($spanning['blockName'] ?? ''), 'spanning-table-is-preserved', (string) ($spanning['blockName'] ?? 'null'));
+
+// Layout projection wins over preservation: a nested table is unrepresentable by
+// classification, but the layout branch claims it first and yields columns.
+$nestedUnrepresentable = $converter->convert(
+    $elementFrom('<table><tr><td><table><tr><td>inner</td></tr></table></td></tr></table>'),
+    'table',
+    $fallbacks
+)->block;
+$assert('core/columns' === ($nestedUnrepresentable['blockName'] ?? ''), 'layout-projection-precedes-preservation');
+
+if ($failures) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Table element converter tests: ' . $assertions . " passed\n";

--- a/php-transformer/tests/unit/unsupported-element-recorder.php
+++ b/php-transformer/tests/unit/unsupported-element-recorder.php
@@ -1,0 +1,105 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * UnsupportedElementRecorder, exercised without an HtmlTransformer.
+ *
+ * This is the terminal core/html fallback decision (issue #497). Previously it
+ * could only be observed by transforming a document containing an element that
+ * nothing else in the dispatch chain claimed.
+ */
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\UnsupportedElementContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\UnsupportedElementRecorder;
+
+$assertions = 0;
+$failures   = array();
+$assert     = static function (bool $condition, string $label, string $detail = '') use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']' . ('' !== $detail ? ': ' . $detail : '');
+    }
+};
+
+$elementFrom = static function (string $html): DOMElement {
+    $doc = new DOMDocument();
+    $doc->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+    foreach ($doc->getElementsByTagName('body')->item(0)->childNodes as $node) {
+        if ($node instanceof DOMElement) {
+            return $node;
+        }
+    }
+    throw new RuntimeException('No element parsed');
+};
+
+$makeRecorder = static function (array $overrides = array()): UnsupportedElementRecorder {
+    $defaults = array(
+        'maybeGenerate'   => static fn (DOMElement $e): ?array => null,
+        'generatedBlock'  => static fn (array $g, DOMElement $e): array => array('blockName' => 'blocks-engine/generated', 'from' => $g),
+        'selector'        => static fn (DOMElement $e): string => strtolower($e->tagName) . '.sel',
+        'htmlAttributes'  => static fn (DOMElement $e): array => array('data-x' => '1'),
+        'sourceContext'   => static fn (DOMElement $e): array => array('ctx' => true),
+        'classify'        => static fn (DOMElement $e): array => array('kind' => 'unknown'),
+        'events'          => static fn (DOMElement $e): array => array(),
+        'childCount'      => static fn (DOMElement $e): int => $e->childNodes->length,
+        'safeHtml'        => static fn (DOMElement $e): string => '<safe/>',
+        'formControl'     => static fn (DOMElement $e): array => array(),
+        'buildDiagnostic' => static fn (array $f): array => $f + array('built' => true),
+    );
+    $c = array_merge($defaults, $overrides);
+
+    return new UnsupportedElementRecorder(new UnsupportedElementContext(
+        $c['maybeGenerate'],
+        $c['generatedBlock'],
+        $c['selector'],
+        $c['htmlAttributes'],
+        $c['sourceContext'],
+        $c['classify'],
+        $c['events'],
+        $c['childCount'],
+        $c['safeHtml'],
+        $c['formControl'],
+        $c['buildDiagnostic']
+    ));
+};
+
+// A high-confidence custom block short-circuits the fallback entirely: a block
+// is returned and no diagnostic is recorded.
+$fallbacks = array();
+$generated = $makeRecorder(array('maybeGenerate' => static fn (DOMElement $e): ?array => array('name' => 'x-widget')))
+    ->record($elementFrom('<x-widget></x-widget>'), 'x-widget', $fallbacks);
+$assert('blocks-engine/generated' === ($generated['blockName'] ?? ''), 'generated-block-returned');
+$assert(array() === $fallbacks, 'generated-block-records-no-fallback');
+
+// Otherwise a fallback diagnostic is appended and the element drops.
+$fallbacks = array();
+$dropped   = $makeRecorder()->record($elementFrom('<x-thing>hello</x-thing>'), 'x-thing', $fallbacks);
+$assert(null === $dropped, 'unsupported-element-drops');
+$assert(1 === count($fallbacks), 'unsupported-element-records-one-fallback');
+
+$row = $fallbacks[0];
+$assert('html_unsupported_element' === ($row['diagnostic_code'] ?? ''), 'fallback-diagnostic-code');
+$assert('unsupported_element' === ($row['type'] ?? ''), 'fallback-type');
+$assert('unsupported_element' === ($row['reason'] ?? ''), 'fallback-reason');
+$assert('html' === ($row['source_format'] ?? ''), 'fallback-source-format');
+$assert('x-thing' === ($row['tag'] ?? ''), 'fallback-carries-tag');
+$assert('x-thing.sel' === ($row['selector'] ?? ''), 'fallback-carries-selector');
+$assert('<safe/>' === ($row['html'] ?? ''), 'fallback-carries-safe-html');
+$assert(5 === ($row['text_length'] ?? 0), 'fallback-measures-text-length');
+$assert(true === ($row['built'] ?? false), 'fallback-passes-through-diagnostic-builder');
+$assert(! array_key_exists('control', $row), 'non-control-fallback-omits-control-key');
+
+// Form-control metadata is attached only when the element actually has it.
+$fallbacks = array();
+$makeRecorder(array('formControl' => static fn (DOMElement $e): array => array('role' => 'textbox')))
+    ->record($elementFrom('<x-input></x-input>'), 'x-input', $fallbacks);
+$assert(array('role' => 'textbox') === ($fallbacks[0]['control'] ?? null), 'control-metadata-attached-when-present');
+
+if ($failures) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Unsupported element recorder tests: ' . $assertions . " passed\n";


### PR DESCRIPTION
Slice 3 for #242, workstream 1. Follows #1310 and #1312.

## What moved

**`TableElementConverter`** — the `table` branch. Ordering is the contract here: layout-table shapes (`isNestedLayoutTableMember`, `isMediaLayoutTable`, `isPercentLayoutTable`) are claimed *before* the element reaches data-table classification, so a table used purely for layout becomes columns rather than a semantic `core/table`. That precedence is now asserted directly rather than implied by statement order in a 300-line method.

`TableClassificationPolicy` was already a first-class collaborator, so it is injected as itself instead of wrapped in closures — only the transformer-owned block builders are passed as closures.

**`UnsupportedElementRecorder`** — the terminal `captureUnsupported` block that closes `convertElement()`. This is the core/html fallback decision from issue #497: generate a static-render custom block when the structural classifier is confident, otherwise record an `html_unsupported_element` diagnostic and drop the element.

## Behavior preservation

Corpus hash diff on clean `trunk` before any edit, recaptured after — `serializedBlocks` SHA-256 plus block/diagnostic/fallback counts for every fixture HTML file:

```
385 fixtures — DIFFERING: 0 — threw: 0
```

The fallback counts matter for this slice specifically: `UnsupportedElementRecorder` appends diagnostics, so an identical fallback count across the corpus is what shows the diagnostic path is unchanged, not just the block output.

`composer test` exit 0 — 289 parity fixtures, contract suite, unit suite, packaging proof.

## Coverage

Two new isolation tests, neither constructs a transformer:

- `tests/unit/table-element-converter.php` — 13 assertions. Covers that layout projection precedes preservation (a nested table is unrepresentable by classification, but the layout branch claims it first and yields columns), and that a spanning table is preserved rather than lossily flattened.
- `tests/unit/unsupported-element-recorder.php` — 15 assertions. Covers that a generated custom block short-circuits the fallback entirely with **no diagnostic recorded**, the full diagnostic row shape, and that `control` metadata is attached only when the element actually has it.

## Impact

| | trunk | after |
|---|---:|---:|
| `HtmlTransformer.php` | 12,606 | 12,608 |
| `convertElement()` | 349 | 301 |

The class grew by 2 lines — the two context factories cost slightly more than the extracted branches saved. That is the honest number and it is the point: this epic is not about shrinking the file, it is about removing methods from the transformer's `$this` scope and making them testable.

Cumulative across the three slices: `convertElement()` **441 → 301**, with 9 collaborator files and 100 isolation assertions that construct no transformer.

## Scope

`convertElement()` is still a 301-line ordered chain. What remains inline is mostly guard clauses and pattern-recognizer delegations that are already thin; the next meaningful targets are the media/anchor/inline/list/figure `convertXDispatchElement` methods, which are separate methods but still trait- or `$this`-bound.

---

*AI assistance disclosure: implemented and drafted by Claude Sonnet 4.6 running in Claude Code, operated by @chubes4. The AI captured the pre-change corpus baseline, performed both extractions, verified byte-identical `serializedBlocks` and fallback counts across 385 fixtures, and wrote the isolation tests. Reviewed by a human before opening.*
