### PR TITLE
Promote navigation through nested inert support wrappers

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
@@ -162,6 +162,9 @@ final class SemanticParityReporter
     private function collectSourceLandmarks(DOMElement $element, array &$counts, array &$selectors, array &$seenNavigation): void
     {
         $landmark = $this->landmarkKindForElement($element);
+        if ( 'nav' === $landmark && $this->isSourceChromeOnlyNavigation($element) ) {
+            $landmark = '';
+        }
         if ( '' !== $landmark ) {
             if ( 'nav' === $landmark ) {
                 $signature = $this->sourceNavigationMenuSignature($this->sourceNavigationMenuItems($element));
@@ -279,7 +282,9 @@ final class SemanticParityReporter
      */
     private function collectSourceNavigationMenus(DOMElement $element, array &$menus, array &$seen): void
     {
-        if ( 'nav' === strtolower($element->tagName) || 'navigation' === strtolower($this->attr($element, 'role')) ) {
+        if ( ('nav' === strtolower($element->tagName) || 'navigation' === strtolower($this->attr($element, 'role')))
+            && ! $this->isSourceChromeOnlyNavigation($element)
+        ) {
             $items = $this->sourceNavigationMenuItems($element);
 
             $signature = $this->sourceNavigationMenuSignature($items);
@@ -460,6 +465,35 @@ final class SemanticParityReporter
         }
 
         return false;
+    }
+
+    private function isSourceChromeOnlyNavigation(DOMElement $element): bool
+    {
+        $hasToggle = false;
+        return $this->isSourceChromeOnlyNavigationContents($element, $hasToggle) && $hasToggle;
+    }
+
+    private function isSourceChromeOnlyNavigationContents(DOMElement $element, bool &$hasToggle): bool
+    {
+        foreach ( $element->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType && '' !== trim($child->textContent ?? '') ) {
+                return false;
+            }
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+            if ( 'button' === strtolower($child->tagName) && $this->isSourceMenuToggleControl($child) ) {
+                $hasToggle = true;
+                continue;
+            }
+            if ( ! in_array(strtolower($child->tagName), array( 'div', 'span' ), true)
+                || ! $this->isSourceChromeOnlyNavigationContents($child, $hasToggle)
+            ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function isSourceMenuToggleControl(DOMElement $element): bool

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -753,6 +753,13 @@ final class NavigationPattern implements PatternRecognizerInterface
             }
 
             if ( $child instanceof DOMElement ) {
+                if ( $hasListBackedMenu ) {
+                    // Once a list established the menu, a sibling wrapper is
+                    // support only when the explicit inert proof above accepts
+                    // it. Promoting an ambiguous companion would silently add
+                    // its meaningful content to the menu.
+                    return array();
+                }
                 if ( ! $allowsDirectItems ) {
                     return array();
                 }
@@ -783,10 +790,9 @@ final class NavigationPattern implements PatternRecognizerInterface
     }
 
     /**
-     * A list-backed menu can carry direct support nodes that cannot render.
-     * Attribute-only accessibility and interaction state is insufficient:
-     * authors can keep aria-hidden or inert content visible. Limit this
-     * exception to a recognized list and structural or presentation proof.
+     * A list-backed menu can carry direct support nodes that cannot render. A
+     * neutral wrapper is equally safe only when every descendant is hidden from
+     * assistive technology and cannot receive focus or navigate anywhere.
      */
     private function isInertNavigationSupportChild(DOMElement $element, ?NavigationPatternContext $navigationContext): bool
     {
@@ -802,12 +808,67 @@ final class NavigationPattern implements PatternRecognizerInterface
         }
 
         $style = strtolower($navigationContext->resolvedStyle($element));
-        return 1 === preg_match('/(?:^|;)\s*(?:display\s*:\s*none|visibility\s*:\s*hidden)\s*(?:!important)?\s*(?:;|$)/', $style)
+        if ( 1 === preg_match('/(?:^|;)\s*(?:display\s*:\s*none|visibility\s*:\s*hidden)\s*(?:!important)?\s*(?:;|$)/', $style)
             || (
                 1 === preg_match('/(?:^|;)\s*position\s*:\s*(?:absolute|fixed)\s*(?:!important)?\s*(?:;|$)/', $style)
                 && 1 === preg_match('/(?:^|;)\s*overflow\s*:\s*hidden\s*(?:!important)?\s*(?:;|$)/', $style)
                 && 1 === preg_match('/(?:^|;)\s*clip(?:-path)?\s*:/', $style)
-            );
+            )
+        ) {
+            return true;
+        }
+
+        return $this->isInertNavigationSupportWrapper($element);
+    }
+
+    private function isInertNavigationSupportWrapper(DOMElement $element): bool
+    {
+        if ( ! in_array(strtolower($element->tagName), array( 'div', 'span' ), true)
+            || '' !== trim($element->textContent ?? '') && 0 === $element->childElementCount
+        ) {
+            return false;
+        }
+
+        return $this->inertNavigationSupportDescendants($element, false);
+    }
+
+    private function inertNavigationSupportDescendants(DOMElement $element, bool $hidden): bool
+    {
+        $hidden = $hidden || 'true' === strtolower(trim($this->attr($element, 'aria-hidden')));
+        if ( $element->hasAttribute('href') || $element->hasAttribute('src')
+            || '' !== trim($this->attr($element, 'aria-label') . $this->attr($element, 'title'))
+            || $element->hasAttribute('aria-controls') || $element->hasAttribute('aria-expanded')
+        ) {
+            return false;
+        }
+        foreach ( $element->attributes as $attribute ) {
+            if ( str_starts_with(strtolower($attribute->name), 'on') ) {
+                return false;
+            }
+        }
+
+        $tabindex = trim($this->attr($element, 'tabindex'));
+        if ( '' !== $tabindex && ( ! $hidden || ! is_numeric($tabindex) || -1 < (int) $tabindex ) ) {
+            return false;
+        }
+
+        $tagName = strtolower($element->tagName);
+        if ( in_array($tagName, array( 'a', 'button', 'input', 'select', 'textarea' ), true)
+            && ( ! $hidden || 'button' !== $tagName || '-1' !== $tabindex )
+        ) {
+            return false;
+        }
+
+        foreach ( $element->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType && '' !== trim($child->textContent ?? '') && ! $hidden ) {
+                return false;
+            }
+            if ( $child instanceof DOMElement && ! $this->inertNavigationSupportDescendants($child, $hidden) ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/php-transformer/tests/unit/navigation-dropped-anchors.php
+++ b/php-transformer/tests/unit/navigation-dropped-anchors.php
@@ -116,6 +116,22 @@ foreach ( $controls as $label => [$markup, $needle] ) {
     );
 }
 
+$chromeOnly = ( new HtmlTransformer() )->transform(
+    '<nav aria-label="Site"><div><button type="button" aria-label="Menu">Menu icon</button></div></nav>'
+)->toArray();
+$chromeOnlyParity = $chromeOnly['source_reports']['semantic_parity'] ?? array();
+$assert(
+    'pass' === ($chromeOnlyParity['status'] ?? '') && 0 === count($chromeOnlyParity['findings'] ?? array()),
+    'a button-only hamburger landmark is treated as chrome instead of a missing menu',
+    json_encode($chromeOnlyParity)
+);
+$assert(
+    0 === ($chromeOnlyParity['landmarks']['source']['nav'] ?? -1)
+    && array() === ($chromeOnlyParity['navigation_menus']['source'] ?? null),
+    'a chrome-only hamburger contributes neither a source landmark nor menu to parity',
+    json_encode($chromeOnlyParity)
+);
+
 // -- An anchor named by an image alone is labelled with that alt text, not with
 // the raw `<img>` markup it is built from.
 $combined = $outcome(

--- a/php-transformer/tests/unit/navigation-inert-support-children.php
+++ b/php-transformer/tests/unit/navigation-inert-support-children.php
@@ -32,6 +32,24 @@ $assert(str_contains($markup, '"url":"/about"') && str_contains($markup, '"url":
 $assert('pass' === ($result['source_reports']['semantic_parity']['status'] ?? ''), 'inert support children retain semantic navigation parity', json_encode($result['source_reports']['semantic_parity'] ?? array()));
 $assert('pass' === ($result['source_reports']['wp_block_validity']['status'] ?? ''), 'promoted navigation remains Gutenberg-valid', json_encode($result['source_reports']['wp_block_validity'] ?? array()));
 
+$nestedSupport = ( new HtmlTransformer() )->transform(
+    '<nav aria-label="Site"><ul><li><a href="#features">Features</a></li><li><a href="#benefits">Benefits</a></li><li><a href="#signup">Signup</a></li></ul><div class="scroll-support"><div aria-hidden="true"><button tabindex="-1">Previous</button></div><div aria-hidden="true"><button tabindex="-1">Next</button></div></div></nav>'
+)->toArray();
+$nestedSupportMarkup = (string) ($nestedSupport['serialized_blocks'] ?? '');
+$assert(1 === substr_count($nestedSupportMarkup, '<!-- wp:navigation '), 'a neutral wrapper containing only hidden unfocusable controls promotes navigation', $nestedSupportMarkup);
+$assert(str_contains($nestedSupportMarkup, '"url":"#features"') && str_contains($nestedSupportMarkup, '"url":"#benefits"') && str_contains($nestedSupportMarkup, '"url":"#signup"'), 'nested inert support preserves every list destination', $nestedSupportMarkup);
+$assert(! str_contains($nestedSupportMarkup, 'scroll-support'), 'nested inert support does not become a companion block', $nestedSupportMarkup);
+
+$nestedFocusable = ( new HtmlTransformer() )->transform(
+    '<nav aria-label="Site"><ul><li><a href="#features">Features</a></li><li><a href="#benefits">Benefits</a></li></ul><div class="scroll-support"><div aria-hidden="true"><button>Next</button></div></div></nav>'
+)->toArray();
+$assert(! str_contains((string) ($nestedFocusable['serialized_blocks'] ?? ''), '<!-- wp:navigation '), 'a nested focusable control still rejects navigation promotion', (string) ($nestedFocusable['serialized_blocks'] ?? ''));
+
+$nestedDestination = ( new HtmlTransformer() )->transform(
+    '<nav aria-label="Site"><ul><li><a href="#features">Features</a></li><li><a href="#benefits">Benefits</a></li></ul><div class="scroll-support"><div aria-hidden="true"><a href="#next" tabindex="-1">Next</a></div></div></nav>'
+)->toArray();
+$assert(! str_contains((string) ($nestedDestination['serialized_blocks'] ?? ''), '<!-- wp:navigation '), 'a nested destination-bearing control still rejects navigation promotion', (string) ($nestedDestination['serialized_blocks'] ?? ''));
+
 $visible = ( new HtmlTransformer() )->transform(
     '<nav aria-label="Primary">' . $menu . '<span>Menu updated daily</span></nav>'
 )->toArray();


### PR DESCRIPTION
## Summary

- promote list-backed navigation when sibling wrapper descendants are provably hidden and unfocusable
- continue rejecting focusable, destination-bearing, named, or otherwise meaningful companion content
- classify button-only hamburger landmarks as navigation chrome instead of missing menus

## Verification

- `cd php-transformer && composer test`
- navigation dropped-anchor contract: 23 assertions
- navigation inert-support contract: 14 assertions

Closes #1225.

## AI assistance

OpenCode with OpenAI `openai/gpt-5.6-terra` implemented the candidate and regression coverage. OpenCode with OpenAI `openai/gpt-5.6-sol` reviewed and salvaged the candidate, hydrated dependencies, ran the full gate, and prepared this PR. Chris Huber remains responsible for the change.