### PR TITLE
Preserve resolved button radius and padding

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -3434,7 +3434,7 @@ final class HtmlTransformer
             ),
             new ButtonPatternContext(
                 fn (DOMElement $anchor): ?array => $this->fileBlockFromAnchor($anchor),
-                fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->styleResolver->mergedPresentationStyle($sourceElement)),
+                fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->styleResolver->specificityResolvedPresentationStyle($sourceElement)),
                 fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement),
                 fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content),
                 fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name),
@@ -4557,9 +4557,6 @@ if ( 'svg' === $tagName ) {
                 }
                 if ( '' === trim((string) ($style['border']['width'] ?? '')) ) {
                     $declarations[] = 'border-width:0!important';
-                }
-                if ( '' === trim((string) ($style['border']['radius'] ?? '')) ) {
-                    $declarations[] = 'border-radius:0!important';
                 }
             }
             $height = $this->cssComparableValue((string) ($sourceDeclarations['height'] ?? ''));

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonStyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonStyleResolver.php
@@ -86,9 +86,6 @@ final class ButtonStyleResolver
 
         $border = is_array($mapped['border'] ?? null) ? $mapped['border'] : array();
         if ( array() !== $border ) {
-            if ( '' === trim((string) ($border['radius'] ?? '')) && ! isset($declarations['border-radius']) ) {
-                $border['radius'] = '0';
-            }
             $style['border'] = $border;
         }
 

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
@@ -104,14 +104,6 @@ final class ButtonsPattern
         $resolvedPresentation = trim($buttons->resolvedStyle($presentationElement));
         $hasAuthoredStyleRules = $resolvedPresentation !== trim($presentationElement->getAttribute('style'));
         $attrs = $this->buttonPresentationAttributes($presentationElement, $context, $buttons);
-        if ( $presentationElement !== $anchor ) {
-            $anchorStyle = $buttons->resolvedStyle($anchor);
-            if ( preg_match('/(?:^|;)\s*border\s*:\s*(?!0(?:;|$)|none(?:;|$))[^;]+/i', $anchorStyle)
-                && ! preg_match('/(?:^|;)\s*border-radius\s*:/i', $anchorStyle)
-            ) {
-                $attrs['style']['border']['radius'] = '0';
-            }
-        }
         // core/button only saves className on its wrapper. Anchor-root selectors
         // are projected through the generated control marker onto the saved link.
         if ( $hasAuthoredStyleRules && ($presentationElement === $anchor || $presentationElement->parentNode === $anchor) ) {
@@ -352,20 +344,9 @@ final class ButtonsPattern
                 $attrs['className'] = 'is-style-outline';
             }
             $attrs['style']['color']['background'] = 'transparent';
-            if ( ! $this->hasBorderRadius($attrs) ) {
-                $attrs['style']['border']['radius'] = '0';
-            }
         }
 
         return $attrs;
-    }
-
-    /**
-     * @param array<string, mixed> $attrs
-     */
-    private function hasBorderRadius(array $attrs): bool
-    {
-        return '' !== trim((string) ($attrs['style']['border']['radius'] ?? ''));
     }
 
     private function mergeClassNames(string ...$classNames): string

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1140,7 +1140,7 @@ $outlineButtonMarkup = (string) ($outlineButton['serialized_blocks'] ?? '');
 $outlineButtonCss = implode("\n", array_column($outlineButton['assets'] ?? array(), 'content'));
 $assert(str_contains($outlineButtonMarkup, '<!-- wp:button'), 'styled anchor with presentational span materializes as core/button');
 $assert(str_contains($outlineButtonCss, 'background-color:transparent'), 'outline button carries transparent background to suppress default theme fill');
-$assert(str_contains($outlineButtonCss, 'border-radius:0'), 'outline button with no source radius carries square radius to suppress default rounded inner button chrome');
+$assert(! str_contains($outlineButtonCss, 'border-radius:0'), 'outline button does not infer a square radius from its border declarations');
 $assert(! str_contains($outlineButtonMarkup, '<div class="wp-block-button btn btn-secondary'), 'outline button with native styles avoids duplicating source button chrome on the outer wrapper');
 $assert(! str_contains($outlineButtonMarkup, '<span>Tickets</span>'), 'button label unwraps presentational span to avoid nested default styling');
 
@@ -1238,7 +1238,7 @@ $assert(str_contains($fullWidthNativeButtonCss, '.wp-block-buttons){display:bloc
 $assert('pass' === ($fullWidthNativeButton['source_reports']['wp_block_validity']['status'] ?? ''), 'styled full-width native button wrapper chain remains editor-valid');
 
 $contextualSurfaceButton = ( new HtmlTransformer() )->transform(
-    '<style>.cta{display:inline-block;border:1px solid #000}.cta .cta-inner{display:inline-block;min-width:170px;padding:22px 26px;background-color:#00ff8e;color:#000;font-size:16px;line-height:1;font-weight:700}.highlight .cta-inner{background:#fff;color:#000}</style><div style="text-align:center"><a class="cta highlight" href="/learn"><span class="cta-inner">Learn more</span></a></div>'
+    '<style>.cta{display:inline-block;border:1px solid #000}.cta .cta-inner{display:inline-block;min-width:170px;padding:22px 26px;border-radius:0;background-color:#00ff8e;color:#000;font-size:16px;line-height:1;font-weight:700}.highlight .cta-inner{background:#fff;color:#000}</style><div style="text-align:center"><a class="cta highlight" href="/learn"><span class="cta-inner">Learn more</span></a></div>'
 )->toArray();
 $contextualSurfaceButtonAttrs = $contextualSurfaceButton['blocks'][0]['innerBlocks'][0]['attrs'] ?? array();
 $contextualSurfaceButtonCss = implode("\n", array_map(static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '', $contextualSurfaceButton['assets'] ?? array()));

--- a/php-transformer/tests/unit/author-selector-semantics.php
+++ b/php-transformer/tests/unit/author-selector-semantics.php
@@ -426,7 +426,7 @@ $assert(str_contains($linkedRichTextMarkerMarkup, '<a href="/"><mark class="labe
 
 $resetRoleButton = ( new HtmlTransformer() )->transform('<style>a{background:0 0;border:0}.label{font-size:25px}</style><a role="button"><span class="label">Contact</span></a>')->toArray();
 $resetRoleButtonCss = implode("\n", array_map(static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '', $resetRoleButton['assets'] ?? array()));
-$assert(str_contains($resetRoleButtonCss, 'background-color:transparent!important') && str_contains($resetRoleButtonCss, 'border-style:none!important') && str_contains($resetRoleButtonCss, 'border-width:0!important') && str_contains($resetRoleButtonCss, 'border-radius:0!important'), 'native button protection carries explicit source reset chrome past later theme defaults');
+$assert(str_contains($resetRoleButtonCss, 'background-color:transparent!important') && str_contains($resetRoleButtonCss, 'border-style:none!important') && str_contains($resetRoleButtonCss, 'border-width:0!important') && ! str_contains($resetRoleButtonCss, 'border-radius:0!important'), 'native button protection carries only the properties reset by the source border declaration past later theme defaults');
 $assert(str_contains($selectorIdentityMarkup, '<a href="/plain">Plain link</a>') && ! str_contains($selectorIdentityMarkup, '<a class="" href="/plain"'), 'plain links remain native links without invented source identity');
 $emptyAccessibleLink = $transform('<a class="logo-link" id="site-logo" data-kind="brand" href="/" aria-label="Home"></a>');
 $emptyAccessibleLinkMarkup = (string) ($emptyAccessibleLink['serialized_blocks'] ?? '');

--- a/php-transformer/tests/unit/button-style-resolver.php
+++ b/php-transformer/tests/unit/button-style-resolver.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ButtonStyleResolver;
 
 $failures = 0;
 $passes   = 0;
@@ -104,6 +105,15 @@ $explicitButtonAttrs = $explicitButton['blocks'][0]['innerBlocks'][0]['innerBloc
 $assert(! isset($explicitButtonAttrs['style']['color']['text']) && str_contains($explicitCss, 'color:#102030'), 'explicit anchor color remains authoritative over inherited color through CSS', $explicitMarkup);
 $assert(str_contains($explicitCss, 'text-align:end!important') && ! str_contains($explicitCss, 'text-align:start!important'), 'explicit anchor alignment remains authoritative over inherited alignment', $explicitCss);
 $assert('pass' === ($explicitButton['source_reports']['wp_block_validity']['status'] ?? ''), 'explicit native button remains editor-valid', json_encode($explicitButton['source_reports']['wp_block_validity'] ?? array()));
+
+$resetButton = ( new HtmlTransformer() )->transform(
+    '<style>.cta{padding:13.5px 27px;border-radius:56.25px;background:#123456;color:#fff}a{border:0;padding:0}</style><a class="cta" href="/quote">Quote</a>'
+)->toArray();
+$resetButtonCss = implode("\n", array_column($resetButton['assets'] ?? array(), 'content'));
+$assert(str_contains($resetButtonCss, 'border-radius:56.25px!important') && str_contains($resetButtonCss, 'padding-right:27px!important') && str_contains($resetButtonCss, 'padding-left:27px!important'), 'resolved button styling overrides an authored border and padding reset', $resetButtonCss);
+
+$squareButtonStyle = ( new ButtonStyleResolver() )->nativeAttributes('border:0;padding:0;border-radius:0');
+$assert('0' === ($squareButtonStyle['style']['border']['radius'] ?? '') && '0' === ($squareButtonStyle['style']['spacing']['padding']['left'] ?? '') && '0' === ($squareButtonStyle['style']['spacing']['padding']['right'] ?? ''), 'explicit zero button radius and padding remain preserved', json_encode($squareButtonStyle));
 
 foreach ( array(
     '/contact' => array( '', '' ),


### PR DESCRIPTION
## Summary

- resolve promoted button presentation through the specificity-aware source cascade
- preserve real padding when a generic reset is overridden by a component rule
- stop inferring `border-radius: 0` from `border` declarations, including outline and nested-surface paths
- preserve explicit zero radius and padding declarations

Fixes #1321

## Verification

- `php tests/unit/button-style-resolver.php` (45 assertions)
- `php tests/unit/author-selector-semantics.php` (99 assertions)
- `php tests/contract/run.php`
- `composer test`
- `composer validate --strict`
- `php tests/contract/production-acceptance-matrix.php`

*AI assistance disclosure: implemented with gpt-5.6-terra via OpenCode. The model implemented and tested the CSS-cascade and radius inference fixes; I reviewed the diff, reran repository gates, and published the branch and PR.*
