### PR TITLE
Preserve inherited header anchor typography

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -4292,8 +4292,8 @@ if ( 'svg' === $tagName ) {
     }
 
     /**
-     * A linked text logo becomes a paragraph for valid block markup. Carry the
-     * source anchor's exact header winners onto the saved inner anchor instead
+     * A linked text logo becomes a paragraph for valid block markup. Carry
+     * non-inherited header anchor behavior onto the saved inner anchor instead
      * of re-pointing its source selector at a higher-specificity target.
      *
      * @param array<string, mixed> $attrs
@@ -4326,13 +4326,6 @@ if ( 'svg' === $tagName ) {
                 $declarations[$property] = $this->resolveCssVariablesInValue($value);
             }
         }
-        foreach ( array( 'font-family', 'font-size', 'font-style', 'letter-spacing', 'line-height', 'text-transform', 'white-space' ) as $property ) {
-            $value = $this->styleResolver->authoredInheritedPropertyWinner($anchor, $property);
-            if ( '' !== $value && ! str_contains(strtolower($value), '!important') ) {
-                $declarations[$property] = $value;
-            }
-        }
-
         if ( array() === $declarations ) {
             return;
         }

--- a/php-transformer/tests/unit/author-selector-semantics.php
+++ b/php-transformer/tests/unit/author-selector-semantics.php
@@ -245,6 +245,22 @@ $assert(
     'synthetic header anchor stays uncoloured when source does not state inherit'
 );
 
+$inheritedHeaderTypography = $transform(
+    '<style>.label{font-family:Georgia;font-size:18px;font-style:italic;letter-spacing:.05em;line-height:1.4;text-transform:uppercase;white-space:nowrap}.brand{display:inline-flex}</style>'
+        . '<header><div class="label"><a class="brand" href="/">Brand</a></div></header>'
+);
+$inheritedHeaderTypographyMarkup = (string) ($inheritedHeaderTypography['serialized_blocks'] ?? '');
+$inheritedHeaderTypographyCss = $css($inheritedHeaderTypography);
+preg_match('/p\.(blocks-engine-synthetic-header-anchor-[a-f0-9]+)>a\{([^}]*)\}/', $inheritedHeaderTypographyCss, $inheritedHeaderTypographyRule);
+$inheritedHeaderTypographyCarrier = (string) ($inheritedHeaderTypographyRule[2] ?? '');
+$assert(
+    str_contains($inheritedHeaderTypographyMarkup, 'wp-block-group label')
+        && str_contains($inheritedHeaderTypographyCss, '.label{font-family:Georgia;font-size:18px')
+        && str_contains($inheritedHeaderTypographyCarrier, 'display:inline-flex')
+        && ! preg_match('/(?:font-family|font-size|font-style|letter-spacing|line-height|text-transform|white-space):/', $inheritedHeaderTypographyCarrier),
+    'header anchor carrier leaves typography to the reconstructed ancestor chain while retaining non-inherited layout'
+);
+
 $mediaLogo = $transform('<a id="brand" href="/"><picture><img src="logo.png" alt=""></picture><span>Brand</span></a>');
 $mediaLogoMarkup = (string) ($mediaLogo['serialized_blocks'] ?? '');
 $assert(


### PR DESCRIPTION
## Summary

- stop synthetic header-anchor carriers from pinning inherited typography onto the inner anchor
- let typography inherit from the reconstructed source ancestor chain
- retain explicit inherited color plus non-inherited layout and gap carriers
- add a regression covering inherited brand typography with carried anchor layout

Fixes #1320

## Verification

- `php tests/unit/author-selector-semantics.php` (100 assertions)
- `composer test`
- `composer validate --strict`
- `php tests/contract/production-acceptance-matrix.php`

*AI assistance disclosure: implemented with gpt-5.6-terra via OpenCode. The model implemented and tested the inherited typography fix; I reviewed the diff, reran repository gates, and published the branch and PR.*
