### PR TITLE
Convert RuntimeIslandTrait into a RuntimeIslandAnalyzer collaborator (#242)

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -147,7 +147,8 @@
             "php tests/unit/text-leaf-element-converter.php",
             "php tests/unit/rich-text-element-converter.php",
             "php tests/unit/table-element-converter.php",
-            "php tests/unit/unsupported-element-recorder.php"
+            "php tests/unit/unsupported-element-recorder.php",
+            "php tests/unit/runtime-island-analyzer.php"
     ],
     "test:parity": "php tests/parity/run.php",
     "test:migration:examples": "php tests/migration/examples.php",

--- a/php-transformer/src/HtmlToBlocks/Elements/RuntimeIslandAnalyzer.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/RuntimeIslandAnalyzer.php
@@ -1,6 +1,7 @@
 <?php
+declare(strict_types=1);
 
-namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support;
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\ShellLandmarkPolicy;
 use DOMElement;
@@ -11,47 +12,76 @@ use DOMElement;
  * Decides which elements carry a runtime contract the block output cannot
  * express natively — canvas and DOM targets, app-shell roots, workspace
  * surfaces, bounded data-attribute targets — and records the islands and
- * preservation fallbacks that follow from that. Moved verbatim out of
- * HtmlTransformer under #242; behaviour is unchanged.
+ * preservation fallbacks that follow.
+ *
+ * Previously `RuntimeIslandTrait`, whose own docblock recorded that it had been
+ * "moved verbatim out of HtmlTransformer under #242". That move relocated the
+ * code without changing anything: as a single-consumer trait every method still
+ * resolved against the transformer's `$this`. Here the same logic runs against
+ * an explicit {@see RuntimeIslandContext} and is exercised without a
+ * transformer.
  */
-trait RuntimeIslandTrait
+final class RuntimeIslandAnalyzer
 {
+    /**
+     * Tags a bare runtime selector may name.
+     *
+     * @var array<int, string>
+     */
+    private const RUNTIME_TAG_SELECTORS = array( 'button', 'input', 'select', 'textarea', 'ul', 'ol', 'li', 'span', 'menu', 'menuitem' );
+
+    /**
+     * Generic class/id tokens that usually mark a JS-owned application surface
+     * rather than editorial content. Used only with runtime selector evidence.
+     *
+     * @var array<int, string>
+     */
+    private const RUNTIME_APP_ROOT_TOKENS = array(
+        'app', 'application', 'board', 'canvas', 'dashboard', 'desktop', 'editor',
+        'explorer', 'instrument', 'lab', 'playground', 'rack', 'scene', 'shell',
+        'simulator', 'stage', 'studio', 'terminal', 'viewport', 'workspace', 'world',
+    );
+
+    public function __construct(private readonly RuntimeIslandContext $context)
+    {
+    }
+
     /**
      * @param array<int, array<string, mixed>> $fallbacks
      */
-    private function captureCanvasFallback(DOMElement $element, array &$fallbacks): void
+    public function captureCanvasFallback(DOMElement $element, array &$fallbacks): void
     {
-        $this->fallbackEmitter()->captureCanvasFallback($element, $fallbacks, $this->runtimeDom());
+        $this->context->fallbackEmitter()->captureCanvasFallback($element, $fallbacks, $this->context->runtimeDom());
     }
 
-    private function isRuntimeCanvasTarget(DOMElement $element): bool
+    public function isRuntimeCanvasTarget(DOMElement $element): bool
     {
-        return $this->fallbackEmitter()->isRuntimeCanvasTarget($element);
+        return $this->context->fallbackEmitter()->isRuntimeCanvasTarget($element);
     }
 
     /**
      * @param array<string, mixed> $options
      * @return array<string, bool>
      */
-    private function runtimeCanvasSelectorsFromOptions(array $options): array
+    public function runtimeCanvasSelectorsFromOptions(array $options): array
     {
         return $this->runtimeSelectorsFromOptions($options, 'runtime_canvas_selectors');
     }
 
-    private function isRuntimeDomTarget(DOMElement $element): bool
+    public function isRuntimeDomTarget(DOMElement $element): bool
     {
-        $id = trim($this->attr($element, 'id'));
-        if ( '' !== $id && $this->runtimeSelectors()->hasDom('#' . $id) && ! $this->isPresentationalRuntimeSelector('#' . $id) ) {
+        $id = trim($this->context->attr($element, 'id'));
+        if ( '' !== $id && $this->context->runtimeSelectors()->hasDom('#' . $id) && ! $this->isPresentationalRuntimeSelector('#' . $id) ) {
             return true;
         }
 
-        foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) {
-            if ( '' !== $class && $this->runtimeSelectors()->hasDom('.' . $class) && ! $this->isPresentationalRuntimeSelector('.' . $class) ) {
+        foreach ( preg_split('/\s+/', trim($this->context->attr($element, 'class'))) ?: array() as $class ) {
+            if ( '' !== $class && $this->context->runtimeSelectors()->hasDom('.' . $class) && ! $this->isPresentationalRuntimeSelector('.' . $class) ) {
                 return true;
             }
         }
 
-        foreach ( array_keys($this->runtimeSelectors()->domSelectors()) as $selector ) {
+        foreach ( array_keys($this->context->runtimeSelectors()->domSelectors()) as $selector ) {
             if ( ! $this->isPresentationalRuntimeSelector((string) $selector) && $this->elementMatchesRuntimeSelector($element, (string) $selector) ) {
                 return true;
             }
@@ -61,22 +91,22 @@ trait RuntimeIslandTrait
     }
 
     /** @return array<int,string> */
-    private function runtimeDomSelectorsForElement(DOMElement $element): array
+    public function runtimeDomSelectorsForElement(DOMElement $element): array
     {
         $selectors = array();
-        $id = trim($this->attr($element, 'id'));
-        if ( '' !== $id && $this->runtimeSelectors()->hasDom('#' . $id) ) $selectors[] = '#' . $id;
-        foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) if ( '' !== $class && $this->runtimeSelectors()->hasDom('.' . $class) ) $selectors[] = '.' . $class;
-        foreach ( array_keys($this->runtimeSelectors()->domSelectors()) as $selector ) {
+        $id = trim($this->context->attr($element, 'id'));
+        if ( '' !== $id && $this->context->runtimeSelectors()->hasDom('#' . $id) ) $selectors[] = '#' . $id;
+        foreach ( preg_split('/\s+/', trim($this->context->attr($element, 'class'))) ?: array() as $class ) if ( '' !== $class && $this->context->runtimeSelectors()->hasDom('.' . $class) ) $selectors[] = '.' . $class;
+        foreach ( array_keys($this->context->runtimeSelectors()->domSelectors()) as $selector ) {
             if ( str_starts_with((string) $selector, '.') || str_starts_with((string) $selector, '#') || strtolower((string) $selector) === strtolower($element->tagName) ) continue;
             if ( ! $this->isPresentationalRuntimeSelector((string) $selector) && $this->elementMatchesRuntimeSelector($element, (string) $selector) ) $selectors[] = (string) $selector;
         }
         return array_values(array_unique($selectors));
     }
 
-    private function shouldPreserveRuntimeAppShell(DOMElement $element): bool
+    public function shouldPreserveRuntimeAppShell(DOMElement $element): bool
     {
-        if ( ! $this->runtimeSelectors()->hasRuntimeTargets() ) {
+        if ( ! $this->context->runtimeSelectors()->hasRuntimeTargets() ) {
             return false;
         }
 
@@ -101,13 +131,13 @@ trait RuntimeIslandTrait
     /**
      * @return array<int, array<string, mixed>>
      */
-    private function runtimeTargetsInSubtree(DOMElement $element, int $limit): array
+    public function runtimeTargetsInSubtree(DOMElement $element, int $limit): array
     {
         $targets = array();
-        foreach ( $this->descendantElements($element) as $descendant ) {
+        foreach ( $this->context->descendantElements($element) as $descendant ) {
             if ( $this->isRuntimeDomTarget($descendant) || $this->isRuntimeCanvasTarget($descendant) ) {
                 $targets[] = array_filter(array(
-                    'selector'   => $this->runtimeIslandSelector($descendant),
+                    'selector'   => $this->context->runtimeIslandSelector($descendant),
                     'tag'        => strtolower($descendant->tagName),
                     'attributes' => $this->boundedRuntimeTargetAttributes($descendant),
                 ), static fn (mixed $value): bool => '' !== $value && array() !== $value);
@@ -121,7 +151,7 @@ trait RuntimeIslandTrait
         return $targets;
     }
 
-    private function shouldRecordRuntimeHtmlSubtreeIsland(DOMElement $element): bool
+    public function shouldRecordRuntimeHtmlSubtreeIsland(DOMElement $element): bool
     {
         if ( ! in_array(strtolower($element->tagName), array( 'article', 'aside', 'div', 'main', 'section' ), true) ) {
             return false;
@@ -135,9 +165,9 @@ trait RuntimeIslandTrait
             return true;
         }
 
-        foreach ( $this->descendantElements($element) as $descendant ) {
+        foreach ( $this->context->descendantElements($element) as $descendant ) {
             $tagName = strtolower($descendant->tagName);
-            if ( 'form' === $tagName && $this->formHasDataEntryControls($descendant) ) {
+            if ( 'form' === $tagName && $this->context->formHasDataEntryControls($descendant) ) {
                 return true;
             }
             if ( in_array($tagName, array( 'canvas', 'template' ), true) ) {
@@ -151,7 +181,7 @@ trait RuntimeIslandTrait
     /**
      * @param array<int, array<string, mixed>> $blocks
      */
-    private function recordRuntimeIslandsForPreservedHtmlBlocks(array $blocks): void
+    public function recordRuntimeIslandsForPreservedHtmlBlocks(array $blocks): void
     {
         foreach ( $blocks as $block ) {
             if ( ! is_array($block) ) {
@@ -160,15 +190,15 @@ trait RuntimeIslandTrait
 
             if ( 'core/html' === ($block['blockName'] ?? '') ) {
                 $content = is_array($block['attrs'] ?? null) && is_scalar($block['attrs']['content'] ?? null) ? (string) $block['attrs']['content'] : '';
-                $element = $this->preservedHtmlRootElement($content);
+                $element = $this->context->preservedHtmlRootElement($content);
                 if ( $element instanceof DOMElement && $this->shouldRecordRuntimeHtmlSubtreeIsland($element) ) {
                     $targets = $this->runtimeTargetsInSubtree($element, 8);
                     $this->recordRuntimeIsland($element, 'app_shell', 'runtime_html_subtree', 'client_script_execution', array(
-                        'events'            => $this->eventMetadata($element),
+                        'events'            => $this->context->eventMetadata($element),
                         'target_count'      => count($targets),
                         'targets'           => $targets,
                         'app_shell_signals' => $this->runtimeAppShellSignals($element),
-                        'required_scripts'  => $this->requiredScriptsForElement($element),
+                        'required_scripts'  => $this->context->requiredScriptsForElement($element),
                     ));
                 }
             }
@@ -182,22 +212,22 @@ trait RuntimeIslandTrait
     /**
      * @return array<int, string>
      */
-    private function runtimeAppShellSignals(DOMElement $element): array
+    public function runtimeAppShellSignals(DOMElement $element): array
     {
         $signals = array();
         if ( $this->hasRuntimeAppRootToken($element) ) {
             $signals[] = 'app_root_token';
         }
-        if ( $this->hasWorkspaceSurface($element) ) {
+        if ( $this->context->hasWorkspaceSurface($element) ) {
             $signals[] = 'workspace_surface';
         }
 
         return array_values(array_unique($signals));
     }
 
-    private function hasRuntimeAppRootToken(DOMElement $element): bool
+    public function hasRuntimeAppRootToken(DOMElement $element): bool
     {
-        $tokens = preg_split('/[^A-Za-z0-9]+/', strtolower(trim($this->attr($element, 'id') . ' ' . $this->attr($element, 'class')))) ?: array();
+        $tokens = preg_split('/[^A-Za-z0-9]+/', strtolower(trim($this->context->attr($element, 'id') . ' ' . $this->context->attr($element, 'class')))) ?: array();
         foreach ( $tokens as $token ) {
             if ( in_array($token, self::RUNTIME_APP_ROOT_TOKENS, true) ) {
                 return true;
@@ -207,9 +237,9 @@ trait RuntimeIslandTrait
         return false;
     }
 
-    private function textareaIsRuntimeWorkspaceSurface(DOMElement $textarea, DOMElement $root): bool
+    public function textareaIsRuntimeWorkspaceSurface(DOMElement $textarea, DOMElement $root): bool
     {
-        if ( ! $this->isRuntimeDomTarget($textarea) || $this->hasFormAncestor($textarea) ) {
+        if ( ! $this->isRuntimeDomTarget($textarea) || $this->context->hasFormAncestor($textarea) ) {
             return false;
         }
 
@@ -217,7 +247,7 @@ trait RuntimeIslandTrait
         // pseudo-form, not an editor surface. Only a non-control target inside
         // that same candidate upgrades it to a runtime workspace.
         for ( $ancestor = $textarea->parentNode; $ancestor instanceof DOMElement; $ancestor = $ancestor->parentNode ) {
-            if ( $this->isDivBasedPseudoForm($ancestor) ) {
+            if ( $this->context->isDivBasedPseudoForm($ancestor) ) {
                 return $ancestor === $root && $this->hasNonFormControlRuntimeTarget($ancestor);
             }
             if ( $ancestor === $root ) {
@@ -228,10 +258,10 @@ trait RuntimeIslandTrait
         return true;
     }
 
-    private function hasNonFormControlRuntimeTarget(DOMElement $element): bool
+    public function hasNonFormControlRuntimeTarget(DOMElement $element): bool
     {
-        foreach ( $this->descendantElements($element) as $descendant ) {
-            if ( $this->isRuntimeDomTarget($descendant) && ! $this->isFormControlElement($descendant) ) {
+        foreach ( $this->context->descendantElements($element) as $descendant ) {
+            if ( $this->isRuntimeDomTarget($descendant) && ! $this->context->isFormControlElement($descendant) ) {
                 return true;
             }
         }
@@ -242,11 +272,11 @@ trait RuntimeIslandTrait
     /**
      * @return array<string, string>
      */
-    private function boundedRuntimeTargetAttributes(DOMElement $element): array
+    public function boundedRuntimeTargetAttributes(DOMElement $element): array
     {
         $attributes = array();
         foreach ( array( 'id', 'class', 'role', 'aria-label', 'type', 'name' ) as $name ) {
-            $value = trim($this->attr($element, $name));
+            $value = trim($this->context->attr($element, $name));
             if ( '' !== $value ) {
                 $attributes[$name] = substr($value, 0, 160);
             }
@@ -261,14 +291,14 @@ trait RuntimeIslandTrait
         return $attributes;
     }
 
-    private function shouldPreserveDataAttributeRuntimeTarget(DOMElement $element): bool
+    public function shouldPreserveDataAttributeRuntimeTarget(DOMElement $element): bool
     {
         $tagName = strtolower($element->tagName);
-        if ( in_array($tagName, array( 'canvas', 'form', 'script' ), true) || $this->isFormControlElement($element) ) {
+        if ( in_array($tagName, array( 'canvas', 'form', 'script' ), true) || $this->context->isFormControlElement($element) ) {
             return false;
         }
 
-        foreach ( array_keys($this->runtimeSelectors()->domSelectors()) as $selector ) {
+        foreach ( array_keys($this->context->runtimeSelectors()->domSelectors()) as $selector ) {
             if ( str_contains((string) $selector, '[') && $this->elementMatchesRuntimeSelector($element, (string) $selector) ) {
                 return true;
             }
@@ -277,19 +307,19 @@ trait RuntimeIslandTrait
         return false;
     }
 
-    private function isPresentationalRuntimeSelector(string $selector): bool
+    public function isPresentationalRuntimeSelector(string $selector): bool
     {
-        return $this->isPresentationalAnimationSelector($selector) && ! $this->runtimeSelectors()->hasBehavioral($selector);
+        return $this->context->isPresentationalAnimationSelector($selector) && ! $this->context->runtimeSelectors()->hasBehavioral($selector);
     }
 
-    private function elementMatchesRuntimeSelector(DOMElement $element, string $selector): bool
+    public function elementMatchesRuntimeSelector(DOMElement $element, string $selector): bool
     {
         $tag = strtolower($element->tagName);
         if ( $selector === $tag && in_array($tag, array_merge(array('canvas', 'svg'), self::RUNTIME_TAG_SELECTORS), true) ) {
             return true;
         }
         if ( preg_match('/^([a-z][a-z0-9-]*)\.([A-Za-z][A-Za-z0-9_-]*)$/', $selector, $match) ) {
-            return $tag === strtolower((string) $match[1]) && in_array((string) $match[2], preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array(), true);
+            return $tag === strtolower((string) $match[1]) && in_array((string) $match[2], preg_split('/\s+/', trim($this->context->attr($element, 'class'))) ?: array(), true);
         }
         if ( preg_match('/^(?:([a-z][a-z0-9-]*))?\[(data-[A-Za-z][A-Za-z0-9_-]*)(?:=["\'][^"\']{1,80}["\'])?\]$/', $selector, $match) ) {
             return ( '' === (string) ($match[1] ?? '') || $tag === strtolower((string) $match[1]) ) && $element->hasAttribute(strtolower((string) $match[2]));
@@ -301,36 +331,36 @@ trait RuntimeIslandTrait
     /**
      * @param array<string, mixed> $metadata
      */
-    private function recordRuntimeIsland(DOMElement $element, string $kind, string $reason, string $runtimeRequirement, array $metadata = array()): void
+    public function recordRuntimeIsland(DOMElement $element, string $kind, string $reason, string $runtimeRequirement, array $metadata = array()): void
     {
-        $this->fallbackEmitter()->recordRuntimeIsland($element, $kind, $reason, $runtimeRequirement, $metadata, $this->runtimeDom());
+        $this->context->fallbackEmitter()->recordRuntimeIsland($element, $kind, $reason, $runtimeRequirement, $metadata, $this->context->runtimeDom());
     }
 
-    private function recordNativeRuntimeDomPreservation(DOMElement $element, string $blockName, bool $includeRichTextDescendants = false): void
+    public function recordNativeRuntimeDomPreservation(DOMElement $element, string $blockName, bool $includeRichTextDescendants = false): void
     {
         $elements = array($element);
         if ($includeRichTextDescendants) {
-            foreach ($this->descendantElements($element) as $descendant) {
-                if ($this->isInlineContentElement(strtolower($descendant->tagName))) {
+            foreach ($this->context->descendantElements($element) as $descendant) {
+                if ($this->context->isInlineContentElement(strtolower($descendant->tagName))) {
                     $elements[] = $descendant;
                 }
             }
         }
         foreach ($elements as $target) {
             foreach ($this->runtimeDomSelectorsForElement($target) as $selector) {
-                $this->runtimeDom()->recordPreservation($blockName, strtolower($target->tagName), $selector);
+                $this->context->runtimeDom()->recordPreservation($blockName, strtolower($target->tagName), $selector);
             }
         }
     }
 
-    private function recordRuntimeDomFallback(DOMElement $element, string $blockName): void
+    public function recordRuntimeDomFallback(DOMElement $element, string $blockName): void
     {
         foreach ($this->runtimeDomSelectorsForElement($element) as $selector) {
-            $this->runtimeDom()->recordFallback($blockName, strtolower($element->tagName), $selector);
+            $this->context->runtimeDom()->recordFallback($blockName, strtolower($element->tagName), $selector);
         }
     }
 
-    private function canRetainRuntimeDomContractNatively(DOMElement $element, string $blockName): bool
+    public function canRetainRuntimeDomContractNatively(DOMElement $element, string $blockName): bool
     {
         if ( ! in_array($blockName, array('core/group', 'core/paragraph', 'core/heading'), true) ) {
             return false;
@@ -346,7 +376,7 @@ trait RuntimeIslandTrait
             return false;
         }
 
-        foreach ($this->descendantElements($element) as $descendant) {
+        foreach ($this->context->descendantElements($element) as $descendant) {
             if (in_array(strtolower($descendant->tagName), array('button', 'input', 'select', 'textarea', 'canvas', 'form', 'template'), true)) {
                 return false;
             }
@@ -359,7 +389,7 @@ trait RuntimeIslandTrait
      * @param array<string, mixed> $options
      * @return array<int, array<string, mixed>>
      */
-    private function runtimeScriptMetadataFromOptions(array $options): array
+    public function runtimeScriptMetadataFromOptions(array $options): array
     {
         $metadata = array();
         foreach ( $options['runtime_script_metadata'] ?? array() as $script ) {
@@ -376,14 +406,14 @@ trait RuntimeIslandTrait
             ), static fn (mixed $value): bool => '' !== $value && array() !== $value);
         }
 
-        return $this->dedupeArrayRows($metadata);
+        return $this->context->dedupeArrayRows($metadata);
     }
 
     /**
      * @param array<string, mixed> $options
      * @return array<string, bool>
      */
-    private function runtimeSelectorsFromOptions(array $options, string $key): array
+    public function runtimeSelectorsFromOptions(array $options, string $key): array
     {
         $selectors = array();
         foreach ( $options[$key] ?? array() as $selector ) {
@@ -395,7 +425,7 @@ trait RuntimeIslandTrait
         return $selectors;
     }
 
-    private function isBoundedRuntimeSelector(string $selector): bool
+    public function isBoundedRuntimeSelector(string $selector): bool
     {
         $name = '[A-Za-z][A-Za-z0-9_-]*';
         $runtimeTags = implode('|', self::RUNTIME_TAG_SELECTORS);

--- a/php-transformer/src/HtmlToBlocks/Elements/RuntimeIslandContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/RuntimeIslandContext.php
@@ -1,0 +1,159 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackEmitter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeDomState;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeSelectorState;
+use Closure;
+use DOMElement;
+
+/**
+ * Explicit collaborator surface for {@see RuntimeIslandAnalyzer}.
+ *
+ * The session state objects and the fallback emitter are resolved lazily
+ * through closures because they are per-transform: the analyzer is constructed
+ * once with the transformer, but must see the state belonging to the transform
+ * currently running.
+ */
+final class RuntimeIslandContext
+{
+    /**
+     * @param Closure(): FallbackEmitter                                      $fallbackEmitter
+     * @param Closure(): RuntimeDomState                                      $runtimeDom
+     * @param Closure(): RuntimeSelectorState                                 $runtimeSelectors
+     * @param Closure(DOMElement, string): string                             $attr
+     * @param Closure(DOMElement): iterable<DOMElement>                       $descendantElements
+     * @param Closure(DOMElement): string                                     $runtimeIslandSelector
+     * @param Closure(DOMElement): array<string, mixed>                       $eventMetadata
+     * @param Closure(DOMElement): array<int, array<string, mixed>>           $requiredScriptsForElement
+     * @param Closure(string): ?DOMElement                                    $preservedHtmlRootElement
+     * @param Closure(DOMElement): bool                                       $formHasDataEntryControls
+     * @param Closure(DOMElement): bool                                       $hasFormAncestor
+     * @param Closure(DOMElement): bool                                       $hasWorkspaceSurface
+     * @param Closure(DOMElement): bool                                       $isDivBasedPseudoForm
+     * @param Closure(DOMElement): bool                                       $isFormControlElement
+     * @param Closure(string): bool                                           $isInlineContentElement
+     * @param Closure(string): bool                                           $isPresentationalAnimationSelector
+     * @param Closure(array<int, array<string, mixed>>): array<int, array<string, mixed>> $dedupeArrayRows
+     */
+    public function __construct(
+        private readonly Closure $fallbackEmitter,
+        private readonly Closure $runtimeDom,
+        private readonly Closure $runtimeSelectors,
+        private readonly Closure $attr,
+        private readonly Closure $descendantElements,
+        private readonly Closure $runtimeIslandSelector,
+        private readonly Closure $eventMetadata,
+        private readonly Closure $requiredScriptsForElement,
+        private readonly Closure $preservedHtmlRootElement,
+        private readonly Closure $formHasDataEntryControls,
+        private readonly Closure $hasFormAncestor,
+        private readonly Closure $hasWorkspaceSurface,
+        private readonly Closure $isDivBasedPseudoForm,
+        private readonly Closure $isFormControlElement,
+        private readonly Closure $isInlineContentElement,
+        private readonly Closure $isPresentationalAnimationSelector,
+        private readonly Closure $dedupeArrayRows
+    ) {
+    }
+
+    public function fallbackEmitter(): FallbackEmitter
+    {
+        return ($this->fallbackEmitter)();
+    }
+
+    public function runtimeDom(): RuntimeDomState
+    {
+        return ($this->runtimeDom)();
+    }
+
+    public function runtimeSelectors(): RuntimeSelectorState
+    {
+        return ($this->runtimeSelectors)();
+    }
+
+    public function attr(DOMElement $element, string $name): string
+    {
+        return ($this->attr)($element, $name);
+    }
+
+    /**
+     * @return iterable<DOMElement>
+     */
+    public function descendantElements(DOMElement $element): iterable
+    {
+        return ($this->descendantElements)($element);
+    }
+
+    public function runtimeIslandSelector(DOMElement $element): string
+    {
+        return ($this->runtimeIslandSelector)($element);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function eventMetadata(DOMElement $element): array
+    {
+        return ($this->eventMetadata)($element);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function requiredScriptsForElement(DOMElement $element): array
+    {
+        return ($this->requiredScriptsForElement)($element);
+    }
+
+    public function preservedHtmlRootElement(string $html): ?DOMElement
+    {
+        return ($this->preservedHtmlRootElement)($html);
+    }
+
+    public function formHasDataEntryControls(DOMElement $element): bool
+    {
+        return ($this->formHasDataEntryControls)($element);
+    }
+
+    public function hasFormAncestor(DOMElement $element): bool
+    {
+        return ($this->hasFormAncestor)($element);
+    }
+
+    public function hasWorkspaceSurface(DOMElement $element): bool
+    {
+        return ($this->hasWorkspaceSurface)($element);
+    }
+
+    public function isDivBasedPseudoForm(DOMElement $element): bool
+    {
+        return ($this->isDivBasedPseudoForm)($element);
+    }
+
+    public function isFormControlElement(DOMElement $element): bool
+    {
+        return ($this->isFormControlElement)($element);
+    }
+
+    public function isInlineContentElement(string $tagName): bool
+    {
+        return ($this->isInlineContentElement)($tagName);
+    }
+
+    public function isPresentationalAnimationSelector(string $selector): bool
+    {
+        return ($this->isPresentationalAnimationSelector)($selector);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     * @return array<int, array<string, mixed>>
+     */
+    public function dedupeArrayRows(array $rows): array
+    {
+        return ($this->dedupeArrayRows)($rows);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -26,6 +26,8 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\DescriptionLi
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\LayoutShellBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\ResponsiveLayoutBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\ResponsiveMediaBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandAnalyzer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TableElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TableElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\UnsupportedElementContext;
@@ -83,7 +85,6 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\DomHelpersTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\ElementConversionTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\FormDispatchTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\LinkUrlSanitizer;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\RuntimeIslandTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\NavigationToggleSuppressionTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SvgMaterializationTrait;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\FontMaterializationPlanBuilder;
@@ -113,7 +114,6 @@ final class HtmlTransformer
     use FormDispatchTrait;
     use NavigationStyleProjectionTrait;
     use NavigationToggleSuppressionTrait;
-    use RuntimeIslandTrait;
     use StyleResolutionTrait;
     use SvgMaterializationTrait;
 
@@ -247,6 +247,8 @@ final class HtmlTransformer
 
     private readonly RichTextElementConverter $richTextConverter;
 
+    private readonly RuntimeIslandAnalyzer $runtimeIslands;
+
     private readonly TableElementConverter $tableConverter;
 
     private readonly UnsupportedElementRecorder $unsupportedRecorder;
@@ -363,8 +365,37 @@ final class HtmlTransformer
         $this->patternProbeContext = $this->createProbePatternContext();
         $this->textLeafConverter = new TextLeafElementConverter($this->createTextLeafElementContext());
         $this->richTextConverter = new RichTextElementConverter($this->createRichTextElementContext());
+        $this->runtimeIslands = new RuntimeIslandAnalyzer($this->createRuntimeIslandContext());
         $this->tableConverter = new TableElementConverter($this->createTableElementContext());
         $this->unsupportedRecorder = new UnsupportedElementRecorder($this->createUnsupportedElementContext());
+    }
+
+
+    /**
+     * Collaborator surface for {@see RuntimeIslandAnalyzer}. Session-scoped
+     * state is resolved lazily so the analyzer always sees the running transform.
+     */
+    private function createRuntimeIslandContext(): RuntimeIslandContext
+    {
+        return new RuntimeIslandContext(
+            fn (): FallbackEmitter => $this->fallbackEmitter(),
+            fn (): RuntimeDomState => $this->runtimeDom(),
+            fn (): RuntimeSelectorState => $this->runtimeSelectors(),
+            fn (DOMElement $element, string $name): string => $this->attr($element, $name),
+            fn (DOMElement $element): iterable => $this->descendantElements($element),
+            fn (DOMElement $element): string => $this->runtimeIslandSelector($element),
+            fn (DOMElement $element): array => $this->eventMetadata($element),
+            fn (DOMElement $element): array => $this->requiredScriptsForElement($element),
+            fn (string $html): ?DOMElement => $this->preservedHtmlRootElement($html),
+            fn (DOMElement $element): bool => $this->formHasDataEntryControls($element),
+            fn (DOMElement $element): bool => $this->hasFormAncestor($element),
+            fn (DOMElement $element): bool => $this->hasWorkspaceSurface($element),
+            fn (DOMElement $element): bool => $this->isDivBasedPseudoForm($element),
+            fn (DOMElement $element): bool => $this->isFormControlElement($element),
+            fn (string $tagName): bool => $this->isInlineContentElement($tagName),
+            fn (string $selector): bool => $this->isPresentationalAnimationSelector($selector),
+            fn (array $rows): array => $this->dedupeArrayRows($rows)
+        );
     }
 
     /**
@@ -424,7 +455,7 @@ final class HtmlTransformer
             fn (DOMElement $element): ?array => $this->authoredMarqueeBlock($element),
             fn (DOMElement $element): bool => $this->hasEmptyVisualInlineChild($element),
             fn (DOMElement $element): bool => $this->hasBoxChromeWrapperStyling($element),
-            fn (DOMElement $element): bool => $this->isRuntimeDomTarget($element),
+            fn (DOMElement $element): bool => $this->runtimeIslands->isRuntimeDomTarget($element),
             fn (string $text): array => $this->convertText($text),
             fn (string $html): string => $this->runtime->stripAllTags($html),
             function (DOMElement $element, array &$fallbacks, bool $captureUnsupported): array {
@@ -560,16 +591,16 @@ final class HtmlTransformer
             $this->assetMetadataFromOptions($options)
         ));
         $this->session->configurePolicy(! empty($options['extract_global_shell']), ! empty($options['fallback_reduction_mode']));
-        $this->runtimeBehavior()->installRuntimeScriptMetadata($this->runtimeScriptMetadataFromOptions($options));
+        $this->runtimeBehavior()->installRuntimeScriptMetadata($this->runtimeIslands->runtimeScriptMetadataFromOptions($options));
         $staticCss = (string) ($options['static_css'] ?? '');
         $styleAnalysis = $this->composedStyleAnalysis($this->stylesheetPayloads($html, $staticCss, $options));
         $this->sourceStyles()->installStylesheetAnalysis($this->detectStaticClassPromotions($html), $styleAnalysis);
         $this->resetPresentationResolutionCache();
-        $runtimeDomSelectors = $this->runtimeSelectorsFromOptions($options, 'runtime_dom_selectors');
+        $runtimeDomSelectors = $this->runtimeIslands->runtimeSelectorsFromOptions($options, 'runtime_dom_selectors');
         $this->session->installRuntimeSelectorState(new RuntimeSelectorState(
             $runtimeDomSelectors,
-            $this->runtimeSelectorsFromOptions($options, 'runtime_behavioral_selectors'),
-            $this->runtimeCanvasSelectorsFromOptions($options)
+            $this->runtimeIslands->runtimeSelectorsFromOptions($options, 'runtime_behavioral_selectors'),
+            $this->runtimeIslands->runtimeCanvasSelectorsFromOptions($options)
         ));
         $this->session->installLayoutGeometryState(new LayoutGeometryState(
             is_array($options['layout_geometry_proof']['reductions'] ?? null) ? $options['layout_geometry_proof']['reductions'] : array()
@@ -675,7 +706,7 @@ final class HtmlTransformer
         if (! $this->session->usesFallbackReductionMode()) {
             $blocks = $this->reduceCoreHtmlFallbackBlocks($blocks);
         }
-        $this->recordRuntimeIslandsForPreservedHtmlBlocks($blocks);
+        $this->runtimeIslands->recordRuntimeIslandsForPreservedHtmlBlocks($blocks);
         $this->appendInteractiveControlBehaviorLossFallbacks($body, $fallbacks);
         $this->appendProductGridFallbacks($body, $fallbacks, $blocks);
         $this->appendCommerceControlsFallbacks($body, $fallbacks);
@@ -912,7 +943,7 @@ final class HtmlTransformer
         libxml_use_internal_errors($previous);
         if ($loaded) {
             foreach ($document->getElementsByTagName('*') as $element) {
-                if ($element instanceof DOMElement && $this->isRuntimeDomTarget($element)) {
+                if ($element instanceof DOMElement && $this->runtimeIslands->isRuntimeDomTarget($element)) {
                     return null;
                 }
             }
@@ -1204,7 +1235,7 @@ final class HtmlTransformer
             && '' === trim($this->attr($element, 'role'))
             && '' === trim($this->attr($element, 'style'))
             && array() === $this->interactiveAttributes($element)
-            && ! $this->isRuntimeDomTarget($element)
+            && ! $this->runtimeIslands->isRuntimeDomTarget($element)
             && ! $this->hasMotionStructureToken($element);
     }
 
@@ -1252,11 +1283,11 @@ final class HtmlTransformer
     {
         $block = $this->createBlock($generated['blockName'], $generated['attrs'], array(), $element);
         foreach (array_merge(array($element), $this->descendantElements($element)) as $target) {
-            if (! $this->isRuntimeDomTarget($target)) {
+            if (! $this->runtimeIslands->isRuntimeDomTarget($target)) {
                 continue;
             }
             $block['_editability_runtime_owned'] = true;
-            $this->recordNativeRuntimeDomPreservation($target, $generated['blockName']);
+            $this->runtimeIslands->recordNativeRuntimeDomPreservation($target, $generated['blockName']);
         }
         return $block;
     }
@@ -3310,7 +3341,7 @@ final class HtmlTransformer
                 }
             ),
             new NavigationPatternContext(
-                $includeRuntimeDomTarget ? fn (DOMElement $sourceElement): bool => $this->isRuntimeDomTarget($sourceElement) : null,
+                $includeRuntimeDomTarget ? fn (DOMElement $sourceElement): bool => $this->runtimeIslands->isRuntimeDomTarget($sourceElement) : null,
                 fn (DOMElement $item, DOMElement $anchor): string => $this->navigationUnderlineColor($item, $anchor),
                 fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->specificityResolvedPresentationStyle($sourceElement)),
                 fn (DOMElement $sourceElement): array => $this->navigationColorInteractionStates($sourceElement),
@@ -3504,7 +3535,7 @@ final class HtmlTransformer
             return $this->capturedDialogBlock($element, $fallbacks);
         }
 
-        if ( $this->shouldPreserveDataAttributeRuntimeTarget($element) ) {
+        if ( $this->runtimeIslands->shouldPreserveDataAttributeRuntimeTarget($element) ) {
             return $this->htmlPreservationBlock($element);
         }
 
@@ -3659,11 +3690,11 @@ if ( 'svg' === $tagName ) {
         }
 
         if ( 'canvas' === $tagName ) {
-            if ( ! $this->isRuntimeCanvasTarget($element) ) {
+            if ( ! $this->runtimeIslands->isRuntimeCanvasTarget($element) ) {
                 return null;
             }
 
-            $this->recordRuntimeIsland($element, 'canvas', 'canvas_requires_runtime', 'canvas_element_and_client_script_execution', array(
+            $this->runtimeIslands->recordRuntimeIsland($element, 'canvas', 'canvas_requires_runtime', 'canvas_element_and_client_script_execution', array(
                 'script_dependency_hint' => 'Scripts may target this canvas and call canvas APIs such as getContext(); preserving the native element keeps the runtime addressable.',
                 'required_scripts'        => $this->requiredScriptsForElement($element),
             ));
@@ -3673,7 +3704,7 @@ if ( 'svg' === $tagName ) {
         if ( 'script' === $tagName ) {
             if ( $this->captureStaticScriptMetadata($element) ) {
                 if ( $this->isAddressableStaticJsonTarget($element) ) {
-                    $this->recordRuntimeIsland($element, 'static_script', 'static_script_runtime_target', 'client_script_configuration', array(
+                    $this->runtimeIslands->recordRuntimeIsland($element, 'static_script', 'static_script_runtime_target', 'client_script_configuration', array(
                         'script_role' => 'data',
                         'required_scripts' => $this->requiredScriptsForElement($element),
                     ));
@@ -3815,7 +3846,7 @@ if ( 'svg' === $tagName ) {
 
     private function isSafeTransparentCustomElement(DOMElement $element): bool
     {
-        if ( $this->isRuntimeDomTarget($element) || array() !== $this->eventMetadata($element) || $this->hasMotionStructureToken($element) ) {
+        if ( $this->runtimeIslands->isRuntimeDomTarget($element) || array() !== $this->eventMetadata($element) || $this->hasMotionStructureToken($element) ) {
             return false;
         }
 
@@ -4121,16 +4152,16 @@ if ( 'svg' === $tagName ) {
             $attrs = $this->applyDeclaredBlockSupport($name, $attrs, $sourceElement);
             $this->recordPresentationProvenance($name, $attrs, $sourceElement);
             $this->recordStructureProvenance($name, $attrs, $sourceElement);
-            if ( $this->isRuntimeDomTarget($sourceElement) && ! $this->isFormControlElement($sourceElement) && ! in_array($sourceTagName, array( 'canvas', 'form', 'script' ), true) ) {
+            if ( $this->runtimeIslands->isRuntimeDomTarget($sourceElement) && ! $this->isFormControlElement($sourceElement) && ! in_array($sourceTagName, array( 'canvas', 'form', 'script' ), true) ) {
                 $runtimeOwned = true;
-                if ( ! $this->canRetainRuntimeDomContractNatively($sourceElement, $name) ) {
-                    $this->recordRuntimeIsland($sourceElement, 'dom', 'runtime_dom_target', 'client_script_execution', array(
+                if ( ! $this->runtimeIslands->canRetainRuntimeDomContractNatively($sourceElement, $name) ) {
+                    $this->runtimeIslands->recordRuntimeIsland($sourceElement, 'dom', 'runtime_dom_target', 'client_script_execution', array(
                         'events'          => $this->eventMetadata($sourceElement),
                         'required_scripts' => $this->requiredScriptsForElement($sourceElement),
                     ));
-                    $this->recordRuntimeDomFallback($sourceElement, $name);
+                    $this->runtimeIslands->recordRuntimeDomFallback($sourceElement, $name);
                 } else {
-                    $this->recordNativeRuntimeDomPreservation($sourceElement, $name, in_array($name, array('core/paragraph', 'core/heading'), true));
+                    $this->runtimeIslands->recordNativeRuntimeDomPreservation($sourceElement, $name, in_array($name, array('core/paragraph', 'core/heading'), true));
                 }
             }
             $provenanceId = $this->transformationProvenance()->registerSource(
@@ -5593,7 +5624,7 @@ if ( 'svg' === $tagName ) {
                 continue;
             }
 
-            if ( '' === trim($sourceInline->textContent ?? '') && 0 === $this->childElementCount($sourceInline) && ! $this->isRuntimeDomTarget($sourceInline) && ! $this->shouldPreserveEmptyVisualElement($sourceInline) ) {
+            if ( '' === trim($sourceInline->textContent ?? '') && 0 === $this->childElementCount($sourceInline) && ! $this->runtimeIslands->isRuntimeDomTarget($sourceInline) && ! $this->shouldPreserveEmptyVisualElement($sourceInline) ) {
                 $targetInline->parentNode?->removeChild($targetInline);
                 continue;
             }
@@ -6052,7 +6083,7 @@ if ( 'svg' === $tagName ) {
             );
         }
 
-        if ( $this->isRuntimeDomTarget($element) ) {
+        if ( $this->runtimeIslands->isRuntimeDomTarget($element) ) {
             return array(
                 'conversion_classification' => 'runtime_island_preserved',
                 'preservation_strategy'     => 'core_block_shell_with_runtime_target',
@@ -6169,7 +6200,7 @@ if ( 'svg' === $tagName ) {
 
     private function shouldPreserveWrapper(DOMElement $element): bool
     {
-        return ShellLandmarkPolicy::isWrapperPreservingTag($element->tagName) && ( $this->isRuntimeDomTarget($element) || $this->hasAuthorSemanticMarker($element) || array() !== $this->presentationAttributes($element) || array() !== $this->structureSignals($element, array()) );
+        return ShellLandmarkPolicy::isWrapperPreservingTag($element->tagName) && ( $this->runtimeIslands->isRuntimeDomTarget($element) || $this->hasAuthorSemanticMarker($element) || array() !== $this->presentationAttributes($element) || array() !== $this->structureSignals($element, array()) );
     }
 
     /** @param array<string, mixed> $childBlock @return array<string, mixed>|null */
@@ -6181,7 +6212,7 @@ if ( 'svg' === $tagName ) {
         if ( 'div' !== strtolower($element->tagName)
             || ! in_array($childBlock['blockName'] ?? null, array('core/group', 'core/image'), true)
             || ($fullWidthTransparentShell && 'core/group' !== ($childBlock['blockName'] ?? null))
-            || $this->isRuntimeDomTarget($element)
+            || $this->runtimeIslands->isRuntimeDomTarget($element)
             || (null === $proof && $this->isDirectChildOfStructuralLayout($element))
             || '' !== trim($this->attr($element, 'id'))
             || '' !== trim($this->attr($element, 'role'))
@@ -6248,7 +6279,7 @@ if ( 'svg' === $tagName ) {
     private function proofBackedWrapperCoalescing(DOMElement $element, array &$fallbacks): ?array
     {
         $proof = $this->layoutGeometryProofFor($element);
-        if (null === $proof || $this->isRuntimeDomTarget($element) || '' !== trim($this->attr($element, 'id')) || '' !== trim($this->attr($element, 'role')) || array() !== $this->interactiveAttributes($element) || $this->hasMotionStructureToken($element)) return null;
+        if (null === $proof || $this->runtimeIslands->isRuntimeDomTarget($element) || '' !== trim($this->attr($element, 'id')) || '' !== trim($this->attr($element, 'role')) || array() !== $this->interactiveAttributes($element) || $this->hasMotionStructureToken($element)) return null;
         $children = $this->convertChildren($element, $fallbacks, true);
         if (1 !== count($children) || !in_array($children[0]['blockName'] ?? null, array('core/group', 'core/image'), true)) return null;
         $sourceChild = $this->soleElementChild($element);
@@ -6330,7 +6361,7 @@ if ( 'svg' === $tagName ) {
     private function isNeutralGroupChainWrapper(DOMElement $element): bool
     {
         if ( 'div' !== strtolower($element->tagName)
-            || $this->isRuntimeDomTarget($element)
+            || $this->runtimeIslands->isRuntimeDomTarget($element)
             || $this->isDirectChildOfStructuralLayout($element)
             || '' !== trim($this->attr($element, 'id'))
             || '' !== trim($this->attr($element, 'role'))
@@ -6692,13 +6723,13 @@ if ( 'svg' === $tagName ) {
         }
 
         if ( $this->isInlineContentElement(strtolower($element->tagName)) ) {
-            return $this->isRuntimeDomTarget($element)
+            return $this->runtimeIslands->isRuntimeDomTarget($element)
                 || in_array(strtolower($this->attr($element, 'role')), array( 'presentation', 'none' ), true)
                 || 'true' === strtolower($this->attr($element, 'aria-hidden'))
                 || $this->isEmptyVisualInlineCandidate($element);
         }
 
-        if ( $this->isRuntimeDomTarget($element)
+        if ( $this->runtimeIslands->isRuntimeDomTarget($element)
             || '' !== trim($this->attr($element, 'id'))
             || '' !== trim($this->attr($element, 'role'))
             || array() !== $this->interactiveAttributes($element)
@@ -6762,7 +6793,7 @@ if ( 'svg' === $tagName ) {
         $identity = strtolower(trim($this->attr($element, 'class') . ' ' . $this->attr($element, 'id') . ' ' . $this->attr($element, 'role')));
         if ( ! preg_match('/(?:^|[^a-z0-9])(?:search|cart)(?:[^a-z0-9]|$)/', $identity)
             || '' !== $this->renderedTextContent($element)
-            || $this->isRuntimeDomTarget($element)
+            || $this->runtimeIslands->isRuntimeDomTarget($element)
             || $this->isDirectChildOfStructuralLayout($element)
             || $this->hasAuthorInlineAlignment($element)
         ) {
@@ -6776,7 +6807,7 @@ if ( 'svg' === $tagName ) {
         }
 
         foreach ( $element->getElementsByTagName('*') as $descendant ) {
-            if ( $descendant instanceof DOMElement && $this->isRuntimeDomTarget($descendant) ) {
+            if ( $descendant instanceof DOMElement && $this->runtimeIslands->isRuntimeDomTarget($descendant) ) {
                 return false;
             }
         }
@@ -6798,7 +6829,7 @@ if ( 'svg' === $tagName ) {
         if ( 0 !== $this->childElementCount($element)
             || '' !== trim($element->textContent ?? '')
             || ! $this->sourceElementStartsHidden($element)
-            || $this->isRuntimeDomTarget($element)
+            || $this->runtimeIslands->isRuntimeDomTarget($element)
             || $this->hasConditionalStyleFamily($element, 'layout')
             || $this->hasConditionalStyleFamily($element, 'visibility')
             || $this->hasConditionalStyleFamily($element, 'opacity')
@@ -6877,7 +6908,7 @@ if ( 'svg' === $tagName ) {
         }
 
         $attrs['className'] = trim((string) ($attrs['className'] ?? '') . ' ' . self::EMPTY_FLEX_ITEM_CLASS);
-        if ( $this->isRuntimeDomTarget($element) ) {
+        if ( $this->runtimeIslands->isRuntimeDomTarget($element) ) {
             $attrs['className'] = trim($attrs['className'] . ' ' . self::EMPTY_RUNTIME_TARGET_CLASS);
             $this->runtimeBehavior()->markEmptyRuntimeTargetGenerated();
         }
@@ -7600,7 +7631,7 @@ if ( 'svg' === $tagName ) {
             if ( ! $child instanceof DOMElement ) {
                 continue;
             }
-            if ( $this->isRuntimeDomTarget($child) ) {
+            if ( $this->runtimeIslands->isRuntimeDomTarget($child) ) {
                 ++$targets;
             }
         }
@@ -8287,7 +8318,7 @@ if ( 'svg' === $tagName ) {
         if ( null === $block ) {
             return array();
         }
-        return $this->blockBinding($block, 'commerce_controls', $this->runtimeDomSelectorsForElement($control));
+        return $this->blockBinding($block, 'commerce_controls', $this->runtimeIslands->runtimeDomSelectorsForElement($control));
     }
 
     /**
@@ -8825,7 +8856,7 @@ if ( 'svg' === $tagName ) {
             return false;
         }
 
-        if ( $this->isRuntimeDomTarget($element) ) {
+        if ( $this->runtimeIslands->isRuntimeDomTarget($element) ) {
             return false;
         }
 
@@ -10370,7 +10401,7 @@ if ( 'svg' === $tagName ) {
             if ( in_array($tagName, array( 'canvas', 'iframe', 'template' ), true) ) {
                 return true;
             }
-            if ( 'textarea' === $tagName && $this->textareaIsRuntimeWorkspaceSurface($descendant, $element) ) {
+            if ( 'textarea' === $tagName && $this->runtimeIslands->textareaIsRuntimeWorkspaceSurface($descendant, $element) ) {
                 return true;
             }
             if ( '' !== trim($this->attr($descendant, 'contenteditable')) ) {
@@ -11360,7 +11391,7 @@ if ( 'svg' === $tagName ) {
     private function capturedMediaLayoutBoundaryBlock(DOMElement $element): ?array
     {
         if ( ! in_array(strtolower($element->tagName), array('main', 'article', 'section', 'div', 'figure'), true)
-            || $this->isRuntimeDomTarget($element)
+            || $this->runtimeIslands->isRuntimeDomTarget($element)
             || $this->hasRuntimeTargetInSubtree($element)
             || $this->hasLayoutGeometryProofInSubtree($element)
             || $this->sourceElementNestingDepth($element) <= self::MAX_CAPTURED_LAYOUT_SOURCE_NESTING
@@ -11502,7 +11533,7 @@ if ( 'svg' === $tagName ) {
             if (str_starts_with((string) $selector, '.') && in_array(substr((string) $selector, 1), $this->classNames($element), true)) {
                 return true;
             }
-            if ($this->elementMatchesRuntimeSelector($element, (string) $selector)) {
+            if ($this->runtimeIslands->elementMatchesRuntimeSelector($element, (string) $selector)) {
                 return true;
             }
         }
@@ -11663,7 +11694,7 @@ if ( 'svg' === $tagName ) {
             || $this->hasConditionalStyleFamily($element, 'layout')
             || $this->hasConditionalStyleFamily($element, 'visibility')
             || $this->hasConditionalStyleFamily($element, 'opacity')
-            || $this->isRuntimeDomTarget($element)
+            || $this->runtimeIslands->isRuntimeDomTarget($element)
             || '' !== trim($this->attr($element, 'src'))
             || '' !== trim($this->attr($element, 'srcdoc'))
             || '' !== trim($this->attr($element, 'name'))
@@ -12159,7 +12190,7 @@ if ( 'svg' === $tagName ) {
         }
 
         $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($iframe));
-        $this->recordRuntimeIsland($iframe, 'iframe', 'iframe_requires_embed_runtime', 'third_party_embed_runtime', array(
+        $this->runtimeIslands->recordRuntimeIsland($iframe, 'iframe', 'iframe_requires_embed_runtime', 'third_party_embed_runtime', array(
             'preservation_strategy' => 'sanitized_embed_markup',
             'attributes'            => $this->safeEmbedAttributes($iframe),
         ));

--- a/php-transformer/src/HtmlToBlocks/Support/ButtonLinkDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/ButtonLinkDispatchTrait.php
@@ -16,7 +16,7 @@ trait ButtonLinkDispatchTrait
      */
     private function convertAnchorDispatchElement(DOMElement $element, array &$fallbacks): ?array
     {
-        if ( $this->isRuntimeDomTarget($element) ) {
+        if ( $this->runtimeIslands->isRuntimeDomTarget($element) ) {
             return $this->htmlPreservationBlock($element);
         }
 
@@ -108,7 +108,7 @@ trait ButtonLinkDispatchTrait
      */
     private function convertButtonDispatchElement(DOMElement $element): ?array
     {
-        if ( $this->isRuntimeDomTarget($element) ) {
+        if ( $this->runtimeIslands->isRuntimeDomTarget($element) ) {
             $this->recordRuntimeControlIsland($element);
             return $this->htmlPreservationBlock($element);
         }

--- a/php-transformer/src/HtmlToBlocks/Support/ElementConversionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/ElementConversionTrait.php
@@ -199,7 +199,7 @@ trait ElementConversionTrait
         if ( $this->isInertHiddenSvgStorage($element) ) {
             return null;
         }
-        if ( $this->isRuntimeDomTarget($element) ) {
+        if ( $this->runtimeIslands->isRuntimeDomTarget($element) ) {
             $html = $this->sanitizeInlineSvgMarkup($element);
             if ( $this->isSafeSvgContent($html) ) {
                 return $this->createBlock('core/html', array( 'content' => $this->restoreSvgCasing($this->ensureInlineSvgBoxStyle($html, $element)) ), array(), $element);
@@ -272,7 +272,7 @@ trait ElementConversionTrait
             return $socialLinks;
         }
 
-        if ( $this->isRuntimeDomTarget($element) ) {
+        if ( $this->runtimeIslands->isRuntimeDomTarget($element) ) {
             return $this->htmlPreservationBlock($element);
         }
 
@@ -372,13 +372,13 @@ trait ElementConversionTrait
     {
         $tagName = strtolower($element->tagName);
 
-        if ( $this->shouldPreserveRuntimeAppShell($element) ) {
-            $targets = $this->runtimeTargetsInSubtree($element, 8);
-            $this->recordRuntimeIsland($element, 'app_shell', 'runtime_app_shell', 'client_script_execution', array(
+        if ( $this->runtimeIslands->shouldPreserveRuntimeAppShell($element) ) {
+            $targets = $this->runtimeIslands->runtimeTargetsInSubtree($element, 8);
+            $this->runtimeIslands->recordRuntimeIsland($element, 'app_shell', 'runtime_app_shell', 'client_script_execution', array(
                 'events'          => $this->eventMetadata($element),
                 'target_count'    => count($targets),
                 'targets'         => $targets,
-                'app_shell_signals' => $this->runtimeAppShellSignals($element),
+                'app_shell_signals' => $this->runtimeIslands->runtimeAppShellSignals($element),
                 'required_scripts' => $this->requiredScriptsForElement($element),
             ));
 

--- a/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
@@ -92,7 +92,7 @@ trait FormDispatchTrait
     private function recordFormRuntimeIsland(DOMElement $element, ?array $readableFormBlock): void
     {
         $controls = $this->formControls($element);
-        $this->recordRuntimeIsland($element, 'form', 'form_requires_runtime', 'server_or_client_form_handler', array(
+        $this->runtimeIslands->recordRuntimeIsland($element, 'form', 'form_requires_runtime', 'server_or_client_form_handler', array(
             'form'             => $this->formMetadata($element),
             'controls'         => $controls,
             'control_count'    => count($controls),
@@ -580,7 +580,7 @@ trait FormDispatchTrait
      */
     private function searchBlockFromStandaloneControl(DOMElement $element): ?array
     {
-        if ( 0 < $element->getElementsByTagName('form')->length || 0 < $element->getElementsByTagName('script')->length || array() !== $this->eventMetadata($element) || $this->isRuntimeDomTarget($element) ) {
+        if ( 0 < $element->getElementsByTagName('form')->length || 0 < $element->getElementsByTagName('script')->length || array() !== $this->eventMetadata($element) || $this->runtimeIslands->isRuntimeDomTarget($element) ) {
             return null;
         }
 
@@ -590,7 +590,7 @@ trait FormDispatchTrait
                 $inputs[] = $input;
             }
         }
-        if ( 1 !== count($inputs) || array() !== $this->eventMetadata($inputs[0]) || $this->isRuntimeDomTarget($inputs[0]) ) {
+        if ( 1 !== count($inputs) || array() !== $this->eventMetadata($inputs[0]) || $this->runtimeIslands->isRuntimeDomTarget($inputs[0]) ) {
             return null;
         }
         $controls = $this->formControlElements($element);
@@ -650,8 +650,8 @@ trait FormDispatchTrait
                 continue;
             }
 
-            if ( $this->isRuntimeDomTarget($control) ) {
-                $this->recordRuntimeIsland($control, 'control', 'runtime_dom_target', 'client_script_execution', array(
+            if ( $this->runtimeIslands->isRuntimeDomTarget($control) ) {
+                $this->runtimeIslands->recordRuntimeIsland($control, 'control', 'runtime_dom_target', 'client_script_execution', array(
                     'control'          => $this->formControlMetadata($control),
                     'events'           => $this->eventMetadata($control),
                     'required_scripts' => $this->requiredScriptsForElement($control),
@@ -761,7 +761,7 @@ trait FormDispatchTrait
                         return null;
                     }
 
-                    if ( $this->isRuntimeDomTarget($control) ) {
+                    if ( $this->runtimeIslands->isRuntimeDomTarget($control) ) {
                         $this->recordRuntimeControlIsland($control);
                         return $this->htmlPreservationBlock($element);
                     }
@@ -803,7 +803,7 @@ trait FormDispatchTrait
             return $this->htmlPreservationBlock($element);
         }
 
-        if ( $this->isRuntimeDomTarget($element) ) {
+        if ( $this->runtimeIslands->isRuntimeDomTarget($element) ) {
             $this->recordRuntimeControlIsland($element);
             return $this->htmlPreservationBlock($element);
         }
@@ -832,7 +832,7 @@ trait FormDispatchTrait
 
     private function recordRuntimeControlIsland(DOMElement $element): void
     {
-        $this->recordRuntimeIsland($element, 'control', 'runtime_dom_target', 'client_script_execution', array(
+        $this->runtimeIslands->recordRuntimeIsland($element, 'control', 'runtime_dom_target', 'client_script_execution', array(
             'control'          => $this->formControlMetadata($element),
             'events'           => $this->eventMetadata($element),
             'required_scripts' => $this->requiredScriptsForElement($element),
@@ -860,7 +860,7 @@ trait FormDispatchTrait
             return false;
         }
 
-        $this->recordRuntimeIsland($element, 'control', 'form_control_requires_runtime', 'client_form_control_runtime', array(
+        $this->runtimeIslands->recordRuntimeIsland($element, 'control', 'form_control_requires_runtime', 'client_form_control_runtime', array(
             'control'          => $this->formControlMetadata($element),
             'events'           => $this->eventMetadata($element),
             'required_scripts' => $this->requiredScriptsForElement($element),
@@ -1043,12 +1043,12 @@ trait FormDispatchTrait
 
     private function formHasRuntimeDomTargets(DOMElement $form): bool
     {
-        if ( $this->isRuntimeDomTarget($form) || $this->hasRuntimeClassSignal($form) ) {
+        if ( $this->runtimeIslands->isRuntimeDomTarget($form) || $this->hasRuntimeClassSignal($form) ) {
             return true;
         }
 
         foreach ( $this->formControlElements($form) as $control ) {
-            if ( $this->isRuntimeDomTarget($control) || $this->hasRuntimeClassSignal($control) ) {
+            if ( $this->runtimeIslands->isRuntimeDomTarget($control) || $this->hasRuntimeClassSignal($control) ) {
                 return true;
             }
         }
@@ -1085,7 +1085,7 @@ trait FormDispatchTrait
         $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($element));
         $replacesRuntimeIsland = null !== $bindingBlock;
         $bindingBlock ??= $readableFormBlock;
-        $supersededRuntimeSelectors = $this->runtimeDomSelectorsForElement($element);
+        $supersededRuntimeSelectors = $this->runtimeIslands->runtimeDomSelectorsForElement($element);
         if ( $replacesRuntimeIsland ) $supersededRuntimeSelectors[] = $this->runtimeIslandSelector($element);
 
         $finding = array(

--- a/php-transformer/tests/unit/runtime-island-analyzer.php
+++ b/php-transformer/tests/unit/runtime-island-analyzer.php
@@ -1,0 +1,184 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * RuntimeIslandAnalyzer, exercised without an HtmlTransformer.
+ *
+ * While this was `RuntimeIslandTrait` no such test was possible: every method
+ * resolved against the transformer's `$this`, so asserting "an id matching a
+ * behavioral runtime selector is a DOM target, but the same id matching only a
+ * presentational animation selector is not" required transforming a document
+ * with the right script evidence and stylesheet attached.
+ */
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandAnalyzer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeDomState;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeSelectorState;
+
+$assertions = 0;
+$failures   = array();
+$assert     = static function (bool $condition, string $label, string $detail = '') use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']' . ('' !== $detail ? ': ' . $detail : '');
+    }
+};
+
+$elementFrom = static function (string $html): DOMElement {
+    $doc = new DOMDocument();
+    $doc->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+    foreach ($doc->getElementsByTagName('body')->item(0)->childNodes as $node) {
+        if ($node instanceof DOMElement) {
+            return $node;
+        }
+    }
+    throw new RuntimeException('No element parsed');
+};
+
+$descendants = static function (DOMElement $element): array {
+    $out = array();
+    foreach ($element->getElementsByTagName('*') as $node) {
+        if ($node instanceof DOMElement) {
+            $out[] = $node;
+        }
+    }
+    return $out;
+};
+
+/**
+ * @param array<int,string> $domSelectors
+ * @param array<int,string> $presentationalSelectors
+ */
+$makeAnalyzer = static function (array $domSelectors = array(), array $presentationalSelectors = array(), array $overrides = array()) use ($descendants): RuntimeIslandAnalyzer {
+    // Behavioral evidence mirrors the DOM selectors unless a selector is
+    // declared presentational-only, which is exactly the distinction
+    // isPresentationalRuntimeSelector() exists to make.
+    $behavioral = array();
+    foreach ($domSelectors as $selector) {
+        if ( ! in_array($selector, $presentationalSelectors, true) ) {
+            $behavioral[$selector] = true;
+        }
+    }
+    $selectors = new RuntimeSelectorState(
+        array_fill_keys($domSelectors, true),
+        $behavioral,
+        array()
+    );
+
+    $defaults = array(
+        'fallbackEmitter'  => static fn () => throw new RuntimeException('fallbackEmitter not expected in this test'),
+        'runtimeDom'       => static fn (): RuntimeDomState => new RuntimeDomState(),
+        'runtimeSelectors' => static fn (): RuntimeSelectorState => $selectors,
+        'attr'             => static fn (DOMElement $e, string $n): string => $e->getAttribute($n),
+        'descendants'      => $descendants,
+        'islandSelector'   => static fn (DOMElement $e): string => strtolower($e->tagName),
+        'eventMetadata'    => static fn (DOMElement $e): array => array(),
+        'requiredScripts'  => static fn (DOMElement $e): array => array(),
+        'preservedRoot'    => static fn (string $h): ?DOMElement => null,
+        'formHasEntry'     => static fn (DOMElement $e): bool => false,
+        'hasFormAncestor'  => static fn (DOMElement $e): bool => false,
+        'hasWorkspace'     => static fn (DOMElement $e): bool => false,
+        'isPseudoForm'     => static fn (DOMElement $e): bool => false,
+        'isFormControl'    => static fn (DOMElement $e): bool => in_array(strtolower($e->tagName), array('input', 'select', 'textarea', 'button'), true),
+        'isInline'         => static fn (string $t): bool => in_array($t, array('span', 'em', 'strong', 'a'), true),
+        'isPresentational' => static fn (string $s): bool => in_array($s, $presentationalSelectors, true),
+        'dedupe'           => static fn (array $rows): array => array_values($rows),
+    );
+    $c = array_merge($defaults, $overrides);
+
+    return new RuntimeIslandAnalyzer(new RuntimeIslandContext(
+        $c['fallbackEmitter'],
+        $c['runtimeDom'],
+        $c['runtimeSelectors'],
+        $c['attr'],
+        $c['descendants'],
+        $c['islandSelector'],
+        $c['eventMetadata'],
+        $c['requiredScripts'],
+        $c['preservedRoot'],
+        $c['formHasEntry'],
+        $c['hasFormAncestor'],
+        $c['hasWorkspace'],
+        $c['isPseudoForm'],
+        $c['isFormControl'],
+        $c['isInline'],
+        $c['isPresentational'],
+        $c['dedupe']
+    ));
+};
+
+// An id or class named by a runtime selector is a DOM target.
+$byId = $makeAnalyzer(array('#mount'));
+$assert($byId->isRuntimeDomTarget($elementFrom('<div id="mount"></div>')), 'id-selector-is-runtime-target');
+$assert(! $byId->isRuntimeDomTarget($elementFrom('<div id="other"></div>')), 'unlisted-id-is-not-runtime-target');
+
+$byClass = $makeAnalyzer(array('.widget'));
+$assert($byClass->isRuntimeDomTarget($elementFrom('<div class="a widget b"></div>')), 'class-selector-is-runtime-target');
+
+// A selector that is only presentational animation evidence does not make the
+// element a runtime target. This is the distinction that keeps CSS-animated
+// decoration out of runtime-island preservation.
+$presentational = $makeAnalyzer(array('#mount'), array('#mount'));
+$assert(! $presentational->isRuntimeDomTarget($elementFrom('<div id="mount"></div>')), 'presentational-only-selector-is-not-runtime-target');
+
+// Bounded selector grammar: shapes the analyzer will accept as runtime evidence.
+$grammar = $makeAnalyzer();
+foreach (array('#app', '.panel', 'div.panel', '[data-widget]', 'div[data-widget]', 'canvas', 'svg', 'button') as $ok) {
+    $assert($grammar->isBoundedRuntimeSelector($ok), 'bounded-selector-' . $ok);
+}
+foreach (array('div > span', '*', 'div:hover', '', 'div p') as $bad) {
+    $assert(! $grammar->isBoundedRuntimeSelector($bad), 'unbounded-selector-rejected-' . ($bad === '' ? 'empty' : $bad));
+}
+
+// Attribute-selector matching drives data-attribute preservation, but never for
+// canvas, form, script, or form controls.
+$dataAttr = $makeAnalyzer(array('[data-widget]'));
+$assert($dataAttr->shouldPreserveDataAttributeRuntimeTarget($elementFrom('<div data-widget="1"></div>')), 'data-attribute-target-preserved');
+$assert(! $dataAttr->shouldPreserveDataAttributeRuntimeTarget($elementFrom('<canvas data-widget="1"></canvas>')), 'canvas-excluded-from-data-attribute-preservation');
+$assert(! $dataAttr->shouldPreserveDataAttributeRuntimeTarget($elementFrom('<form data-widget="1"></form>')), 'form-excluded-from-data-attribute-preservation');
+$assert(! $dataAttr->shouldPreserveDataAttributeRuntimeTarget($elementFrom('<input data-widget="1">')), 'form-control-excluded-from-data-attribute-preservation');
+
+// Bounded attribute capture is truncated and keeps data-* alongside identity.
+$attrs = $makeAnalyzer()->boundedRuntimeTargetAttributes($elementFrom('<div id="i" class="c" role="tab" data-k="' . str_repeat('x', 300) . '"></div>'));
+$assert('i' === ($attrs['id'] ?? ''), 'bounded-attributes-keep-id');
+$assert('tab' === ($attrs['role'] ?? ''), 'bounded-attributes-keep-role');
+$assert(160 === strlen($attrs['data-k'] ?? ''), 'bounded-attributes-truncate-to-160');
+
+// An app-shell root needs both multiple runtime targets and a root token; a
+// generic wrapper with targets but no token is not a shell.
+$shell = $makeAnalyzer(array('.target'));
+$assert(
+    ! $shell->shouldPreserveRuntimeAppShell($elementFrom('<div class="wrapper"><span class="target"></span><span class="target"></span></div>')),
+    'targets-without-app-root-token-are-not-a-shell'
+);
+$assert(
+    $shell->shouldPreserveRuntimeAppShell($elementFrom('<div id="workspace"><span class="target"></span><span class="target"></span></div>')),
+    'app-root-token-with-targets-is-a-shell'
+);
+$assert(
+    ! $shell->shouldPreserveRuntimeAppShell($elementFrom('<div id="workspace"><span class="target"></span></div>')),
+    'single-target-is-not-a-shell'
+);
+
+// A global shell landmark is never treated as a runtime app shell.
+$assert(
+    ! $shell->shouldPreserveRuntimeAppShell($elementFrom('<header id="workspace"><span class="target"></span><span class="target"></span></header>')),
+    'global-shell-landmark-is-not-a-runtime-app-shell'
+);
+
+// Native retention is limited to semantic wrappers with no interactive descendants.
+$retain = $makeAnalyzer();
+$assert($retain->canRetainRuntimeDomContractNatively($elementFrom('<section><p>text</p></section>'), 'core/group'), 'semantic-wrapper-retains-natively');
+$assert(! $retain->canRetainRuntimeDomContractNatively($elementFrom('<div><p>text</p></div>'), 'core/group'), 'generic-div-does-not-retain-natively');
+$assert(! $retain->canRetainRuntimeDomContractNatively($elementFrom('<section><button>go</button></section>'), 'core/group'), 'interactive-descendant-blocks-native-retention');
+$assert(! $retain->canRetainRuntimeDomContractNatively($elementFrom('<section><p>t</p></section>'), 'core/image'), 'unsupported-block-name-does-not-retain');
+
+if ($failures) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Runtime island analyzer tests: ' . $assertions . " passed\n";


### PR DESCRIPTION
Slice 4 for #242, workstream 1. Follows #1310, #1312, #1315.

This one converts an actual trait, which is the argument the previous three slices were building toward.

## Why this trait

`RuntimeIslandTrait`'s own docblock said it best:

> Moved verbatim out of HtmlTransformer under #242; behaviour is unchanged.

It was one of the extractions this epic already performed. As a **single-consumer trait**, that move relocated 404 lines across a file boundary while every method still resolved against the transformer's `$this`. Nothing left the object scope, nothing became testable, and two agents editing runtime-island logic and transformer logic still collided.

Measured before this PR, 7 of the 8 traits mixed into `HtmlTransformer` have exactly one consumer, totalling 8,483 lines. Only `DomHelpersTrait` (4 consumers) is doing real reuse.

## What changed

`RuntimeIslandAnalyzer` runs the same logic against an explicit `RuntimeIslandContext` of 17 operations. Session-scoped collaborators (`FallbackEmitter`, `RuntimeDomState`, `RuntimeSelectorState`) are resolved through closures because they are per-transform — the analyzer is built once with the transformer but must see the state of the transform currently running.

**No forwarding shims.** All 61 call sites were migrated to the collaborator:

| | call sites |
|---|---:|
| `HtmlTransformer` | 41 |
| `FormDispatchTrait` | 12 |
| `ElementConversionTrait` | 6 |
| `ButtonLinkDispatchTrait` | 2 |

The trait file is deleted, not hollowed out. `RUNTIME_TAG_SELECTORS` and `RUNTIME_APP_ROOT_TOKENS` moved onto the analyzer with it.

## Behavior preservation

Corpus hash diff on clean `trunk` before any edit, recaptured after — `serializedBlocks` SHA-256 plus block/diagnostic/fallback counts:

```
385 fixtures — DIFFERING: 0 — threw: 0
```

Fallback and diagnostic counts matter here: this code records runtime islands and preservation fallbacks, so identical counts are what show the diagnostic path is unchanged.

`composer test` exit 0.

## Coverage

`tests/unit/runtime-island-analyzer.php` — 32 assertions, constructs no transformer. The distinction it pins down was previously unreachable without a full document plus script evidence plus a stylesheet:

- an id matching a **behavioral** runtime selector is a DOM target
- the same id matching only a **presentational animation** selector is not

That is what keeps CSS-animated decoration out of runtime-island preservation, and it had no direct test. Also covered: the bounded selector grammar (accepted and rejected shapes), data-attribute preservation exclusions for `canvas`/`form`/`script`/form controls, 160-char attribute truncation, app-shell detection needing both multiple targets *and* a root token, and native retention being limited to semantic wrappers with no interactive descendants.

## Impact

| | trunk | after |
|---|---:|---:|
| `HtmlTransformer.php` | 12,619 | 12,650 |
| single-consumer trait lines | 8,483 | 8,079 |

`HtmlTransformer.php` is 31 lines larger — the context factory costs more than the `use` statement it replaced. The file size is not the metric. 404 lines of runtime-island decision logic left the transformer's object scope and gained 32 assertions.

Cumulative across the four slices: `convertElement()` **441 → 301**, 11 collaborator files, **132 isolation assertions**, one trait eliminated.

## Scope

Six single-consumer traits remain: `StyleResolutionTrait` (2,822), `FormDispatchTrait` (1,865), `NavigationStyleProjectionTrait` (1,319), `SvgMaterializationTrait` (983), `NavigationToggleSuppressionTrait` (781), `ElementConversionTrait` (594), `ButtonLinkDispatchTrait` (119). `ButtonLinkDispatchTrait` is the natural next one — smallest, and it already depends on the analyzer this PR introduces.

---

*AI assistance disclosure: implemented and drafted by Claude Sonnet 4.6 running in Claude Code, operated by @chubes4. The AI captured the pre-change corpus baseline, converted the trait, migrated all 61 call sites, verified byte-identical `serializedBlocks` and fallback counts across 385 fixtures, and wrote the isolation test. Reviewed by a human before opening.*
