### PR TITLE
Convert NavigationToggleSuppressionTrait into a collaborator (#1327)

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -88,7 +88,8 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\DomHelpersTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\ElementConversionTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\FormDispatchTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\LinkUrlSanitizer;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\NavigationToggleSuppressionTrait;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\NavigationToggleSuppressionContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\NavigationToggleSuppressor;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SvgMaterializationTrait;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\FontMaterializationPlanBuilder;
 use Automattic\BlocksEngine\PhpTransformer\Support\StyleTagScanner;
@@ -114,7 +115,6 @@ final class HtmlTransformer
     use DomHelpersTrait;
     use ElementConversionTrait;
     use FormDispatchTrait;
-    use NavigationToggleSuppressionTrait;
     use SvgMaterializationTrait;
 
     private const MAX_INTERACTION_CANDIDATES = 100;
@@ -251,6 +251,8 @@ final class HtmlTransformer
 
     private readonly NavigationStyleProjector $navigationStyleProjector;
 
+    private readonly NavigationToggleSuppressor $navigationToggleSuppressor;
+
     private readonly RuntimeIslandAnalyzer $runtimeIslands;
 
     private readonly ButtonLinkDispatcher $buttonLinkDispatcher;
@@ -380,6 +382,10 @@ final class HtmlTransformer
             $this->createNavigationStyleProjectionContext(),
             $this->styleResolver
         );
+        $this->navigationToggleSuppressor = new NavigationToggleSuppressor(
+            $this->createNavigationToggleSuppressionContext(),
+            $this->styleResolver
+        );
         $this->runtimeIslands = new RuntimeIslandAnalyzer($this->createRuntimeIslandContext());
         $this->buttonLinkDispatcher = new ButtonLinkDispatcher($this->createButtonLinkDispatchContext());
         $this->tableConverter = new TableElementConverter($this->createTableElementContext());
@@ -459,6 +465,24 @@ final class HtmlTransformer
             'hash'        => $hash,
             'source_hash' => $hash,
         ));
+    }
+
+    /**
+     * Collaborator surface for {@see NavigationToggleSuppressor}. Per-transform
+     * state is resolved lazily so the suppressor always sees the running
+     * transform.
+     */
+    private function createNavigationToggleSuppressionContext(): NavigationToggleSuppressionContext
+    {
+        return new NavigationToggleSuppressionContext(
+            fn (DOMElement $element, string $name): string => $this->attr($element, $name),
+            fn (DOMElement $container, DOMElement $element): bool => $this->elementContains($container, $element),
+            fn (DOMElement $element): bool => $this->hasSourceNavigationSignal($element),
+            fn (DOMElement $element): bool => $this->sourceElementStartsHidden($element),
+            fn (): RuntimeSelectorState => $this->runtimeSelectors(),
+            fn (): PatternRecognizerRegistry => $this->patternRecognizers,
+            fn (): PatternContext => $this->probePatternContext()
+        );
     }
 
     /**
@@ -834,8 +858,8 @@ final class HtmlTransformer
 
         $fallbacks   = array();
         $interactionCandidates = $this->interactionCandidates($body);
-        $this->collectProjectedNavigationRelationships($body);
-        $this->collectSupersededNavToggleSelectors($body);
+        $this->navigationToggleSuppressor->collectProjectedNavigationRelationships($body);
+        $this->navigationToggleSuppressor->collectSupersededNavToggleSelectors($body);
         $shellArtifacts = !array_key_exists('extract_global_shell', $options) || !empty($options['extract_global_shell']) ? $this->globalShellArtifacts($body, (string) ($options['source'] ?? 'html')) : array();
         $this->collectGeneratedComponentCandidates($body);
         $blocks      = $this->navigationBlockNormalizer->normalize($this->convertChildren($body, $fallbacks, true), $this->transformationProvenance()->sources(), $this->transformationProvenance()->sourceBaseHiddenStates());
@@ -3490,7 +3514,7 @@ final class HtmlTransformer
                 fn (DOMElement $item, DOMElement $anchor): string => $this->navigationUnderlineColor($item, $anchor),
                 fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->styleResolver->specificityResolvedPresentationStyle($sourceElement)),
                 fn (DOMElement $sourceElement): array => $this->navigationStyleProjector->navigationColorInteractionStates($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->navigationOverlayMenu($sourceElement)
+                fn (DOMElement $sourceElement): string => $this->navigationToggleSuppressor->navigationOverlayMenu($sourceElement)
             ),
             new MediaPatternContext(
                 fn (DOMElement $sourceElement): string => $this->styleResolver->mergedPresentationStyle($sourceElement),
@@ -3644,13 +3668,13 @@ final class HtmlTransformer
             return $block;
         }
 
-        $projectedNavigation = $this->projectedNavigationTargetForControl($element);
+        $projectedNavigation = $this->navigationToggleSuppressor->projectedNavigationTargetForControl($element);
         if ( $projectedNavigation instanceof DOMElement ) {
             $block = $this->recognizePatterns($projectedNavigation, $fallbacks, array(NavigationPattern::class));
             if ( null !== $block ) {
                 $controlAttrs = $this->styleResolver->presentationAttributes($element);
                 $nativeClassNames = 'blocks-engine-list-navigation blocks-engine-native-responsive-navigation';
-                if ( $this->isImplicitDialogNavigationControl($element) ) {
+                if ( $this->navigationToggleSuppressor->isImplicitDialogNavigationControl($element) ) {
                     $nativeClassNames .= ' blocks-engine-projected-dialog-navigation';
                 }
                 $block['attrs']['className'] = $this->mergeClassNames(
@@ -3663,7 +3687,7 @@ final class HtmlTransformer
             }
         }
 
-        if ( $this->isProjectedNavigationSuppressed($element) || $this->isRedundantMenuToggleControl($element) ) {
+        if ( $this->navigationToggleSuppressor->isProjectedNavigationSuppressed($element) || $this->navigationToggleSuppressor->isRedundantMenuToggleControl($element) ) {
             return null;
         }
 
@@ -8973,7 +8997,7 @@ if ( 'svg' === $tagName ) {
         }
 
         // Behavior is preserved or rebuilt elsewhere — not lost.
-        if ( $this->isRedundantMenuToggleControl($element) ) {
+        if ( $this->navigationToggleSuppressor->isRedundantMenuToggleControl($element) ) {
             return false;
         }
 
@@ -9050,7 +9074,7 @@ if ( 'svg' === $tagName ) {
     private function isFoldedIntoCoreNavigation(DOMElement $element): bool
     {
         for ( $node = $element; $node instanceof DOMElement; $node = $node->parentNode ) {
-            if ( $this->isNavigationMenuCandidate($node) && $this->convertsToCoreNavigation($node) ) {
+            if ( $this->navigationToggleSuppressor->isNavigationMenuCandidate($node) && $this->navigationToggleSuppressor->convertsToCoreNavigation($node) ) {
                 return true;
             }
         }
@@ -10955,7 +10979,7 @@ if ( 'svg' === $tagName ) {
                 'kind'  => 'custom',
             ), static fn ($value): bool => '' !== $value), array(), $anchor);
         }
-        $overlayMenu = $this->navigationOverlayMenu($element);
+        $overlayMenu = $this->navigationToggleSuppressor->navigationOverlayMenu($element);
         $navigationAttrs = array( 'overlayMenu' => $overlayMenu );
         if ( 'mobile' === $overlayMenu ) {
             $navigationAttrs['className'] = 'blocks-engine-native-responsive-navigation';

--- a/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
@@ -601,4 +601,19 @@ trait DomHelpersTrait
     {
         return DeterministicRowDeduplicator::dedupe($rows);
     }
+
+    /**
+     * Whether $container is $element or one of its ancestors. Shared DOM
+     * ancestry helper; consumed by form dispatch and navigation suppression.
+     */
+    private function elementContains(DOMElement $container, DOMElement $element): bool
+    {
+        for ( $node = $element; $node instanceof DOMElement; $node = $node->parentNode ) {
+            if ( $node->isSameNode($container) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionContext.php
+++ b/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionContext.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerRegistry;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeSelectorState;
+use Closure;
+use DOMElement;
+
+/**
+ * Explicit collaborator surface for {@see NavigationToggleSuppressor}.
+ *
+ * Per-transform state (runtime selectors) and the probe pattern context are
+ * resolved through closures because the suppressor is constructed once with the
+ * transformer but must see the state belonging to the transform currently
+ * running.
+ */
+final class NavigationToggleSuppressionContext
+{
+    /**
+     * @param Closure(DOMElement, string): string  $attr
+     * @param Closure(DOMElement, DOMElement): bool $elementContains
+     * @param Closure(DOMElement): bool            $hasSourceNavigationSignal
+     * @param Closure(DOMElement): bool            $sourceElementStartsHidden
+     * @param Closure(): RuntimeSelectorState      $runtimeSelectors
+     * @param Closure(): PatternRecognizerRegistry $patternRecognizers
+     * @param Closure(): PatternContext            $probePatternContext
+     */
+    public function __construct(
+        private readonly Closure $attr,
+        private readonly Closure $elementContains,
+        private readonly Closure $hasSourceNavigationSignal,
+        private readonly Closure $sourceElementStartsHidden,
+        private readonly Closure $runtimeSelectors,
+        private readonly Closure $patternRecognizers,
+        private readonly Closure $probePatternContext
+    ) {
+    }
+
+    public function attr(DOMElement $element, string $name): string
+    {
+        return ($this->attr)($element, $name);
+    }
+
+    public function elementContains(DOMElement $container, DOMElement $element): bool
+    {
+        return ($this->elementContains)($container, $element);
+    }
+
+    public function hasSourceNavigationSignal(DOMElement $element): bool
+    {
+        return ($this->hasSourceNavigationSignal)($element);
+    }
+
+    public function sourceElementStartsHidden(DOMElement $element): bool
+    {
+        return ($this->sourceElementStartsHidden)($element);
+    }
+
+    public function runtimeSelectors(): RuntimeSelectorState
+    {
+        return ($this->runtimeSelectors)();
+    }
+
+    public function patternRecognizers(): PatternRecognizerRegistry
+    {
+        return ($this->patternRecognizers)();
+    }
+
+    public function probePatternContext(): PatternContext
+    {
+        return ($this->probePatternContext)();
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressor.php
+++ b/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressor.php
@@ -3,12 +3,31 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolver;
 use DOMDocument;
 use DOMElement;
 use DOMNode;
 
-trait NavigationToggleSuppressionTrait
+/**
+ * Decides which source menu toggles and overlay menus are superseded by the
+ * emitted core/navigation, and which source nodes the projection suppresses.
+ *
+ * Extracted from HtmlTransformer as a collaborator rather than a mixin: every
+ * dependency it needs from the transformer is declared on
+ * {@see NavigationToggleSuppressionContext}, so this class has no $this access
+ * to the transformer and can be exercised without constructing one.
+ *
+ * The three projection maps below are per-transformer rather than per-transform,
+ * preserving the lifetime they had as trait properties. That lifetime is the
+ * subject of a separate defect report; this class does not change it.
+ */
+final class NavigationToggleSuppressor
 {
+    public function __construct(
+        private readonly NavigationToggleSuppressionContext $context,
+        private readonly StyleResolver $styleResolver
+    ) {
+    }
     /** @var array<string, DOMElement> */
     private array $projectedNavigationTargetsByControlPath = array();
 
@@ -23,12 +42,12 @@ trait NavigationToggleSuppressionTrait
      * conversion. The responsive core/navigation must occupy the control's
      * layout slot, not the hidden overlay's document position.
      */
-    private function collectProjectedNavigationRelationships(DOMElement $root): void
+    public function collectProjectedNavigationRelationships(DOMElement $root): void
     {
         $elementsById = array();
         foreach ( $root->getElementsByTagName('*') as $element ) {
-            if ( $element instanceof DOMElement && '' !== trim($this->attr($element, 'id')) ) {
-                $elementsById[trim($this->attr($element, 'id'))] = $element;
+            if ( $element instanceof DOMElement && '' !== trim($this->context->attr($element, 'id')) ) {
+                $elementsById[trim($this->context->attr($element, 'id'))] = $element;
             }
         }
 
@@ -37,7 +56,7 @@ trait NavigationToggleSuppressionTrait
                 continue;
             }
 
-            foreach ( preg_split('/\s+/', trim($this->attr($control, 'aria-controls'))) ?: array() as $controlledId ) {
+            foreach ( preg_split('/\s+/', trim($this->context->attr($control, 'aria-controls'))) ?: array() as $controlledId ) {
                 $target = $elementsById[ltrim($controlledId, '#')] ?? null;
                 $navigation = $target instanceof DOMElement ? $this->hiddenNavigationInControlledTarget($target) : null;
                 if ( ! $target instanceof DOMElement || ! $navigation instanceof DOMElement ) {
@@ -73,7 +92,7 @@ trait NavigationToggleSuppressionTrait
 
     private function hasDialogPopupSemantics(DOMElement $control): bool
     {
-        return in_array('dialog', preg_split('/\s+/', strtolower(trim($this->attr($control, 'aria-haspopup')))) ?: array(), true)
+        return in_array('dialog', preg_split('/\s+/', strtolower(trim($this->context->attr($control, 'aria-haspopup')))) ?: array(), true)
             && $control->hasAttribute('aria-expanded');
     }
 
@@ -110,7 +129,7 @@ trait NavigationToggleSuppressionTrait
     private function hiddenNavigationInControlledTarget(DOMElement $target): ?DOMElement
     {
         $tagName = strtolower($target->tagName);
-        $role = strtolower($this->attr($target, 'role'));
+        $role = strtolower($this->context->attr($target, 'role'));
         if ( ! $this->sourceElementIsHidden($target)
             || ( ! in_array($tagName, array( 'dialog', 'nav' ), true)
                 && ! in_array($role, array( 'dialog', 'alertdialog', 'navigation' ), true) ) ) {
@@ -137,28 +156,28 @@ trait NavigationToggleSuppressionTrait
     private function isSemanticDialog(DOMElement $element): bool
     {
         return 'dialog' === strtolower($element->tagName)
-            || in_array(strtolower($this->attr($element, 'role')), array( 'dialog', 'alertdialog' ), true);
+            || in_array(strtolower($this->context->attr($element, 'role')), array( 'dialog', 'alertdialog' ), true);
     }
 
     private function sourceElementIsHidden(DOMElement $element): bool
     {
-        return $this->sourceElementStartsHidden($element)
+        return $this->context->sourceElementStartsHidden($element)
             || $element->hasAttribute('hidden')
-            || 'true' === strtolower($this->attr($element, 'aria-hidden'))
-            || 'false' === strtolower($this->attr($element, 'data-visible'));
+            || 'true' === strtolower($this->context->attr($element, 'aria-hidden'))
+            || 'false' === strtolower($this->context->attr($element, 'data-visible'));
     }
 
-    private function projectedNavigationTargetForControl(DOMElement $control): ?DOMElement
+    public function projectedNavigationTargetForControl(DOMElement $control): ?DOMElement
     {
         return $this->projectedNavigationTargetsByControlPath[$control->getNodePath()] ?? null;
     }
 
-    private function isImplicitDialogNavigationControl(DOMElement $control): bool
+    public function isImplicitDialogNavigationControl(DOMElement $control): bool
     {
         return isset($this->implicitDialogNavigationControlPaths[$control->getNodePath()]);
     }
 
-    private function isProjectedNavigationSuppressed(DOMElement $element): bool
+    public function isProjectedNavigationSuppressed(DOMElement $element): bool
     {
         return isset($this->projectedNavigationSuppressedPaths[$element->getNodePath()]);
     }
@@ -181,7 +200,7 @@ trait NavigationToggleSuppressionTrait
      * labeled buttons, and toggle-shaped controls with no associated navigation,
      * still convert to core/button normally.
      */
-    private function isRedundantMenuToggleControl(DOMElement $element): bool
+    public function isRedundantMenuToggleControl(DOMElement $element): bool
     {
         if ( ! $this->isHamburgerMenuToggleControl($element) ) {
             return false;
@@ -200,7 +219,7 @@ trait NavigationToggleSuppressionTrait
      * predicate captures the superseded selectors independently of which drop
      * path executed, with no per-path bookkeeping.
      */
-    private function collectSupersededNavToggleSelectors(DOMElement $root): void
+    public function collectSupersededNavToggleSelectors(DOMElement $root): void
     {
         foreach ( $root->getElementsByTagName('*') as $element ) {
             if ( $element instanceof DOMElement && $this->isRedundantMenuToggleControl($element) ) {
@@ -224,13 +243,13 @@ trait NavigationToggleSuppressionTrait
     {
         $this->recordSupersededSelectorsForElement($toggle);
 
-        foreach ( preg_split('/\s+/', trim($this->attr($toggle, 'aria-controls'))) ?: array() as $controlledId ) {
+        foreach ( preg_split('/\s+/', trim($this->context->attr($toggle, 'aria-controls'))) ?: array() as $controlledId ) {
             $controlledId = ltrim(trim($controlledId), '#');
             if ( '' === $controlledId ) {
                 continue;
             }
 
-            $this->runtimeSelectors()->supersede('#' . $controlledId);
+            $this->context->runtimeSelectors()->supersede('#' . $controlledId);
 
             $target = $this->elementWithId($toggle, $controlledId);
             if ( $target instanceof DOMElement && ! $target->isSameNode($toggle) ) {
@@ -290,25 +309,25 @@ trait NavigationToggleSuppressionTrait
             return false;
         }
 
-        $label = strtolower($this->attr($element, 'aria-label'));
+        $label = strtolower($this->context->attr($element, 'aria-label'));
         if ( str_contains($label, 'navigation') || str_contains($label, 'menu') || str_contains($label, 'mobile') ) {
             return true;
         }
 
-        $role = strtolower($this->attr($element, 'role'));
+        $role = strtolower($this->context->attr($element, 'role'));
         return 'navigation' === $role;
     }
 
     private function recordSupersededSelectorsForElement(DOMElement $element): void
     {
-        $id = trim($this->attr($element, 'id'));
+        $id = trim($this->context->attr($element, 'id'));
         if ( '' !== $id ) {
-            $this->runtimeSelectors()->supersede('#' . $id);
+            $this->context->runtimeSelectors()->supersede('#' . $id);
         }
 
-        foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) {
+        foreach ( preg_split('/\s+/', trim($this->context->attr($element, 'class'))) ?: array() as $class ) {
             if ( '' !== $class ) {
-                $this->runtimeSelectors()->supersede('.' . $class);
+                $this->context->runtimeSelectors()->supersede('.' . $class);
             }
         }
     }
@@ -324,7 +343,7 @@ trait NavigationToggleSuppressionTrait
         }
 
         $isButton = 'button' === $tagName;
-        $isButtonRoleAnchor = 'a' === $tagName && 'button' === strtolower($this->attr($element, 'role'));
+        $isButtonRoleAnchor = 'a' === $tagName && 'button' === strtolower($this->context->attr($element, 'role'));
         if ( ! $isButton && ! $isButtonRoleAnchor ) {
             return false;
         }
@@ -351,7 +370,7 @@ trait NavigationToggleSuppressionTrait
 
     private function isCheckboxBoundEmptyLabel(DOMElement $element): bool
     {
-        $controlId = trim($this->attr($element, 'for'));
+        $controlId = trim($this->context->attr($element, 'for'));
         if ( '' === $controlId || '' !== $this->visibleMenuToggleLabel($element) ) {
             return false;
         }
@@ -359,7 +378,7 @@ trait NavigationToggleSuppressionTrait
         $control = $this->elementWithId($element, $controlId);
         if ( ! $control instanceof DOMElement
             || 'input' !== strtolower($control->tagName)
-            || 'checkbox' !== strtolower($this->attr($control, 'type'))
+            || 'checkbox' !== strtolower($this->context->attr($control, 'type'))
             || ! $this->hasCheckboxNavigationToggleSignal($element, $control)
         ) {
             return false;
@@ -381,7 +400,7 @@ trait NavigationToggleSuppressionTrait
         $identity = array();
         foreach ( array( $label, $control ) as $element ) {
             foreach ( array( 'id', 'class', 'aria-label', 'aria-controls', 'title' ) as $attribute ) {
-                $identity[] = $this->attr($element, $attribute);
+                $identity[] = $this->context->attr($element, $attribute);
             }
         }
 
@@ -390,8 +409,8 @@ trait NavigationToggleSuppressionTrait
 
     private function isCheckboxWithEmptyBoundLabel(DOMElement $element): bool
     {
-        $controlId = trim($this->attr($element, 'id'));
-        if ( '' === $controlId || 'checkbox' !== strtolower($this->attr($element, 'type')) ) {
+        $controlId = trim($this->context->attr($element, 'id'));
+        if ( '' === $controlId || 'checkbox' !== strtolower($this->context->attr($element, 'type')) ) {
             return false;
         }
 
@@ -402,7 +421,7 @@ trait NavigationToggleSuppressionTrait
 
         foreach ( $document->getElementsByTagName('label') as $label ) {
             if ( $label instanceof DOMElement
-                && $controlId === trim($this->attr($label, 'for'))
+                && $controlId === trim($this->context->attr($label, 'for'))
                 && $this->isCheckboxBoundEmptyLabel($label)
             ) {
                 return true;
@@ -510,7 +529,7 @@ trait NavigationToggleSuppressionTrait
 
         if ( ! $node instanceof DOMElement
             || 'svg' === strtolower($node->tagName)
-            || 'true' === strtolower($this->attr($node, 'aria-hidden'))
+            || 'true' === strtolower($this->context->attr($node, 'aria-hidden'))
             || $this->hasHiddenDisplay($node) ) {
             return '';
         }
@@ -539,7 +558,7 @@ trait NavigationToggleSuppressionTrait
      */
     private function hasAssociatedNavigationMenu(DOMElement $toggle): bool
     {
-        $controlledIds = preg_split('/\s+/', trim($this->attr($toggle, 'aria-controls'))) ?: array();
+        $controlledIds = preg_split('/\s+/', trim($this->context->attr($toggle, 'aria-controls'))) ?: array();
         foreach ( $controlledIds as $controlledId ) {
             if ( '' === $controlledId ) {
                 continue;
@@ -573,7 +592,7 @@ trait NavigationToggleSuppressionTrait
      * Preserve a responsive overlay only when the source declares equivalent
      * desktop/mobile menus or an associated hamburger control.
      */
-    private function navigationOverlayMenu(DOMElement $navigation): string
+    public function navigationOverlayMenu(DOMElement $navigation): string
     {
         if ( $this->hasEquivalentSourceNavigationVariant($navigation) ) {
             return 'mobile';
@@ -600,27 +619,27 @@ trait NavigationToggleSuppressionTrait
                 continue;
             }
 
-            if ( $this->elementContains($navigation, $toggle) ) {
+            if ( $this->context->elementContains($navigation, $toggle) ) {
                 return 'mobile';
             }
 
-            foreach ( preg_split('/\s+/', trim($this->attr($toggle, 'aria-controls'))) ?: array() as $controlledId ) {
+            foreach ( preg_split('/\s+/', trim($this->context->attr($toggle, 'aria-controls'))) ?: array() as $controlledId ) {
                 $target = '' === $controlledId ? null : $this->elementWithId($toggle, $controlledId);
                 if ( $target instanceof DOMElement
-                    && ($this->elementContains($target, $navigation) || $this->elementContains($navigation, $target))
+                    && ($this->context->elementContains($target, $navigation) || $this->context->elementContains($navigation, $target))
                 ) {
                     return 'mobile';
                 }
             }
 
             for ( $container = $toggle->parentNode; $container instanceof DOMElement && 'body' !== strtolower($container->tagName); $container = $container->parentNode ) {
-                if ( $this->elementContains($container, $navigation) ) {
+                if ( $this->context->elementContains($container, $navigation) ) {
                     return 'mobile';
                 }
             }
 
             $scope = $this->menuToggleScope($toggle);
-            if ( 'body' !== strtolower($scope->tagName) && $this->elementContains($scope, $navigation) ) {
+            if ( 'body' !== strtolower($scope->tagName) && $this->context->elementContains($scope, $navigation) ) {
                 return 'mobile';
             }
         }
@@ -645,8 +664,8 @@ trait NavigationToggleSuppressionTrait
             if ( ! $candidate instanceof DOMElement
                 || $candidate->isSameNode($navigationRoot)
                 || $this->isProjectedNavigationSuppressed($candidate)
-                || $this->elementContains($navigationRoot, $candidate)
-                || $this->elementContains($candidate, $navigationRoot)
+                || $this->context->elementContains($navigationRoot, $candidate)
+                || $this->context->elementContains($candidate, $navigationRoot)
             ) {
                 continue;
             }
@@ -663,7 +682,7 @@ trait NavigationToggleSuppressionTrait
     private function hasMobileNavigationSignal(DOMElement $element): bool
     {
         for ( $node = $element; $node instanceof DOMElement && 'body' !== strtolower($node->tagName); $node = $node->parentNode ) {
-            $identity = strtolower(trim($this->attr($node, 'id') . ' ' . $this->attr($node, 'class') . ' ' . $this->attr($node, 'aria-label')));
+            $identity = strtolower(trim($this->context->attr($node, 'id') . ' ' . $this->context->attr($node, 'class') . ' ' . $this->context->attr($node, 'aria-label')));
             if ( preg_match('/(?:^|[\s_-])(?:mobile|drawer|offcanvas|overlay|menu-panel|nav-panel)(?:$|[\s_-])/', $identity) ) {
                 return true;
             }
@@ -688,23 +707,13 @@ trait NavigationToggleSuppressionTrait
         $links = array();
         foreach ( $navigation->getElementsByTagName('a') as $anchor ) {
             if ( $anchor instanceof DOMElement && '' !== trim($anchor->textContent ?? '') ) {
-                $links[] = strtolower(trim($anchor->textContent ?? '')) . '|' . trim($this->attr($anchor, 'href'));
+                $links[] = strtolower(trim($anchor->textContent ?? '')) . '|' . trim($this->context->attr($anchor, 'href'));
             }
         }
 
         return 2 > count($links) ? '' : implode("\n", $links);
     }
 
-    private function elementContains(DOMElement $container, DOMElement $element): bool
-    {
-        for ( $node = $element; $node instanceof DOMElement; $node = $node->parentNode ) {
-            if ( $node->isSameNode($container) ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
 
     /**
      * Whether an element is a navigation menu the toggle can be bound to: a
@@ -719,7 +728,7 @@ trait NavigationToggleSuppressionTrait
 
     private function isNavigationLandmark(DOMElement $element): bool
     {
-        return 'nav' === strtolower($element->tagName) || 'navigation' === strtolower($this->attr($element, 'role'));
+        return 'nav' === strtolower($element->tagName) || 'navigation' === strtolower($this->context->attr($element, 'role'));
     }
 
     /**
@@ -734,7 +743,7 @@ trait NavigationToggleSuppressionTrait
                 return $node;
             }
 
-            if ( in_array($tagName, array( 'header', 'nav' ), true) || in_array(strtolower($this->attr($node, 'role')), array( 'banner', 'navigation' ), true) ) {
+            if ( in_array($tagName, array( 'header', 'nav' ), true) || in_array(strtolower($this->context->attr($node, 'role')), array( 'banner', 'navigation' ), true) ) {
                 return $node;
             }
         }
@@ -742,21 +751,21 @@ trait NavigationToggleSuppressionTrait
         return $toggle;
     }
 
-    private function isNavigationMenuCandidate(DOMElement $element): bool
+    public function isNavigationMenuCandidate(DOMElement $element): bool
     {
         $tagName = strtolower($element->tagName);
-        if ( 'nav' === $tagName || 'navigation' === strtolower($this->attr($element, 'role')) ) {
+        if ( 'nav' === $tagName || 'navigation' === strtolower($this->context->attr($element, 'role')) ) {
             return true;
         }
 
-        return in_array($tagName, array( 'ul', 'ol' ), true) && $this->hasSourceNavigationSignal($element);
+        return in_array($tagName, array( 'ul', 'ol' ), true) && $this->context->hasSourceNavigationSignal($element);
     }
 
-    private function convertsToCoreNavigation(DOMElement $element): bool
+    public function convertsToCoreNavigation(DOMElement $element): bool
     {
-        $navigation = $this->patternRecognizers->firstMatch(
+        $navigation = $this->context->patternRecognizers()->firstMatch(
             $element,
-            $this->probePatternContext(),
+            $this->context->probePatternContext(),
             array( \Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationPattern::class )
         );
 


### PR DESCRIPTION
Slice 8 for #242, workstream 1. Part of #1327. Follows #1333.

> **Stacked on #1333.** Base is `refactor-1327-navigation-style-projector`, so this diff shows only slice 8. Both slices rewrite `HtmlTransformer` heavily, and the epic asks for a quiet base rather than racing the same file. GitHub will retarget this to `trunk` once #1333 merges.

`NavigationToggleSuppressionTrait` was a 781-line single-consumer mixin. It is now `NavigationToggleSuppressor` behind a 7-operation `NavigationToggleSuppressionContext`, with no `$this` access to the transformer.

## The measurement in #1327 was wrong, in a useful direction

#1327 recorded 10 external dependencies for this trait. Three of those — `projectedNavigationTargetsByControlPath`, `projectedNavigationSuppressedPaths`, `implicitDialogNavigationControlPaths` — are properties the trait *declares itself*. The counting method matched `$this->x` against method names only, so trait-owned properties were miscounted as reaching outward.

The true figure is **7**, which makes this a cheaper slice than advertised rather than a more expensive one. The ranking in #1327 is unaffected — this was already second — but the same correction should be applied before estimating the remaining traits.

## `elementContains` moved to `DomHelpersTrait`, not into the collaborator

It is a nine-line DOM ancestry check with no `$this` dependency, and `FormDispatchTrait` consumes it as well. Moving it into a class named `NavigationToggleSuppressor` would have left form dispatch reaching into navigation suppression for a generic helper.

`DomHelpersTrait` is the legitimate shared mixin here — four consumers, three of them standalone classes — so that is where it goes. The suppressor reaches it through the context, and form dispatch is unaffected.

## The three projection maps, and a defect they exposed

The maps are keyed by `DOMElement::getNodePath()` and were declared on the trait, meaning they lived on the transformer instance rather than the per-transform session, and were never reset. They move into the collaborator with **that lifetime deliberately preserved** — the collaborator is constructed once per transformer, so semantics are unchanged.

That lifetime is a real defect: node paths collide across unrelated documents, so on a reused `HtmlTransformer` a document's output depends on what was transformed before it. Reproduced on corpus fixtures at 2,357 bytes of lost markup, with `CorpusDiagnosticsRunner` and `StaticStyleParityRunner` both on the reachable path. Filed as **#1334** rather than fixed here, per the epic's rule against smuggling logic changes into an extraction slice. It is easier to fix afterwards, with the state in one collaborator instead of a mixin sharing the transformer's scope.

## Behavior preservation

`serialized_blocks` SHA-256 plus block, diagnostic, fallback, asset-count, asset-key and coverage fingerprints, captured on this branch's base and recaptured after:

```
383 documents — DIFFERING: 0 — threw: 0
markup: 22,047,755 bytes across 383 distinct hashes
```

`composer test` exit 0.

The distinct-hash count is quoted deliberately. The harness used for #1333 read a camelCase key that `TransformerResult::toArray()` does not emit, so every document hashed the empty string and the markup comparison was vacuous — corrected and re-verified [in a comment on that PR](https://github.com/Automattic/blocks-engine/pull/1333#issuecomment-5459345077). The harness now fails hard on a missing key and records markup length, and **383 distinct hashes over 22 MB is the check that the fingerprint can actually discriminate.** A zero-diff result is only worth as much as the variance in the signal behind it.

## Impact

| | slice-7 base | after |
|---|---:|---:|
| `HtmlTransformer.php` | 12,771 | 12,803 |
| **Object scope (class + single-consumer mixins)** | **16,994** | **16,245** |

749 lines and 37 methods leave the shared mutable scope for 32 lines of wiring.

Cumulative across slices 7 and 8: **18,253 → 16,245**, a 2,008-line reduction in the transformer's object scope.

Remaining single-consumer mixins: `FormDispatchTrait` (1,865 / 30 deps), `SvgMaterializationTrait` (983 / 20), `ElementConversionTrait` (594 / 89 — not a collaborator candidate, see #1327). Their dependency counts should be re-measured with the property correction above and the `self::`/`static::` constant check from #1333 before the next slice is scoped.

## Verification notes

No `self::`/`static::` constants in this trait — checked up front, since that gap is what broke #1333 mid-flight. No test reflected on any of the 37 moved methods.

---

*AI assistance disclosure: implemented and drafted by Claude Sonnet 4.6 running in Claude Code, operated by @chubes4. The AI re-measured the trait's dependency surface and corrected the earlier count, performed the extraction, relocated `elementContains`, discovered and separately reported the state-lifetime defect in #1334, captured and compared the corpus fingerprints, and wrote this description. Reviewed by a human before opening.*
