### PR TITLE
Convert NavigationStyleProjectionTrait into a collaborator (#1327)

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -73,7 +73,8 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\SocialLinksPatt
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AuthorSelectorProjectionState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AuthorStyleAnalysis;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\LayoutGeometryState;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\NavigationStyleProjectionTrait;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\NavigationStyleProjectionContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\NavigationStyleProjector;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\PresentationResolutionCache;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssSelectorMatcher;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssSelectorMatchCache;
@@ -113,7 +114,6 @@ final class HtmlTransformer
     use DomHelpersTrait;
     use ElementConversionTrait;
     use FormDispatchTrait;
-    use NavigationStyleProjectionTrait;
     use NavigationToggleSuppressionTrait;
     use SvgMaterializationTrait;
 
@@ -249,6 +249,8 @@ final class HtmlTransformer
 
     private readonly StyleResolver $styleResolver;
 
+    private readonly NavigationStyleProjector $navigationStyleProjector;
+
     private readonly RuntimeIslandAnalyzer $runtimeIslands;
 
     private readonly ButtonLinkDispatcher $buttonLinkDispatcher;
@@ -290,7 +292,12 @@ final class HtmlTransformer
 
     private const EMPTY_FLEX_ITEM_CLASS = 'blocks-engine-empty-flex-item';
 
-    private const EMPTY_RUNTIME_TARGET_CLASS = 'blocks-engine-empty-runtime-target';
+    /**
+     * Marks an emptied block that exists only as a runtime target. Emitted
+     * here and read back by {@see NavigationStyleProjector}, which projects the
+     * editor static-state CSS that hides it.
+     */
+    public const EMPTY_RUNTIME_TARGET_CLASS = 'blocks-engine-empty-runtime-target';
 
     private const CSS_OWNED_LAYOUT_CLASS = 'blocks-engine-css-owned-layout';
 
@@ -369,6 +376,10 @@ final class HtmlTransformer
         $this->textLeafConverter = new TextLeafElementConverter($this->createTextLeafElementContext());
         $this->richTextConverter = new RichTextElementConverter($this->createRichTextElementContext());
         $this->styleResolver = new StyleResolver($this->createStyleResolutionContext(), $this->analysisCache);
+        $this->navigationStyleProjector = new NavigationStyleProjector(
+            $this->createNavigationStyleProjectionContext(),
+            $this->styleResolver
+        );
         $this->runtimeIslands = new RuntimeIslandAnalyzer($this->createRuntimeIslandContext());
         $this->buttonLinkDispatcher = new ButtonLinkDispatcher($this->createButtonLinkDispatchContext());
         $this->tableConverter = new TableElementConverter($this->createTableElementContext());
@@ -407,6 +418,69 @@ final class HtmlTransformer
             fn (string $value, ?DOMElement $element = null): string => $this->resolveCssVariablesInValue($value, $element),
             fn (string $url): string => $this->resolvedAssetImageUrl($url),
             fn (string $id): string => $this->safeAnchor($id)
+        );
+    }
+
+    /**
+     * Materializes a stylesheet into the transform's asset set.
+     *
+     * Transformer-owned rather than a navigation concern: engine-support and
+     * author stylesheets are materialized through here too. The navigation
+     * projector reaches it through {@see NavigationStyleProjectionContext}.
+     *
+     * @param array<int, string> $cssParts
+     */
+    private function materializeStylesheetAsset(array $cssParts, string $source, string $placement, string $pathPrefix, string $target = 'both'): void
+    {
+        $css = trim(implode("\n\n", $cssParts));
+        if ( '' === $css ) {
+            return;
+        }
+
+        $content = $css . "\n";
+        $hash = hash('sha256', $content);
+        $path = 'assets/css/' . $pathPrefix . '-' . substr($hash, 0, 16) . '.css';
+
+        $this->materializedAssets()->register($path, array(
+            'source'      => $source,
+            'source_path' => '',
+            'path'        => $path,
+            'target_path' => $path,
+            'kind'        => 'css',
+            'role'        => 'stylesheet',
+            'stylesheet_placement' => $placement,
+            'stylesheet_target' => $target,
+            'mime_type'   => 'text/css',
+            'media_type'  => 'text/css',
+            'content'     => $content,
+            'bytes'       => strlen($content),
+            'encoding'    => 'utf-8',
+            'binary'      => false,
+            'hash'        => $hash,
+            'source_hash' => $hash,
+        ));
+    }
+
+    /**
+     * Collaborator surface for {@see NavigationStyleProjector}. Per-transform
+     * state is resolved lazily so the projector always sees the running
+     * transform.
+     */
+    private function createNavigationStyleProjectionContext(): NavigationStyleProjectionContext
+    {
+        return new NavigationStyleProjectionContext(
+            fn (): AuthorStyleAnalysis => $this->authorStyles(),
+            fn (): SourceStyleResolutionState => $this->sourceStyles(),
+            fn (): GeneratedSupportStylesheetState => $this->generatedSupportStyles(),
+            fn (): RuntimeBehaviorState => $this->runtimeBehavior(),
+            fn (): TransformationEvidenceState => $this->transformationEvidence(),
+            fn (DOMElement $element, string $name): string => $this->attr($element, $name),
+            fn (DOMElement $element): string => $this->elementSelector($element),
+            fn (string $selector): array => $this->parsedCssSelector($selector),
+            fn (string $id): string => $this->safeAnchor($id),
+            function (array $cssParts, string $source, string $placement, string $pathPrefix, string $target = 'both'): void {
+                $this->materializeStylesheetAsset($cssParts, $source, $placement, $pathPrefix, $target);
+            }
         );
     }
 
@@ -793,7 +867,7 @@ final class HtmlTransformer
             $serializedBlocks,
             $sourceProvenance
         );
-        $this->materializeEditorStaticStateStylesheet();
+        $this->navigationStyleProjector->materializeEditorStaticStateStylesheet();
         $blockValidityReport = $this->runtime->validateBlockSerialization($blocks);
         $semanticParityReport = $this->semanticParityReporter->report($body, $blocks, $sourceProvenance, $html, (string) ($options['static_css'] ?? ''));
         $contentRoundTripReport = $this->contentRoundTripReporter->report($serializedBlocks, $html, $this->transformationEvidence()->formControlEchoTexts());
@@ -1483,7 +1557,7 @@ final class HtmlTransformer
             // paragraph blocks. Neutralize only those generated inner defaults.
             $beforeAuthorCssParts[] = ':root :where(.wp-block-group.' . self::CSS_OWNED_LAYOUT_ITEM_CLASS . ')>*{margin-block-start:0;margin-block-end:0}';
         }
-        foreach ( $this->navigationLinkTextColorRules($serializedBlocks) as $navigationLinkTextColorRule ) {
+        foreach ( $this->navigationStyleProjector->navigationLinkTextColorRules($serializedBlocks) as $navigationLinkTextColorRule ) {
             $afterAuthorCssParts[] = $navigationLinkTextColorRule;
         }
         array_push($afterAuthorCssParts, ...$this->generatedSupportStyles()->conditionalAfterAuthorCss($serializedBlocks));
@@ -1511,7 +1585,7 @@ final class HtmlTransformer
                 $afterAuthorCssParts[] = '.wp-block-navigation.blocks-engine-list-navigation.blocks-engine-native-responsive-navigation{display:flex!important}';
             }
             if ( str_contains($serializedBlocks, 'blocks-engine-projected-dialog-navigation') ) {
-                $mobileOverlayBackground = $this->sourceMobileNavigationOverlayBackground();
+                $mobileOverlayBackground = $this->navigationStyleProjector->sourceMobileNavigationOverlayBackground();
                 $fallbackTextColor = '';
                 if ( '' === $mobileOverlayBackground ) {
                     $mobileOverlayBackground = '#fff';
@@ -1538,16 +1612,16 @@ final class HtmlTransformer
             // block shrinkable, so a narrow viewport still hands over to core's
             // responsive overlay rather than overflowing the page.
             $afterAuthorCssParts[] = 'nav.wp-block-group>.wp-block-navigation.blocks-engine-list-navigation{width:max-content;max-width:100%}';
-            foreach ( $this->listNavigationInlineMarginRules($serializedBlocks) as $inlineMarginRule ) {
+            foreach ( $this->navigationStyleProjector->listNavigationInlineMarginRules($serializedBlocks) as $inlineMarginRule ) {
                 $afterAuthorCssParts[] = $inlineMarginRule;
             }
-            foreach ( $this->listNavigationPaddingRules($serializedBlocks) as $paddingRule ) {
+            foreach ( $this->navigationStyleProjector->listNavigationPaddingRules($serializedBlocks) as $paddingRule ) {
                 $afterAuthorCssParts[] = $paddingRule;
             }
-            foreach ( $this->listNavigationItemAnchorRules($serializedBlocks, $sourceProvenance) as $itemAnchorRule ) {
+            foreach ( $this->navigationStyleProjector->listNavigationItemAnchorRules($serializedBlocks, $sourceProvenance) as $itemAnchorRule ) {
                 $afterAuthorCssParts[] = $itemAnchorRule;
             }
-            $mobileOverlayBackground = $this->sourceMobileNavigationOverlayBackground();
+            $mobileOverlayBackground = $this->navigationStyleProjector->sourceMobileNavigationOverlayBackground();
             if ( '' !== $mobileOverlayBackground ) {
                 $afterAuthorCssParts[] = '.wp-block-navigation.blocks-engine-list-navigation .wp-block-navigation__responsive-container.is-menu-open{background:' . $mobileOverlayBackground . '!important}';
             }
@@ -1569,10 +1643,10 @@ final class HtmlTransformer
         if ( str_contains($serializedBlocks, 'blocks-engine-source-social-item-spacing') ) {
             $afterAuthorCssParts[] = '.wp-block-social-links.blocks-engine-source-social-item-spacing{gap:0}';
         }
-        foreach ( $this->navigationItemStateAnchorRules($serializedBlocks, $sourceProvenance) as $itemAnchorRule ) {
+        foreach ( $this->navigationStyleProjector->navigationItemStateAnchorRules($serializedBlocks, $sourceProvenance) as $itemAnchorRule ) {
             $afterAuthorCssParts[] = $itemAnchorRule;
         }
-        $directNavigationCss = $this->directNavigationSupportCss($serializedBlocks);
+        $directNavigationCss = $this->navigationStyleProjector->directNavigationSupportCss($serializedBlocks);
         if ( '' !== $directNavigationCss ) {
             $afterAuthorCssParts[] = $directNavigationCss;
         }
@@ -3415,7 +3489,7 @@ final class HtmlTransformer
                 $includeRuntimeDomTarget ? fn (DOMElement $sourceElement): bool => $this->runtimeIslands->isRuntimeDomTarget($sourceElement) : null,
                 fn (DOMElement $item, DOMElement $anchor): string => $this->navigationUnderlineColor($item, $anchor),
                 fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->styleResolver->specificityResolvedPresentationStyle($sourceElement)),
-                fn (DOMElement $sourceElement): array => $this->navigationColorInteractionStates($sourceElement),
+                fn (DOMElement $sourceElement): array => $this->navigationStyleProjector->navigationColorInteractionStates($sourceElement),
                 fn (DOMElement $sourceElement): string => $this->navigationOverlayMenu($sourceElement)
             ),
             new MediaPatternContext(
@@ -6123,12 +6197,6 @@ if ( 'svg' === $tagName ) {
         return array() === $ownership ? array() : array( 'navigation_source_ownership' => $ownership );
     }
 
-    /** @return list<string> */
-    private function navigationSourceOwnershipClasses(array $entry, string $kind): array
-    {
-        $className = (string) ($entry['navigation_source_ownership'][$kind]['class_name'] ?? '');
-        return array_values(array_filter(preg_split('/\s+/', trim($className)) ?: array()));
-    }
 
     /**
      * @return array{conversion_classification: string, preservation_strategy: string}

--- a/php-transformer/src/HtmlToBlocks/Style/NavigationStyleProjectionContext.php
+++ b/php-transformer/src/HtmlToBlocks/Style/NavigationStyleProjectionContext.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeBehaviorState;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\TransformationEvidenceState;
+use Closure;
+use DOMElement;
+
+/**
+ * Explicit collaborator surface for {@see NavigationStyleProjector}.
+ *
+ * Per-transform state (author styles, source styles, generated support styles,
+ * materialized assets, runtime behavior, transformation evidence) is resolved
+ * through closures because the projector is constructed once with the
+ * transformer but must see the state belonging to the transform currently
+ * running.
+ *
+ * `materializeStylesheetAsset` is a transformer-owned operation rather than a
+ * navigation concern — the transformer uses it for engine-support and author
+ * stylesheets too — so the projector reaches it through this surface instead of
+ * owning it.
+ */
+final class NavigationStyleProjectionContext
+{
+    /**
+     * @param Closure(): AuthorStyleAnalysis                              $authorStyles
+     * @param Closure(): SourceStyleResolutionState                       $sourceStyles
+     * @param Closure(): GeneratedSupportStylesheetState                  $generatedSupportStyles
+     * @param Closure(): RuntimeBehaviorState                             $runtimeBehavior
+     * @param Closure(): TransformationEvidenceState                      $transformationEvidence
+     * @param Closure(DOMElement, string): string                         $attr
+     * @param Closure(DOMElement): string                                 $elementSelector
+     * @param Closure(string): array<string, mixed>                       $parsedCssSelector
+     * @param Closure(string): string                                     $safeAnchor
+     * @param Closure(array<int, string>, string, string, string, string): void $materializeStylesheetAsset
+     */
+    public function __construct(
+        private readonly Closure $authorStyles,
+        private readonly Closure $sourceStyles,
+        private readonly Closure $generatedSupportStyles,
+        private readonly Closure $runtimeBehavior,
+        private readonly Closure $transformationEvidence,
+        private readonly Closure $attr,
+        private readonly Closure $elementSelector,
+        private readonly Closure $parsedCssSelector,
+        private readonly Closure $safeAnchor,
+        private readonly Closure $materializeStylesheetAsset
+    ) {
+    }
+
+    public function authorStyles(): AuthorStyleAnalysis
+    {
+        return ($this->authorStyles)();
+    }
+
+    public function sourceStyles(): SourceStyleResolutionState
+    {
+        return ($this->sourceStyles)();
+    }
+
+    public function generatedSupportStyles(): GeneratedSupportStylesheetState
+    {
+        return ($this->generatedSupportStyles)();
+    }
+
+    public function runtimeBehavior(): RuntimeBehaviorState
+    {
+        return ($this->runtimeBehavior)();
+    }
+
+    public function transformationEvidence(): TransformationEvidenceState
+    {
+        return ($this->transformationEvidence)();
+    }
+
+    public function attr(DOMElement $element, string $name): string
+    {
+        return ($this->attr)($element, $name);
+    }
+
+    public function elementSelector(DOMElement $element): string
+    {
+        return ($this->elementSelector)($element);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function parsedCssSelector(string $selector): array
+    {
+        return ($this->parsedCssSelector)($selector);
+    }
+
+    public function safeAnchor(string $id): string
+    {
+        return ($this->safeAnchor)($id);
+    }
+
+    /**
+     * @param array<int, string> $cssParts
+     */
+    public function materializeStylesheetAsset(
+        array $cssParts,
+        string $source,
+        string $placement,
+        string $pathPrefix,
+        string $target = 'both'
+    ): void {
+        ($this->materializeStylesheetAsset)($cssParts, $source, $placement, $pathPrefix, $target);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Style/NavigationStyleProjector.php
+++ b/php-transformer/src/HtmlToBlocks/Style/NavigationStyleProjector.php
@@ -3,11 +3,25 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
 use DOMElement;
 
-trait NavigationStyleProjectionTrait
+/**
+ * Projects author navigation styling onto the emitted navigation blocks.
+ *
+ * Extracted from HtmlTransformer as a collaborator rather than a mixin: every
+ * dependency it needs from the transformer is declared on
+ * {@see NavigationStyleProjectionContext}, so this class has no $this access to
+ * the transformer and can be exercised without constructing one.
+ */
+final class NavigationStyleProjector
 {
-    private function directNavigationSupportCss(string $serializedBlocks): string
+    public function __construct(
+        private readonly NavigationStyleProjectionContext $context,
+        private readonly StyleResolver $styleResolver
+    ) {
+    }
+    public function directNavigationSupportCss(string $serializedBlocks): string
     {
         if ( ! str_contains($serializedBlocks, 'blocks-engine-direct-navigation') ) {
             return '';
@@ -58,60 +72,29 @@ trait NavigationStyleProjectionTrait
         return implode("\n", array_values($rules));
     }
 
-    /** @param array<int, string> $cssParts */
-    private function materializeStylesheetAsset(array $cssParts, string $source, string $placement, string $pathPrefix, string $target = 'both'): void
-    {
-        $css = trim(implode("\n\n", $cssParts));
-        if ( '' === $css ) {
-            return;
-        }
 
-        $content = $css . "\n";
-        $hash = hash('sha256', $content);
-        $path = 'assets/css/' . $pathPrefix . '-' . substr($hash, 0, 16) . '.css';
-
-        $this->materializedAssets()->register($path, array(
-            'source'      => $source,
-            'source_path' => '',
-            'path'        => $path,
-            'target_path' => $path,
-            'kind'        => 'css',
-            'role'        => 'stylesheet',
-            'stylesheet_placement' => $placement,
-            'stylesheet_target' => $target,
-            'mime_type'   => 'text/css',
-            'media_type'  => 'text/css',
-            'content'     => $content,
-            'bytes'       => strlen($content),
-            'encoding'    => 'utf-8',
-            'binary'      => false,
-            'hash'        => $hash,
-            'source_hash' => $hash,
-        ));
-    }
-
-    private function materializeEditorStaticStateStylesheet(): void
+    public function materializeEditorStaticStateStylesheet(): void
     {
         $rules = array();
         $anchorProjectionCss = $this->editorAnchorProjectionCss();
         if ( '' !== $anchorProjectionCss ) {
             $rules[] = $anchorProjectionCss;
         }
-        if ( preg_match('/(?:^|[;{])\s*(?:-webkit-)?animation(?:-[a-z-]+)?\s*:/i', $this->authorStyles()->combinedCss()) ) {
+        if ( preg_match('/(?:^|[;{])\s*(?:-webkit-)?animation(?:-[a-z-]+)?\s*:/i', $this->context->authorStyles()->combinedCss()) ) {
             $rules[] = ':root *,:root *::before,:root *::after{animation-delay:-999999s!important;animation-iteration-count:1!important;animation-fill-mode:both!important;transition:none!important}';
         }
-        if ( $this->runtimeBehavior()->emptyRuntimeTargetGenerated() ) {
-            $selector = ':root .' . self::EMPTY_RUNTIME_TARGET_CLASS . '.wp-block-group__placeholder';
+        if ( $this->context->runtimeBehavior()->emptyRuntimeTargetGenerated() ) {
+            $selector = ':root .' . HtmlTransformer::EMPTY_RUNTIME_TARGET_CLASS . '.wp-block-group__placeholder';
             $rules[] = $selector . '{flex-basis:auto!important;width:auto!important;min-width:10ch!important;min-height:1.2em!important}'
                 . $selector . '>*{display:none!important}'
                 . $selector . '::before{content:"Dynamic content";display:block;opacity:.45;white-space:nowrap}';
         }
-        if ( preg_match('/\bbody\b[^{}]*\{[^}]*(?:overflow\s*:\s*(?:hidden|clip)|height\s*:\s*100(?:d|s|l)?vh)/is', $this->authorStyles()->combinedCss()) ) {
+        if ( preg_match('/\bbody\b[^{}]*\{[^}]*(?:overflow\s*:\s*(?:hidden|clip)|height\s*:\s*100(?:d|s|l)?vh)/is', $this->context->authorStyles()->combinedCss()) ) {
             $rules[] = ':root body{overflow:auto!important;height:auto!important;min-height:100%!important;width:auto!important}';
         }
 
         $repairs = array();
-        foreach ( $this->transformationEvidence()->frozenHiddenStateFindings() as $finding ) {
+        foreach ( $this->context->transformationEvidence()->frozenHiddenStateFindings() as $finding ) {
             $selector = (string) ($finding['editor_selector'] ?? '');
             if ( '' === $selector ) {
                 continue;
@@ -137,21 +120,21 @@ trait NavigationStyleProjectionTrait
             $rules[] = ':root ' . $selector . '{' . rtrim($body, ';') . '}';
         }
 
-        $this->materializeStylesheetAsset($rules, 'editor-static-state', 'after-author', 'editor-static-state', 'editor');
+        $this->context->materializeStylesheetAsset($rules, 'editor-static-state', 'after-author', 'editor-static-state', 'editor');
     }
 
     private function editorAnchorProjectionCss(): string
     {
         $ids = array_fill_keys(array_filter(
-            $this->authorStyles()->sourceElementIds(),
-            fn (string $id): bool => '' !== $this->safeAnchor($id)
+            $this->context->authorStyles()->sourceElementIds(),
+            fn (string $id): bool => '' !== $this->context->safeAnchor($id)
         ), true);
         if ( array() === $ids ) {
             return '';
         }
 
         return trim(( new CssStylesheetTransformer() )->transform(
-            $this->authorStyles()->combinedCss(),
+            $this->context->authorStyles()->combinedCss(),
             static function (string $prelude, string $body) use ($ids): array {
                 $projected = array();
                 foreach ( CssStylesheetTransformer::splitSelectorList($prelude) ?? array() as $selector ) {
@@ -194,7 +177,7 @@ trait NavigationStyleProjectionTrait
      *
      * @return array<int, string>
      */
-    private function listNavigationInlineMarginRules(string $serializedBlocks): array
+    public function listNavigationInlineMarginRules(string $serializedBlocks): array
     {
         if ( ! str_contains($serializedBlocks, 'blocks-engine-list-navigation') ) {
             return array();
@@ -206,7 +189,7 @@ trait NavigationStyleProjectionTrait
         }
 
         $rules = array();
-        foreach ( array_merge($this->sourceStyles()->staticRules(), $this->sourceStyles()->conditionalRules()) as $rule ) {
+        foreach ( array_merge($this->context->sourceStyles()->staticRules(), $this->context->sourceStyles()->conditionalRules()) as $rule ) {
             $selector = trim((string) ($rule['selector'] ?? ''));
             if ( 1 !== preg_match('/^\.([A-Za-z_][A-Za-z0-9_-]*)$/', $selector, $match) ) {
                 continue;
@@ -239,7 +222,7 @@ trait NavigationStyleProjectionTrait
     }
 
     /** @return array<int, string> */
-    private function listNavigationPaddingRules(string $serializedBlocks): array
+    public function listNavigationPaddingRules(string $serializedBlocks): array
     {
         if ( ! preg_match_all('/<!--\s*wp:navigation\s*(\{.*?\})\s*-->/s', $serializedBlocks, $matches, PREG_SET_ORDER) ) {
             return array();
@@ -262,7 +245,7 @@ trait NavigationStyleProjectionTrait
                 : array();
             if ( array() === $padding ) {
                 foreach ( $classes as $class ) {
-                    $fallbackPadding = $this->generatedSupportStyles()->listNavigationPadding($class);
+                    $fallbackPadding = $this->context->generatedSupportStyles()->listNavigationPadding($class);
                     if ( array() !== $fallbackPadding ) {
                         $padding = $fallbackPadding;
                         break;
@@ -332,7 +315,7 @@ trait NavigationStyleProjectionTrait
      * @param array<int, array<string, mixed>> $sourceProvenance
      * @return array<int, string>
      */
-    private function listNavigationItemAnchorRules(string $serializedBlocks, array $sourceProvenance): array
+    public function listNavigationItemAnchorRules(string $serializedBlocks, array $sourceProvenance): array
     {
         if ( ! str_contains($serializedBlocks, 'blocks-engine-list-navigation') ) {
             return array();
@@ -477,7 +460,7 @@ trait NavigationStyleProjectionTrait
      * @param array<int, array<string, mixed>> $sourceProvenance
      * @return array<int, string>
      */
-    private function navigationItemStateAnchorRules(string $serializedBlocks, array $sourceProvenance): array
+    public function navigationItemStateAnchorRules(string $serializedBlocks, array $sourceProvenance): array
     {
         $hasListNavigation = str_contains($serializedBlocks, 'blocks-engine-list-navigation');
         if ( ! str_contains($serializedBlocks, '<!-- wp:navigation ') ) {
@@ -585,14 +568,14 @@ trait NavigationStyleProjectionTrait
      */
     private function navigationAuthorStyleRules(): array
     {
-        if ( '' === trim($this->authorStyles()->combinedCss()) ) {
+        if ( '' === trim($this->context->authorStyles()->combinedCss()) ) {
             return array();
         }
 
         $rules = array();
         $order = 0;
         ( new CssStylesheetTransformer() )->visitStyleRules(
-            $this->authorStyles()->combinedCss(),
+            $this->context->authorStyles()->combinedCss(),
             function (string $prelude, string $body, array $conditions) use (&$rules, &$order): void {
                 $this->collectNavigationAuthorStyleRule($prelude, $body, $conditions, $rules, $order);
             }
@@ -619,7 +602,7 @@ trait NavigationStyleProjectionTrait
             if ( '' === $selector || str_starts_with($selector, '@') ) {
                 continue;
             }
-            $parsed = $this->parsedCssSelector($selector);
+            $parsed = $this->context->parsedCssSelector($selector);
             if ( ! ($parsed['supported'] ?? false) ) {
                 continue;
             }
@@ -691,10 +674,10 @@ trait NavigationStyleProjectionTrait
         }
 
         $anchors = array();
-        foreach ( $this->authorStyles()->sourceElementsByClass($class) as $element ) {
+        foreach ( $this->context->authorStyles()->sourceElementsByClass($class) as $element ) {
             if ( $element instanceof DOMElement
                 && 'a' === strtolower($element->tagName)
-                && isset($selectors[$this->elementSelector($element)])
+                && isset($selectors[$this->context->elementSelector($element)])
             ) {
                 $anchors[] = $element;
             }
@@ -721,14 +704,14 @@ trait NavigationStyleProjectionTrait
         }
 
         $anchors = array();
-        foreach ( $this->authorStyles()->sourceElementsByClass($class) as $item ) {
+        foreach ( $this->context->authorStyles()->sourceElementsByClass($class) as $item ) {
             if ( ! $item instanceof DOMElement ) {
                 continue;
             }
             foreach ( $item->childNodes as $child ) {
                 if ( $child instanceof DOMElement
                     && 'a' === strtolower($child->tagName)
-                    && isset($selectors[$this->elementSelector($child)])
+                    && isset($selectors[$this->context->elementSelector($child)])
                 ) {
                     $anchors[] = $child;
                 }
@@ -769,7 +752,7 @@ trait NavigationStyleProjectionTrait
             }
 
             if ( array() === ($candidate['conditions'] ?? array()) && '' === ($candidate['pseudo'] ?? '') ) {
-                $inline = $this->styleResolver->safeVisualDeclarations($this->styleResolver->cssDeclarations($this->attr($anchor, 'style')));
+                $inline = $this->styleResolver->safeVisualDeclarations($this->styleResolver->cssDeclarations($this->context->attr($anchor, 'style')));
                 if ( array_key_exists($property, $inline) ) {
                     $entry = array(
                         'id' => -1,
@@ -911,7 +894,7 @@ trait NavigationStyleProjectionTrait
                 return null;
             }
 
-            $itemClasses = preg_split('/\s+/', trim($this->attr($item, 'class'))) ?: array();
+            $itemClasses = preg_split('/\s+/', trim($this->context->attr($item, 'class'))) ?: array();
             if ( in_array($class, $itemClasses, true) ) {
                 // The class also belonged to the source item. Its item paint is
                 // authored, not an artifact of core moving the anchor class.
@@ -999,10 +982,10 @@ trait NavigationStyleProjectionTrait
     }
 
     /** @return list<string> */
-    private function navigationColorInteractionStates(DOMElement $element): array
+    public function navigationColorInteractionStates(DOMElement $element): array
     {
         $matched = array();
-        foreach ( $this->sourceStyles()->navigationStateRules() as $rule ) {
+        foreach ( $this->context->sourceStyles()->navigationStateRules() as $rule ) {
             if ( ! isset($rule['declarations']['color'])
                 || ! $this->styleResolver->matchesCssSelector($element, $rule['base_selector'])
             ) {
@@ -1036,7 +1019,7 @@ trait NavigationStyleProjectionTrait
      *
      * @return array<int, string>
      */
-    private function navigationLinkTextColorRules(string $serializedBlocks): array
+    public function navigationLinkTextColorRules(string $serializedBlocks): array
     {
         $prefix = 'blocks-engine-navigation-link-color-';
         $currentPrefix = 'blocks-engine-navigation-current-color-';
@@ -1059,7 +1042,7 @@ trait NavigationStyleProjectionTrait
             $color = trim((string) ($attrs['style']['color']['text'] ?? ''));
             if ( '' === $color ) {
                 foreach ( preg_split('/\s+/', trim((string) ($attrs['className'] ?? ''))) ?: array() as $class ) {
-                    $fallbackColor = $this->generatedSupportStyles()->navigationLinkColor($class);
+                    $fallbackColor = $this->context->generatedSupportStyles()->navigationLinkColor($class);
                     if ( '' !== $fallbackColor ) {
                         $color = $fallbackColor;
                         break;
@@ -1297,10 +1280,10 @@ trait NavigationStyleProjectionTrait
         return $carried;
     }
 
-    private function sourceMobileNavigationOverlayBackground(): string
+    public function sourceMobileNavigationOverlayBackground(): string
     {
         $background = '';
-        foreach ( array_merge($this->sourceStyles()->staticRules(), $this->sourceStyles()->conditionalRules()) as $rule ) {
+        foreach ( array_merge($this->context->sourceStyles()->staticRules(), $this->context->sourceStyles()->conditionalRules()) as $rule ) {
             $selector = strtolower((string) ($rule['selector'] ?? ''));
             if ( ! str_contains($selector, 'nav') || ! preg_match('/(?:^|[^a-z0-9])(?:mobile|drawer|offcanvas|overlay|menu-panel|nav-panel)(?:[^a-z0-9]|$)/', $selector) ) {
                 continue;
@@ -1316,4 +1299,13 @@ trait NavigationStyleProjectionTrait
         return $background;
     }
 
+    /**
+     * @param array<string, mixed> $entry
+     * @return list<string>
+     */
+    private function navigationSourceOwnershipClasses(array $entry, string $kind): array
+    {
+        $className = (string) ($entry['navigation_source_ownership'][$kind]['class_name'] ?? '');
+        return array_values(array_filter(preg_split('/\s+/', trim($className)) ?: array()));
+    }
 }

--- a/php-transformer/tests/unit/navigation-author-rule-memory.php
+++ b/php-transformer/tests/unit/navigation-author-rule-memory.php
@@ -21,8 +21,13 @@ if ( ! $body instanceof DOMElement ) {
 $session = $reflection->getProperty('session')->getValue($transformer);
 $session->installAuthorStyleAnalysis(new AuthorStyleAnalysis($css, $css, array(), $body));
 
-$collect = $reflection->getMethod('navigationAuthorStyleRules');
-$rules = $collect->invoke($transformer);
+// Author-rule collection moved to NavigationStyleProjector. Reach it through
+// the transformer's collaborator so this still exercises the real wiring —
+// including the context closure that resolves the running transform's session
+// state — rather than a projector built in isolation.
+$projector = $reflection->getProperty('navigationStyleProjector')->getValue($transformer);
+$collect = ( new ReflectionClass($projector) )->getMethod('navigationAuthorStyleRules');
+$rules = $collect->invoke($projector);
 $rule = is_array($rules) ? ($rules[0] ?? array()) : array();
 
 $valid = 1 === count($rules)


### PR DESCRIPTION
Slice 7 for #242, workstream 1. Closes #1327. Follows #1310, #1312, #1315, #1316, #1317, #1318.

`NavigationStyleProjectionTrait` was a 1,319-line single-consumer mixin. Per #1318's finding that trait extraction moves code across a file boundary without changing the `$this` surface, it is now `NavigationStyleProjector` behind a 10-operation `NavigationStyleProjectionContext`, with no `$this` access to the transformer.

#1327 picked this trait by measuring lines-removed per external dependency rather than by size. It ranked highest of the five remaining (110 lines/dep vs `FormDispatchTrait`'s 62), and the boundary held up: 9 entry points, every one reached only from `HtmlTransformer`, so this was a single-consumer migration rather than #1318's 292-call-site fan-out.

## Two members moved in opposite directions

Neither was in the original plan; both came out of reading the actual call sites.

**`navigationSourceOwnershipClasses` moved into the projector.** It lived on `HtmlTransformer` but was reached only from this trait, and is pure string work with no `$this` dependency. Threading it through the context would have widened the surface to describe a method nothing else uses. It leaves the transformer entirely.

**`materializeStylesheetAsset` moved the other way, into `HtmlTransformer`.** It lived in the navigation trait, but three of its four call sites are engine-support and author stylesheets — it is transformer-owned asset materialization that happened to be filed under navigation. Moving it into a class named `NavigationStyleProjector` would have meant the transformer calling `$this->navigationStyleProjector->materializeStylesheetAsset()` to write its author CSS. It stays with the transformer; the projector reaches it through the context.

That removal is also why the context is 10 operations rather than the 12 dependencies #1327 measured: `materializedAssets` was used only inside `materializeStylesheetAsset`, so it left the surface with it.

## A constant the dependency analysis missed

`self::EMPTY_RUNTIME_TARGET_CLASS` is defined on `HtmlTransformer` and referenced from the trait. The `$this->`-based dependency counting in #1327 does not see `self::` constants, so this was invisible until the contract suite hit it.

It is now `public`, referenced as `HtmlTransformer::EMPTY_RUNTIME_TARGET_CLASS`, following the existing `ButtonLinkDispatcher::POSITIONED_FRAGMENT_LINK_CARRIER_CLASS` convention where the class that emits a marker owns the constant and readers reference it. Here the transformer emits the marker and the projector targets it in editor static-state CSS.

**Worth carrying into the remaining slices:** extend the dependency measurement to `self::`/`static::` constants before estimating a trait, not just `$this->`.

## Behavior preservation

`serializedBlocks` SHA-256 plus block, diagnostic, fallback, asset-count, asset-key and coverage fingerprints, captured across all fixture documents on the clean base and recaptured after:

```
383 documents — DIFFERING: 0 — threw: 0

                baseline    after
blocks             1,631    1,631
diagnostics        6,772    6,772
fallbacks          1,037    1,037
assets             3,239    3,239
```

`composer test` exit 0.

Two details about how that baseline was built, because they changed the result:

**Stylesheets are attached.** Navigation style projection reads author CSS, so a corpus run with no `static_css` would not exercise the code under change. The harness concatenates each fixture's stylesheets and passes them through `static_css`; 82 of 87 fixtures carry CSS.

**The harness was verified to reach the code before it was trusted.** All 9 entry points were temporarily instrumented and confirmed to fire within the first 60 documents, rather than assuming corpus breadth implies coverage.

## Where the corpus was not enough

The undefined-constant fault above did **not** surface in the 383-document run — it reported 0 throwing while the fault was live, because the branch holding that constant sits behind a conditional the corpus never enters. The contract suite caught it.

Recording this because these slices lean on the corpus as the primary behavior gate: it proves output identity across a wide input surface, but it is not a branch-coverage instrument. Corpus green plus suite green is the real bar; corpus green alone is not.

## Impact

| | trunk | after |
|---|---:|---:|
| `HtmlTransformer.php` | 12,711 | 12,771 |
| Named methods on the class | 515 | 516 |
| **Methods in the transformer's object scope** | **548** | **516** |
| **Object scope (class + single-consumer mixins)** | **18,253** | **16,994** |

The class grows 60 lines — the property, the constructor wiring, the context factory and the relocated `materializeStylesheetAsset` — while 1,259 lines and 32 methods leave the shared mutable scope. Same shape as #1318, which grew the file by 37 lines while removing 2,822 from the object scope.

Remaining single-consumer mixins, by the #1327 ranking: `FormDispatchTrait` (1,865 / 30 deps), `SvgMaterializationTrait` (983 / 20), `NavigationToggleSuppressionTrait` (781 / 10), `ElementConversionTrait` (594 / 89 — not a collaborator candidate, see #1327).

## Test updates

One test reflected on `navigationAuthorStyleRules()` via `HtmlTransformer` — the #1197 memory-bound contract. It now reaches the method through the transformer's collaborator, so it still exercises the real wiring including the context closure that resolves the running transform's session state. The method stays private on the projector and is reached by reflection rather than widening its API for a test, following #1318. A sweep for other tests referencing any of the 34 moved methods found none.

---

*AI assistance disclosure: implemented and drafted by Claude Sonnet 4.6 running in Claude Code, operated by @chubes4. The AI measured the trait's dependency surface, captured and verified the pre-change corpus baseline, performed the extraction, migrated the call sites, diagnosed the undefined-constant and moved-method-reflection failures surfaced by the suite, and wrote this description. Reviewed by a human before opening.*
