### PR TITLE
Lower captured disclosure dialogs without details geometry

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -3736,6 +3736,11 @@ if ( $this->isInlineContentElement($tagName) ) {
         }
 
         if ( 'details' === $tagName ) {
+            $capturedDisclosureDialog = $this->capturedDisclosureDialog($element);
+            if ( $capturedDisclosureDialog instanceof DOMElement ) {
+                return $this->capturedDialogBlock($capturedDisclosureDialog, $fallbacks);
+            }
+
             return $this->recognizePatterns($element, $fallbacks, array(DetailsPattern::class));
         }
 
@@ -4087,6 +4092,61 @@ if ( 'svg' === $tagName ) {
             'innerHTML' => $opening . '</dialog>',
             'innerContent' => $innerContent,
         );
+    }
+
+    /**
+     * An empty native details summary is sometimes capture scaffolding for an
+     * adjacent dialog. A core/details block gives that otherwise invisible
+     * trigger WordPress's default summary geometry, so preserve the bounded
+     * dialog as a closed native dialog instead.
+     */
+    private function capturedDisclosureDialog(DOMElement $element): ?DOMElement
+    {
+        $summary = null;
+        $dialog = null;
+
+        foreach ( $element->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType ) {
+                if ( '' !== trim(str_replace("\xc2\xa0", ' ', $child->textContent ?? '')) ) {
+                    return null;
+                }
+                continue;
+            }
+
+            if ( ! $child instanceof DOMElement ) {
+                return null;
+            }
+
+            $tagName = strtolower($child->tagName);
+            if ( 'summary' === $tagName && ! $summary instanceof DOMElement ) {
+                $summary = $child;
+                continue;
+            }
+
+            if ( 'dialog' === strtolower($this->attr($child, 'role')) && ! $dialog instanceof DOMElement ) {
+                $dialog = $child;
+                continue;
+            }
+
+            return null;
+        }
+
+        if ( ! $summary instanceof DOMElement || ! $dialog instanceof DOMElement ) {
+            return null;
+        }
+
+        $label = str_replace("\xc2\xa0", ' ', html_entity_decode($this->innerHtml($summary), ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+        if ( '' !== trim(strip_tags($label)) ) {
+            return null;
+        }
+
+        foreach ( $dialog->getElementsByTagName('*') as $descendant ) {
+            if ( $descendant instanceof DOMElement && in_array(strtolower($descendant->tagName), array( 'script', 'canvas', 'template', 'iframe', 'form' ), true) ) {
+                return null;
+            }
+        }
+
+        return $dialog;
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -637,6 +637,22 @@ $assert(str_contains($closedDetailsMarkup, '<details class="wp-block-details"><s
 $assert(strpos($closedDetailsMarkup, '<summary>Closed summary</summary>') < strpos($closedDetailsMarkup, '<p>Closed content.</p>'), 'closed native details preserves summary before content through final serialization');
 $assert('pass' === ($closedDetailsResult['source_reports']['wp_block_validity']['status'] ?? ''), 'closed native details serialization remains Gutenberg-valid');
 
+// A visually empty native summary is capture scaffolding, not an editor-visible
+// disclosure trigger. Keep adjacent prose editable while lowering the bounded
+// dialog separately so core/details cannot add its default closed-state height.
+$capturedDisclosureResult = ( new HtmlTransformer() )->transform('<div class="rich-text"><p>Copyright text</p><details class="dla-disclosure"><summary>&nbsp;</summary><div class="dla-dialog" role="dialog"><nav><a href="/about">About</a><a href="/contact">Contact</a></nav></div></details></div>')->toArray();
+$capturedDisclosureRoot = $capturedDisclosureResult['blocks'][0] ?? array();
+$capturedDisclosureChildren = $capturedDisclosureRoot['innerBlocks'] ?? array();
+$capturedDisclosureDialog = $capturedDisclosureChildren[1] ?? array();
+$capturedDisclosureMarkup = (string) ($capturedDisclosureResult['serialized_blocks'] ?? '');
+$assert('core/group' === ($capturedDisclosureRoot['blockName'] ?? null) && 'core/paragraph' === (($capturedDisclosureChildren[0] ?? array())['blockName'] ?? null) && 'Copyright text' === (($capturedDisclosureChildren[0]['attrs']['content'] ?? null)), 'mixed rich text keeps ordinary sibling prose editable when an empty-summary disclosure is present');
+$assert(str_ends_with((string) ($capturedDisclosureDialog['blockName'] ?? ''), '/captured-dialog') && 'core/navigation' === (($capturedDisclosureDialog['innerBlocks'][0] ?? array())['blockName'] ?? null), 'bounded empty-summary dialog disclosures lower to the typed dialog block with native navigation children');
+$assert(! str_contains($capturedDisclosureMarkup, '<!-- wp:details') && ! str_contains($capturedDisclosureMarkup, '/collection') && str_contains($capturedDisclosureMarkup, '<dialog class="dla-dialog">'), 'empty-summary dialog disclosures avoid both details trigger geometry and collection fallback');
+
+$unsafeCapturedDisclosureResult = ( new HtmlTransformer() )->transform('<div class="rich-text"><p>Copyright text</p><details><summary>&nbsp;</summary><div role="dialog"><script>window.open()</script><nav><a href="/about">About</a></nav></div></details></div>')->toArray();
+$unsafeCapturedDisclosureMarkup = (string) ($unsafeCapturedDisclosureResult['serialized_blocks'] ?? '');
+$assert(! str_contains($unsafeCapturedDisclosureMarkup, '/captured-dialog') && str_contains($unsafeCapturedDisclosureMarkup, 'Copyright text'), 'runtime-heavy empty-summary dialogs fail closed without swallowing adjacent editable prose');
+
 // A single disclosure widget (toggle control + collapsible region) carries no
 // faq/accordion class, only the structural WAI-ARIA disclosure shape, and is
 // converted to a native zero-JS core/details block instead of leaking a dead


### PR DESCRIPTION
## Summary

- detect bounded empty-summary disclosure capture scaffolding
- lower the contained dialog through the typed captured-dialog path while preserving adjacent native rich text
- fail closed for runtime-heavy dialog content without swallowing editable siblings

## Verification

- `cd php-transformer && composer test`
- PHP transformer parity fixtures: 289
- package install proof passed

Closes #1326.

## AI assistance

OpenCode with OpenAI `openai/gpt-5.6-terra` implemented the candidate and regression coverage. OpenCode with OpenAI `openai/gpt-5.6-sol` reviewed and salvaged the candidate, ran the full gate, and prepared this PR. Chris Huber remains responsible for the change.