### PR TITLE
Fix selector cache element identity reuse (#1341)

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatchCache.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatchCache.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
 
 use DOMElement;
+use DOMNode;
+use WeakMap;
 
 /** Caches immutable-DOM selector inputs for one author-selector discovery pass. */
 final class CssSelectorMatchCache
@@ -28,6 +30,11 @@ final class CssSelectorMatchCache
 
     /** @var array<string, list<array<string, mixed>>> */
     private array $ruleCandidates = array();
+
+    /** @var WeakMap<DOMElement, int> */
+    private WeakMap $detachedElementKeys;
+
+    private int $nextDetachedElementKey = 0;
 
     public int $classTokenBuilds = 0;
 
@@ -60,6 +67,11 @@ final class CssSelectorMatchCache
     public int $candidateRulePeakEntries = 0;
 
     public int $candidateRulePeakRetained = 0;
+
+    public function __construct()
+    {
+        $this->detachedElementKeys = new WeakMap();
+    }
 
     /** @return list<string> */
     public function classTokens(DOMElement $element): array
@@ -197,10 +209,28 @@ final class CssSelectorMatchCache
         $this->matches = array();
         $this->ruleCandidates = array();
         $this->candidateRulesRetained = 0;
+        $this->detachedElementKeys = new WeakMap();
+        $this->nextDetachedElementKey = 0;
     }
 
     private function elementKey(DOMElement $element): string
     {
-        return (string) spl_object_id($element);
+        // PHP may return a new wrapper each time the same native DOM node is
+        // fetched, and it reuses spl_object_id() as soon as an old wrapper is
+        // released. A connected node's document path is stable across wrappers
+        // and unique within this per-document cache revision.
+        for ( $ancestor = $element; $ancestor instanceof DOMNode; $ancestor = $ancestor->parentNode ) {
+            if ( $ancestor instanceof \DOMDocument ) {
+                return 'path:' . $element->getNodePath();
+            }
+        }
+
+        // Detached nodes can share a path such as `/p`; keep their live wrapper
+        // identity without retaining the wrapper or ever reusing its token.
+        if ( ! isset($this->detachedElementKeys[$element]) ) {
+            $this->detachedElementKeys[$element] = ++$this->nextDetachedElementKey;
+        }
+
+        return 'detached:' . $this->detachedElementKeys[$element];
     }
 }

--- a/php-transformer/tests/unit/css-selector-matcher.php
+++ b/php-transformer/tests/unit/css-selector-matcher.php
@@ -113,6 +113,50 @@ $assert(! $candidateCache->matches($byId('target'), '.final', CssSelectorMatcher
 $candidateSelectors = array_column($candidateCache->styleRuleCandidates($byId('target'), 'test', $candidateIndex), 'selector');
 $assert(array( '#target', 'span', ':not(.excluded)', 'span[data-value]' ) === $candidateSelectors, 'clearing the immutable revision cache rebuilds class candidates after mutation');
 $assert(4 === $candidateCache->candidateRulesRetained, 'candidate cache accounts for retained rule references');
+
+// DOM nodes are native libxml objects exposed through temporary PHP wrappers.
+// Once a wrapper is released, PHP can immediately reuse its spl_object_id() for
+// a wrapper around a different node. A cache keyed by that bare integer then
+// returns the first node's classes, attributes, selector result, and candidate
+// rules for the second node.
+$identityDom = new DOMDocument();
+$identityDom->loadHTML('<!doctype html><div><i id="identity-first" class="first" data-state="first" data-first="yes"></i><b id="identity-second" class="second" data-state="second" data-second="yes"></b></div>');
+$identityCache = new CssSelectorMatchCache();
+$identityIndex = array(
+    'universal' => array(),
+    'ids' => array(),
+    'classes' => array(
+        'first' => array( array( 'order' => 0, 'rule' => array( 'selector' => '.first' ) ) ),
+        'second' => array( array( 'order' => 1, 'rule' => array( 'selector' => '.second' ) ) ),
+    ),
+    'tags' => array(),
+    'attributes' => array(),
+    'total' => 2,
+);
+$identityFirst = $identityDom->getElementById('identity-first');
+if ( ! $identityFirst instanceof DOMElement ) {
+    throw new RuntimeException('Selector-cache identity fixture did not produce the first element.');
+}
+$firstWrapperId = spl_object_id($identityFirst);
+$identityCache->classTokens($identityFirst);
+$identityCache->attribute($identityFirst, 'data-state');
+$identityCache->attributeNames($identityFirst);
+$identityCache->matches($identityFirst, '.first', CssSelectorMatcher::parse('.first'));
+$identityCache->styleRuleCandidates($identityFirst, 'identity', $identityIndex);
+unset($identityFirst);
+
+$identitySecond = $identityDom->getElementById('identity-second');
+if ( ! $identitySecond instanceof DOMElement ) {
+    throw new RuntimeException('Selector-cache identity fixture did not produce the second element.');
+}
+$assert($firstWrapperId === spl_object_id($identitySecond), 'identity regression fixture recycles the released DOMElement wrapper ID');
+$assert(array( 'second' ) === $identityCache->classTokens($identitySecond), 'class-token cache does not alias a distinct element with a recycled wrapper ID');
+$assert('second' === $identityCache->attribute($identitySecond, 'data-state'), 'attribute cache does not alias a distinct element with a recycled wrapper ID');
+$assert(array( 'id', 'class', 'data-state', 'data-second' ) === $identityCache->attributeNames($identitySecond), 'attribute-name cache does not alias a distinct element with a recycled wrapper ID');
+$assert(! $identityCache->matches($identitySecond, '.first', CssSelectorMatcher::parse('.first'))['matches'], 'selector-result cache does not alias a distinct element with a recycled wrapper ID');
+$identitySelectors = array_column($identityCache->styleRuleCandidates($identitySecond, 'identity', $identityIndex), 'selector');
+$assert(array( '.second' ) === $identitySelectors, 'candidate-rule cache does not alias a distinct element with a recycled wrapper ID');
+
 $largeUniversalRules = array();
 for ( $index = 0; $index < 2048; ++$index ) {
     $largeUniversalRules[] = array( 'order' => $index, 'rule' => array( 'selector' => '*' ) );


### PR DESCRIPTION
Fixes #1341. Unblocks the `SvgMaterializationTrait` extraction under #242.

`CssSelectorMatchCache::elementKey()` used bare `spl_object_id($element)` for class tokens, attributes, attribute names, selector results, and candidate-rule lists. PHP reuses that integer as soon as a temporary `DOMElement` wrapper is released, while the scalar cache entry survives. A later wrapper for a different source node could therefore inherit every cached selector input and result belonging to the first node.

## Reproduction

The regression creates two distinct connected elements, primes all five cache surfaces with the first, releases its PHP wrapper, then fetches the second. The runtime immediately gives the second wrapper the first wrapper's `spl_object_id()`.

Against the parent commit:

```
FAIL: class-token cache does not alias a distinct element with a recycled wrapper ID
FAIL: attribute cache does not alias a distinct element with a recycled wrapper ID
FAIL: attribute-name cache does not alias a distinct element with a recycled wrapper ID
FAIL: selector-result cache does not alias a distinct element with a recycled wrapper ID
FAIL: candidate-rule cache does not alias a distinct element with a recycled wrapper ID
CssSelectorMatcher unit tests: 5 failed, 81 passed
```

Here: `CssSelectorMatcher unit tests: 86 passed`.

## Identity model

**Connected nodes use `DOMNode::getNodePath()`.** A document path is stable across multiple PHP wrappers around the same native node and unique within this cache's immutable document revision. This preserves cache hits when repeated DOM lookups return different wrappers.

**Detached nodes use a monotonically increasing token held in a `WeakMap`.** Detached nodes can share paths such as `/p`, so path identity is unsafe there. The weak key avoids retaining wrappers; the monotonic value is never reused, so scalar entries cannot alias a later wrapper.

`clear()` resets both identity stores alongside the cached values. Existing mutation call sites already clear the immutable revision cache when source paths or attributes change.

I first tried a weak token for every wrapper. That prevented aliasing but destroyed legitimate cache hits because fetching the same native node can produce another PHP wrapper. The connected-path/detached-token split preserves both correctness and the existing cache behavior.

## Blast radius

This is not an extraction-only edge case. Correct identity changes output for **331 of 383** corpus documents on current `trunk`, adding 92,643 bytes of block markup in aggregate while leaving total diagnostic and fallback counts unchanged. The old cache was broadly suppressing or misclassifying output using another element's selector state.

The motivating fixture is now context-independent:

```
52-css-3d-world/about.html
isolated:    21,929 bytes
full corpus: 21,929 bytes
```

Before this fix, moving SVG methods to a collaborator changed temporary wrapper lifetime and made that document produce 22,011 bytes alone but 21,929 bytes during the corpus run. The refactor did not change selector logic; it changed which stale entry won.

## Verification

- `composer test`: exit 0, including 289 parity fixtures and the package-install proof.
- Selector benchmark retains bounded LRU behavior: 7,168 hits, 9,216 misses, 5,120 evictions, 4,096 peak entries over 16,384 accesses.
- CSS-attached corpus: 383 documents, 0 throwing, 383 distinct hashes.
- The paused SVG extraction will be rebased onto this fix and must return 0 differing against this corrected baseline before it resumes.

---

*AI assistance disclosure: implemented and drafted by OpenAI GPT-5.6 Sol running in OpenCode, operated by @chubes4. The AI found the defect while extracting `SvgMaterializationTrait`, reproduced wrapper-ID reuse, wrote and proved the five-surface regression against the parent commit, refined the initial all-WeakMap approach to preserve cross-wrapper cache hits, and ran the suite, benchmark, and corpus measurements quoted above. Reviewed by a human before opening.*
