### PR TITLE
Reset navigation projection state per transform (#1334)

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -107,6 +107,7 @@
       "php tests/unit/navigation-brand-anchor-hoist.php",
       "php tests/unit/navigation-brand-cue-carrier.php",
       "php tests/unit/navigation-author-rule-memory.php",
+      "php tests/unit/navigation-projection-state-isolation.php",
       "php tests/unit/navigation-direct-cluster-parity.php",
       "php tests/unit/navigation-block-normalizer.php",
       "php tests/unit/navigation-inline-margin-carry.php",

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -8,6 +8,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerS
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\ReusableComponentState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeBehaviorState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeDomState;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\NavigationProjectionState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeSelectorState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\TransformationEvidenceState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\TransformationProvenanceState;
@@ -480,6 +481,7 @@ final class HtmlTransformer
             fn (DOMElement $element): bool => $this->hasSourceNavigationSignal($element),
             fn (DOMElement $element): bool => $this->sourceElementStartsHidden($element),
             fn (): RuntimeSelectorState => $this->runtimeSelectors(),
+            fn (): NavigationProjectionState => $this->navigationProjection(),
             fn (): PatternRecognizerRegistry => $this->patternRecognizers,
             fn (): PatternContext => $this->probePatternContext()
         );
@@ -715,6 +717,11 @@ final class HtmlTransformer
     private function runtimeSelectors(): RuntimeSelectorState
     {
         return $this->session->runtimeSelectorState();
+    }
+
+    private function navigationProjection(): NavigationProjectionState
+    {
+        return $this->session->navigationProjectionState();
     }
 
     private function sourceStyles(): SourceStyleResolutionState

--- a/php-transformer/src/HtmlToBlocks/Session/HtmlTransformerSession.php
+++ b/php-transformer/src/HtmlToBlocks/Session/HtmlTransformerSession.php
@@ -26,6 +26,7 @@ final class HtmlTransformerSession
     private readonly TransformationEvidenceState $transformationEvidenceState;
     private readonly TransformationProvenanceState $transformationProvenanceState;
     private readonly RuntimeBehaviorState $runtimeBehaviorState;
+    private readonly NavigationProjectionState $navigationProjectionState;
     private readonly RuntimeDomState $runtimeDomState;
     private readonly ReusableComponentState $reusableComponentState;
     private ?GeneratedBlockRegistry $generatedBlockRegistry = null;
@@ -54,6 +55,7 @@ final class HtmlTransformerSession
         $this->transformationProvenanceState = new TransformationProvenanceState();
         $this->transformationEvidenceState = new TransformationEvidenceState();
         $this->runtimeBehaviorState = new RuntimeBehaviorState();
+        $this->navigationProjectionState = new NavigationProjectionState();
         $this->runtimeSelectorState = new RuntimeSelectorState(array(), array(), array());
     }
 
@@ -146,6 +148,11 @@ final class HtmlTransformerSession
     public function runtimeBehaviorState(): RuntimeBehaviorState
     {
         return $this->runtimeBehaviorState;
+    }
+
+    public function navigationProjectionState(): NavigationProjectionState
+    {
+        return $this->navigationProjectionState;
     }
 
     public function configurePolicy(bool $preserveShellLandmarks, bool $fallbackReductionMode): void

--- a/php-transformer/src/HtmlToBlocks/Session/NavigationProjectionState.php
+++ b/php-transformer/src/HtmlToBlocks/Session/NavigationProjectionState.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session;
+
+use DOMElement;
+
+/**
+ * Per-transform navigation projection relationships.
+ *
+ * Records which source control projects which navigation, which source nodes
+ * the projection suppresses, and which controls are implicit dialog triggers.
+ *
+ * Keys are `DOMElement::getNodePath()` values such as
+ * `/html/body/div[1]/button[1]`, which are only meaningful within the document
+ * they came from and collide freely across documents. Holding this state for
+ * the duration of a single transform is therefore a correctness requirement,
+ * not a housekeeping preference.
+ */
+final class NavigationProjectionState
+{
+    /** @var array<string, DOMElement> */
+    private array $targetsByControlPath = array();
+
+    /** @var array<string, true> */
+    private array $suppressedPaths = array();
+
+    /** @var array<string, true> */
+    private array $implicitDialogControlPaths = array();
+
+    public function hasTargetForControl(DOMElement $control): bool
+    {
+        return isset($this->targetsByControlPath[$control->getNodePath()]);
+    }
+
+    public function targetForControl(DOMElement $control): ?DOMElement
+    {
+        return $this->targetsByControlPath[$control->getNodePath()] ?? null;
+    }
+
+    public function projectTarget(DOMElement $control, DOMElement $navigation): void
+    {
+        $this->targetsByControlPath[$control->getNodePath()] = $navigation;
+    }
+
+    public function suppress(DOMElement $element): void
+    {
+        $this->suppressedPaths[$element->getNodePath()] = true;
+    }
+
+    public function isSuppressed(DOMElement $element): bool
+    {
+        return isset($this->suppressedPaths[$element->getNodePath()]);
+    }
+
+    public function markImplicitDialogControl(DOMElement $control): void
+    {
+        $this->implicitDialogControlPaths[$control->getNodePath()] = true;
+    }
+
+    public function isImplicitDialogControl(DOMElement $control): bool
+    {
+        return isset($this->implicitDialogControlPaths[$control->getNodePath()]);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionContext.php
+++ b/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionContext.php
@@ -5,6 +5,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerRegistry;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\NavigationProjectionState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeSelectorState;
 use Closure;
 use DOMElement;
@@ -12,8 +13,8 @@ use DOMElement;
 /**
  * Explicit collaborator surface for {@see NavigationToggleSuppressor}.
  *
- * Per-transform state (runtime selectors) and the probe pattern context are
- * resolved through closures because the suppressor is constructed once with the
+ * Per-transform state (runtime selectors, navigation projection) and the probe
+ * pattern context are resolved through closures because the suppressor is constructed once with the
  * transformer but must see the state belonging to the transform currently
  * running.
  */
@@ -25,6 +26,7 @@ final class NavigationToggleSuppressionContext
      * @param Closure(DOMElement): bool            $hasSourceNavigationSignal
      * @param Closure(DOMElement): bool            $sourceElementStartsHidden
      * @param Closure(): RuntimeSelectorState      $runtimeSelectors
+     * @param Closure(): NavigationProjectionState $navigationProjection
      * @param Closure(): PatternRecognizerRegistry $patternRecognizers
      * @param Closure(): PatternContext            $probePatternContext
      */
@@ -34,6 +36,7 @@ final class NavigationToggleSuppressionContext
         private readonly Closure $hasSourceNavigationSignal,
         private readonly Closure $sourceElementStartsHidden,
         private readonly Closure $runtimeSelectors,
+        private readonly Closure $navigationProjection,
         private readonly Closure $patternRecognizers,
         private readonly Closure $probePatternContext
     ) {
@@ -62,6 +65,11 @@ final class NavigationToggleSuppressionContext
     public function runtimeSelectors(): RuntimeSelectorState
     {
         return ($this->runtimeSelectors)();
+    }
+
+    public function navigationProjection(): NavigationProjectionState
+    {
+        return ($this->navigationProjection)();
     }
 
     public function patternRecognizers(): PatternRecognizerRegistry

--- a/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressor.php
+++ b/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressor.php
@@ -17,9 +17,8 @@ use DOMNode;
  * {@see NavigationToggleSuppressionContext}, so this class has no $this access
  * to the transformer and can be exercised without constructing one.
  *
- * The three projection maps below are per-transformer rather than per-transform,
- * preserving the lifetime they had as trait properties. That lifetime is the
- * subject of a separate defect report; this class does not change it.
+ * Projection state lives on the per-transform session rather than on this
+ * collaborator, so it resets with every transform.
  */
 final class NavigationToggleSuppressor
 {
@@ -28,15 +27,6 @@ final class NavigationToggleSuppressor
         private readonly StyleResolver $styleResolver
     ) {
     }
-    /** @var array<string, DOMElement> */
-    private array $projectedNavigationTargetsByControlPath = array();
-
-    /** @var array<string, true> */
-    private array $projectedNavigationSuppressedPaths = array();
-
-    /** @var array<string, true> */
-    private array $implicitDialogNavigationControlPaths = array();
-
     /**
      * Bind a hidden dialog/menu to its source hamburger before recursive
      * conversion. The responsive core/navigation must occupy the control's
@@ -66,14 +56,14 @@ final class NavigationToggleSuppressor
                 break;
             }
 
-            if ( isset($this->projectedNavigationTargetsByControlPath[$control->getNodePath()])
+            if ( $this->context->navigationProjection()->hasTargetForControl($control)
                 || ! $this->hasDialogPopupSemantics($control) ) {
                 continue;
             }
 
             $relationship = $this->implicitHiddenNavigationRelationship($control);
             if ( null !== $relationship ) {
-                $this->implicitDialogNavigationControlPaths[$control->getNodePath()] = true;
+                $this->context->navigationProjection()->markImplicitDialogControl($control);
                 $this->recordProjectedNavigationRelationship($control, $relationship['target'], $relationship['navigation']);
             }
         }
@@ -81,13 +71,13 @@ final class NavigationToggleSuppressor
 
     private function recordProjectedNavigationRelationship(DOMElement $control, DOMElement $target, DOMElement $navigation): void
     {
-        if ( isset($this->projectedNavigationSuppressedPaths[$navigation->getNodePath()]) ) {
+        if ( $this->context->navigationProjection()->isSuppressed($navigation) ) {
             return;
         }
 
-        $this->projectedNavigationTargetsByControlPath[$control->getNodePath()] = $navigation;
-        $this->projectedNavigationSuppressedPaths[$target->getNodePath()] = true;
-        $this->projectedNavigationSuppressedPaths[$navigation->getNodePath()] = true;
+        $this->context->navigationProjection()->projectTarget($control, $navigation);
+        $this->context->navigationProjection()->suppress($target);
+        $this->context->navigationProjection()->suppress($navigation);
     }
 
     private function hasDialogPopupSemantics(DOMElement $control): bool
@@ -169,17 +159,17 @@ final class NavigationToggleSuppressor
 
     public function projectedNavigationTargetForControl(DOMElement $control): ?DOMElement
     {
-        return $this->projectedNavigationTargetsByControlPath[$control->getNodePath()] ?? null;
+        return $this->context->navigationProjection()->targetForControl($control);
     }
 
     public function isImplicitDialogNavigationControl(DOMElement $control): bool
     {
-        return isset($this->implicitDialogNavigationControlPaths[$control->getNodePath()]);
+        return $this->context->navigationProjection()->isImplicitDialogControl($control);
     }
 
     public function isProjectedNavigationSuppressed(DOMElement $element): bool
     {
-        return isset($this->projectedNavigationSuppressedPaths[$element->getNodePath()]);
+        return $this->context->navigationProjection()->isSuppressed($element);
     }
 
     /**

--- a/php-transformer/tests/unit/navigation-projection-state-isolation.php
+++ b/php-transformer/tests/unit/navigation-projection-state-isolation.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Regression contract for #1334.
+ *
+ * Navigation projection state is keyed by DOMElement::getNodePath(), and those
+ * paths collide freely across unrelated documents. When the state lived on the
+ * transformer instead of the per-transform session it was never reset, so a
+ * document transformed on a reused HtmlTransformer could inherit suppression
+ * decisions belonging to an earlier document and silently lose block markup.
+ *
+ * The contract: transforming a document on a reused transformer must produce
+ * exactly what transforming it on a fresh transformer produces.
+ */
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\NavigationProjectionState;
+
+$corpus = dirname(__DIR__, 3) . '/fixtures/websites';
+
+/** A document whose hamburger control projects onto a hidden navigation. */
+$priming = $corpus . '/33-sports-team-league/index.html';
+/** An unrelated document that must not inherit those decisions. */
+$subject = $corpus . '/12-portfolio/index.html';
+
+foreach (array($priming, $subject) as $path) {
+    if (! is_file($path)) {
+        fwrite(STDERR, "Navigation projection isolation contract needs fixture: {$path}\n");
+        exit(1);
+    }
+}
+
+$cssFor = static function (string $htmlPath): string {
+    $css = '';
+    foreach (glob(dirname($htmlPath) . '/css/*.css') ?: array() as $stylesheet) {
+        $css .= file_get_contents($stylesheet) . "\n";
+    }
+    return $css;
+};
+
+$markup = static function (HtmlTransformer $transformer, string $htmlPath) use ($cssFor): string {
+    $result = $transformer->transform(
+        (string) file_get_contents($htmlPath),
+        array( 'static_css' => $cssFor($htmlPath) )
+    )->toArray();
+
+    return (string) $result['serialized_blocks'];
+};
+
+$expected = $markup(new HtmlTransformer(), $subject);
+
+$reused = new HtmlTransformer();
+$markup($reused, $priming);
+$actual = $markup($reused, $subject);
+
+if ($expected !== $actual) {
+    fwrite(STDERR, sprintf(
+        "Navigation projection isolation contract failed: reused transformer produced %d bytes, fresh produced %d.\n",
+        strlen($actual),
+        strlen($expected)
+    ));
+    exit(1);
+}
+
+// The priming document must genuinely exercise the projection path, otherwise
+// the comparison above passes for the wrong reason.
+$probe = new HtmlTransformer();
+$markup($probe, $priming);
+$session = ( new ReflectionClass($probe) )->getProperty('session')->getValue($probe);
+$state = $session->navigationProjectionState();
+if (! $state instanceof NavigationProjectionState) {
+    fwrite(STDERR, "Navigation projection isolation contract failed: session exposes no projection state.\n");
+    exit(1);
+}
+
+$document = new DOMDocument();
+$document->loadHTML('<!doctype html><html><body><button></button></body></html>');
+$control = $document->getElementsByTagName('button')->item(0);
+if (! $control instanceof DOMElement) {
+    throw new RuntimeException('Projection probe fixture did not produce a control element.');
+}
+$state->projectTarget($control, $control);
+$state->suppress($control);
+if (! $state->hasTargetForControl($control) || ! $state->isSuppressed($control)) {
+    fwrite(STDERR, "Navigation projection isolation contract failed: state does not record projections.\n");
+    exit(1);
+}
+
+// A fresh transform must not see the writes above.
+$markup($probe, $subject);
+$freshState = ( new ReflectionClass($probe) )->getProperty('session')->getValue($probe)->navigationProjectionState();
+if ($freshState->hasTargetForControl($control) || $freshState->isSuppressed($control)) {
+    fwrite(STDERR, "Navigation projection isolation contract failed: state survived a transform.\n");
+    exit(1);
+}
+
+fwrite(STDOUT, "Navigation projection isolation contract passed\n");


### PR DESCRIPTION
Fixes #1334.

Navigation projection state is keyed by `DOMElement::getNodePath()` — values like `/html/body/div[1]/button[1]` that are only meaningful inside the document they came from. The three maps holding it lived on the transformer rather than the per-transform session and were never reset, so a document transformed on a reused `HtmlTransformer` inherited suppression decisions belonging to whatever ran before it.

## Blast radius is larger than the report

#1334 demonstrated one document losing 2,357 bytes. Running the full corpus through a single shared transformer and comparing each document against its own fresh-instance output:

| | documents differing |
|---|---:|
| Current `trunk` | **143 of 374** |
| This branch | **0 of 374** |

38% of the corpus was order-dependent.

Reachable paths, both in-tree:

- **`CorpusDiagnostics/CorpusDiagnosticsRunner`** constructs one transformer and loops the whole corpus through it, so the findings worklist it produces depended on iteration order.
- **`VisualParity/StaticStyleParityRunner`** holds one transformer across comparisons.

Consumers that build a transformer per document were never affected, which is why the fixture suite stayed green over this.

## The fix

The maps move into a `NavigationProjectionState` on `HtmlTransformerSession`, alongside the runtime, evidence, provenance and style state that already reset with every transform. `NavigationToggleSuppressor` reaches them through its context rather than owning them.

No reset call was added. `transform()` already builds a fresh session, so correctness follows from where the state lives rather than from remembering to clear it. That distinction is the point — a reset call is a thing to forget, and this state was previously forgotten for exactly that reason.

`HtmlTransformerSession`'s own docblock already promised this:

> A fresh session is installed for every transform so a reused transformer retains only its immutable collaborators and shared analysis cache.

These three maps had quietly violated that guarantee. The class now means what it says.

The typed accessors (`projectTarget`, `suppress`, `isSuppressed`, `markImplicitDialogControl`, …) also move node-path keying inside the state object, so callers pass `DOMElement`s and no call site hand-rolls `getNodePath()` into an array key.

## Verification

**The regression test fails without the fix.** `tests/unit/navigation-projection-state-isolation.php` asserts a reused transformer reproduces fresh-instance output byte for byte, and that projection writes do not survive a transform. Against the parent commit it fails as intended:

```
Navigation projection isolation contract failed:
  reused transformer produced 56473 bytes, fresh produced 58830.
```

It also guards against passing for the wrong reason: it verifies the priming document genuinely populates projection state, so the test cannot go green because the fixture stopped exercising the path.

**Fresh-instance behavior is unchanged.** 383 fixture documents with stylesheets attached, `serialized_blocks` SHA-256 plus block, diagnostic, fallback, asset and coverage fingerprints — 0 differing, 0 throwing, against a fingerprint verified discriminating at 383 distinct hashes over 22 MB of markup.

`composer test` exit 0.

## Note on the corpus-diagnostics worklist

This changes `corpus-diagnostics` output, because that tool was reading contaminated results for 143 documents. The new output is the correct one. Anyone holding a stored worklist from before this lands should regenerate rather than diff against it.

## Follow-up worth considering

The same shape may exist elsewhere: state that survived the migration into `Session/` by living on a collaborator or trait instead. A cheap check is to run the corpus through one shared transformer and diff against fresh-instance output — that is now zero, so any future regression of this class shows up immediately as a non-zero count. Turning that into a standing contract test would make the guarantee enforceable rather than incidental, though it is a slow check and would want a place outside the fast unit suite.

---

*AI assistance disclosure: implemented and drafted by Claude Sonnet 4.6 running in Claude Code, operated by @chubes4. The AI had found and reported the underlying defect in #1334 while measuring an unrelated refactor slice; here it moved the state onto the session, wrote the regression test, verified that test fails on the parent commit, and measured the 143/374 corpus figure quoted above. Reviewed by a human before opening.*
