### PR TITLE
Extract SVG materialization into a collaborator

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -91,7 +91,8 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\FormDispatchTrai
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\LinkUrlSanitizer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\NavigationToggleSuppressionContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\NavigationToggleSuppressor;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SvgMaterializationTrait;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SvgMaterializationContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SvgMaterializer;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\FontMaterializationPlanBuilder;
 use Automattic\BlocksEngine\PhpTransformer\Support\StyleTagScanner;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
@@ -116,7 +117,6 @@ final class HtmlTransformer
     use DomHelpersTrait;
     use ElementConversionTrait;
     use FormDispatchTrait;
-    use SvgMaterializationTrait;
 
     private const MAX_INTERACTION_CANDIDATES = 100;
     private const MAX_CAPTURED_LAYOUT_SOURCE_NESTING = 20;
@@ -250,6 +250,8 @@ final class HtmlTransformer
     private readonly StyleResolver $styleResolver;
 
     private readonly NavigationStyleProjector $navigationStyleProjector;
+
+    private readonly SvgMaterializer $svgMaterializer;
 
     private readonly NavigationToggleSuppressor $navigationToggleSuppressor;
 
@@ -386,6 +388,11 @@ final class HtmlTransformer
             $this->createNavigationToggleSuppressionContext(),
             $this->styleResolver
         );
+        $this->svgMaterializer = new SvgMaterializer(
+            $this->createSvgMaterializationContext(),
+            $this->styleResolver,
+            $this->runtime
+        );
         $this->runtimeIslands = new RuntimeIslandAnalyzer($this->createRuntimeIslandContext());
         $this->buttonLinkDispatcher = new ButtonLinkDispatcher($this->createButtonLinkDispatchContext());
         $this->tableConverter = new TableElementConverter($this->createTableElementContext());
@@ -482,6 +489,34 @@ final class HtmlTransformer
             fn (): NavigationProjectionState => $this->navigationProjection(),
             fn (): PatternRecognizerRegistry => $this->patternRecognizers,
             fn (): PatternContext => $this->probePatternContext()
+        );
+    }
+
+    /**
+     * Collaborator surface for {@see SvgMaterializer}. Per-transform state is
+     * resolved lazily so the materializer always sees the running transform.
+     */
+    private function createSvgMaterializationContext(): SvgMaterializationContext
+    {
+        return new SvgMaterializationContext(
+            fn (DOMElement $element, string $name): string => $this->attr($element, $name),
+            fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null, ?DOMElement $logicalSourceElement = null): array
+                => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement, $logicalSourceElement),
+            fn (DOMElement $element): string => $this->elementSelector($element),
+            fn (DOMElement $element): array => $this->htmlAttributes($element),
+            fn (DOMElement $element, array $excludedTags): string => $this->innerHtmlWithoutTags($element, $excludedTags),
+            fn (string $tagName): bool => $this->isInlineContentElement($tagName),
+            fn (string $content): bool => $this->isSafeSvgContent($content),
+            fn (DOMElement $element): bool => $this->isVisualLayerElement($element),
+            fn (): LayoutGeometryState => $this->layoutGeometry(),
+            fn (): AssetMaterializationState => $this->materializedAssets(),
+            fn (DOMElement $element): string => $this->outerHtml($element),
+            fn (DOMElement $element): ?string => $this->reusableComponentFingerprintFor($element),
+            fn (DOMElement $element): string => $this->safeFallbackHtml($element),
+            fn (DOMElement $element): string => $this->sanitizeInlineSvgMarkup($element),
+            fn (DOMElement $element): bool => $this->svgHasDrawableContent($element),
+            fn (): TransformationEvidenceState => $this->transformationEvidence(),
+            fn (): TransformationProvenanceState => $this->transformationProvenance()
         );
     }
 
@@ -3551,7 +3586,7 @@ final class HtmlTransformer
             ),
             new LogoPatternContext(
                 fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->restoreSvgCasing($this->outerHtml($sourceElement)),
+                fn (DOMElement $sourceElement): string => $this->svgMaterializer->restoreSvgCasing($this->outerHtml($sourceElement)),
                 fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content)
             ),
             new GalleryPatternContext(
@@ -3608,7 +3643,7 @@ final class HtmlTransformer
             ),
             logoContext: new LogoPatternContext(
                 fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->restoreSvgCasing($this->outerHtml($sourceElement)),
+                fn (DOMElement $sourceElement): string => $this->svgMaterializer->restoreSvgCasing($this->outerHtml($sourceElement)),
                 fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content)
             ),
             galleryContext: new GalleryPatternContext(
@@ -3690,8 +3725,8 @@ final class HtmlTransformer
 
         // Handle a safe SVG at a phrasing-to-block boundary before generic
         // preservation rules see the SVG as an unsupported document fragment.
-        if ( 'svg' === $tagName && $this->svgNeedsPhrasingHost($element) ) {
-            $imageMarkup = $this->inlineSvgRichTextImageMarkup($element);
+        if ( 'svg' === $tagName && $this->svgMaterializer->svgNeedsPhrasingHost($element) ) {
+            $imageMarkup = $this->svgMaterializer->inlineSvgRichTextImageMarkup($element);
             if ( null !== $imageMarkup ) {
                 return $this->createBlock('core/paragraph', array( 'content' => $imageMarkup ), array(), $element);
             }
@@ -7448,7 +7483,7 @@ if ( 'svg' === $tagName ) {
                 continue;
             }
 
-            $image = $this->inlineSvgRichTextImageMarkup($child);
+            $image = $this->svgMaterializer->inlineSvgRichTextImageMarkup($child);
             if ( null === $image ) {
                 $this->materializedAssets()->restore($generatedAssets);
                 return null;
@@ -7477,7 +7512,7 @@ if ( 'svg' === $tagName ) {
             if ( ! $svg instanceof DOMElement ) {
                 continue;
             }
-            $image = $this->inlineSvgRichTextImageMarkup($svg, false);
+            $image = $this->svgMaterializer->inlineSvgRichTextImageMarkup($svg, false);
             if ( null === $image ) {
                 $this->materializedAssets()->restore($generatedAssets);
                 return null;

--- a/php-transformer/src/HtmlToBlocks/Support/ElementConversionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/ElementConversionTrait.php
@@ -202,7 +202,7 @@ trait ElementConversionTrait
         if ( $this->runtimeIslands->isRuntimeDomTarget($element) ) {
             $html = $this->sanitizeInlineSvgMarkup($element);
             if ( $this->isSafeSvgContent($html) ) {
-                return $this->createBlock('core/html', array( 'content' => $this->restoreSvgCasing($this->ensureInlineSvgBoxStyle($html, $element)) ), array(), $element);
+                return $this->createBlock('core/html', array( 'content' => $this->svgMaterializer->restoreSvgCasing($this->svgMaterializer->ensureInlineSvgBoxStyle($html, $element)) ), array(), $element);
             }
         }
 
@@ -210,7 +210,7 @@ trait ElementConversionTrait
         // is dynamic and keyed on a registered icon slug, not arbitrary SVG.
         // Passive self-contained SVGs can be represented by core/image using
         // a data:image/svg+xml source; the rest stay faithful core/html.
-        if ( $this->isSafeDecorativeSvgElement($element) ) {
+        if ( $this->svgMaterializer->isSafeDecorativeSvgElement($element) ) {
             // Faithfully preserve any inline SVG that carries real drawable
             // artwork — icons, diagrams, illustrations — even when it is
             // marked aria-hidden / role=presentation. aria-hidden hides the
@@ -226,13 +226,13 @@ trait ElementConversionTrait
             // recreated elsewhere; preserve drawable stretched SVGs.
             $isDecorativeChrome = $this->isVisualLayerElement($element);
             if ( ! $isDecorativeChrome && $this->svgHasDrawableContent($element) ) {
-                if ( $this->svgNeedsPhrasingHost($element) ) {
-                    $imageMarkup = $this->inlineSvgRichTextImageMarkup($element);
+                if ( $this->svgMaterializer->svgNeedsPhrasingHost($element) ) {
+                    $imageMarkup = $this->svgMaterializer->inlineSvgRichTextImageMarkup($element);
                     if ( null !== $imageMarkup ) {
                         return $this->createBlock('core/paragraph', array( 'content' => $imageMarkup ), array(), $element);
                     }
                 }
-                $svgBlock = $this->inlineSvgBlockFromElement($element);
+                $svgBlock = $this->svgMaterializer->inlineSvgBlockFromElement($element);
                 if ( null !== $svgBlock ) {
                     return $svgBlock;
                 }
@@ -243,14 +243,14 @@ trait ElementConversionTrait
             return null;
         }
 
-        if ( $this->svgNeedsPhrasingHost($element) ) {
-            $imageMarkup = $this->inlineSvgRichTextImageMarkup($element);
+        if ( $this->svgMaterializer->svgNeedsPhrasingHost($element) ) {
+            $imageMarkup = $this->svgMaterializer->inlineSvgRichTextImageMarkup($element);
             if ( null !== $imageMarkup ) {
                 return $this->createBlock('core/paragraph', array( 'content' => $imageMarkup ), array(), $element);
             }
         }
 
-        $svgBlock = $this->inlineSvgBlockFromElement($element);
+        $svgBlock = $this->svgMaterializer->inlineSvgBlockFromElement($element);
         if ( null !== $svgBlock ) {
             return $svgBlock;
         }

--- a/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
@@ -375,7 +375,7 @@ trait FormDispatchTrait
             return '';
         }
 
-        $svgMarkup = $this->restoreSvgCasing($this->outerHtml($svg));
+        $svgMarkup = $this->svgMaterializer->restoreSvgCasing($this->outerHtml($svg));
         if ( ! preg_match('/<svg\b[^>]*\bxmlns=/i', $svgMarkup) ) {
             $svgMarkup = preg_replace('/<svg\b/i', '<svg xmlns="http://www.w3.org/2000/svg"', $svgMarkup, 1) ?? $svgMarkup;
         }

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationContext.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationContext.php
@@ -1,0 +1,159 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\AssetMaterializationState;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\TransformationEvidenceState;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\TransformationProvenanceState;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\LayoutGeometryState;
+use Closure;
+use DOMElement;
+
+/**
+ * Explicit collaborator surface for {@see SvgMaterializer}.
+ *
+ * Per-transform state (layout geometry, materialized assets, transformation
+ * evidence and provenance) is resolved through closures because the materializer
+ * is constructed once with the transformer but must see the state belonging to
+ * the transform currently running.
+ */
+final class SvgMaterializationContext
+{
+    /**
+     * @param Closure(DOMElement, string): string                                                  $attr
+     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement, ?DOMElement): array<string, mixed> $createBlock
+     * @param Closure(DOMElement): string                                                          $elementSelector
+     * @param Closure(DOMElement): array<string, string>                                           $htmlAttributes
+     * @param Closure(DOMElement, array<int, string>): string                                      $innerHtmlWithoutTags
+     * @param Closure(string): bool                                                                $isInlineContentElement
+     * @param Closure(string): bool                                                                $isSafeSvgContent
+     * @param Closure(DOMElement): bool                                                            $isVisualLayerElement
+     * @param Closure(): LayoutGeometryState                                                       $layoutGeometry
+     * @param Closure(): AssetMaterializationState                                                 $materializedAssets
+     * @param Closure(DOMElement): string                                                          $outerHtml
+     * @param Closure(DOMElement): ?string                                                         $reusableComponentFingerprintFor
+     * @param Closure(DOMElement): string                                                          $safeFallbackHtml
+     * @param Closure(DOMElement): string                                                          $sanitizeInlineSvgMarkup
+     * @param Closure(DOMElement): bool                                                            $svgHasDrawableContent
+     * @param Closure(): TransformationEvidenceState                                               $transformationEvidence
+     * @param Closure(): TransformationProvenanceState                                             $transformationProvenance
+     */
+    public function __construct(
+        private readonly Closure $attr,
+        private readonly Closure $createBlock,
+        private readonly Closure $elementSelector,
+        private readonly Closure $htmlAttributes,
+        private readonly Closure $innerHtmlWithoutTags,
+        private readonly Closure $isInlineContentElement,
+        private readonly Closure $isSafeSvgContent,
+        private readonly Closure $isVisualLayerElement,
+        private readonly Closure $layoutGeometry,
+        private readonly Closure $materializedAssets,
+        private readonly Closure $outerHtml,
+        private readonly Closure $reusableComponentFingerprintFor,
+        private readonly Closure $safeFallbackHtml,
+        private readonly Closure $sanitizeInlineSvgMarkup,
+        private readonly Closure $svgHasDrawableContent,
+        private readonly Closure $transformationEvidence,
+        private readonly Closure $transformationProvenance
+    ) {
+    }
+
+    public function attr(DOMElement $element, string $name): string
+    {
+        return ($this->attr)($element, $name);
+    }
+
+    /**
+     * @param array<string, mixed> $attrs
+     * @param array<int, array<string, mixed>> $innerBlocks
+     * @return array<string, mixed>
+     */
+    public function createBlock(
+        string $name,
+        array $attrs = array(),
+        array $innerBlocks = array(),
+        ?DOMElement $sourceElement = null,
+        ?DOMElement $logicalSourceElement = null
+    ): array {
+        return ($this->createBlock)($name, $attrs, $innerBlocks, $sourceElement, $logicalSourceElement);
+    }
+
+    public function elementSelector(DOMElement $element): string
+    {
+        return ($this->elementSelector)($element);
+    }
+
+    /** @return array<string, string> */
+    public function htmlAttributes(DOMElement $element): array
+    {
+        return ($this->htmlAttributes)($element);
+    }
+
+    /** @param array<int, string> $excludedTags */
+    public function innerHtmlWithoutTags(DOMElement $element, array $excludedTags): string
+    {
+        return ($this->innerHtmlWithoutTags)($element, $excludedTags);
+    }
+
+    public function isInlineContentElement(string $tagName): bool
+    {
+        return ($this->isInlineContentElement)($tagName);
+    }
+
+    public function isSafeSvgContent(string $content): bool
+    {
+        return ($this->isSafeSvgContent)($content);
+    }
+
+    public function isVisualLayerElement(DOMElement $element): bool
+    {
+        return ($this->isVisualLayerElement)($element);
+    }
+
+    public function layoutGeometry(): LayoutGeometryState
+    {
+        return ($this->layoutGeometry)();
+    }
+
+    public function materializedAssets(): AssetMaterializationState
+    {
+        return ($this->materializedAssets)();
+    }
+
+    public function outerHtml(DOMElement $element): string
+    {
+        return ($this->outerHtml)($element);
+    }
+
+    public function reusableComponentFingerprintFor(DOMElement $element): ?string
+    {
+        return ($this->reusableComponentFingerprintFor)($element);
+    }
+
+    public function safeFallbackHtml(DOMElement $element): string
+    {
+        return ($this->safeFallbackHtml)($element);
+    }
+
+    public function sanitizeInlineSvgMarkup(DOMElement $element): string
+    {
+        return ($this->sanitizeInlineSvgMarkup)($element);
+    }
+
+    public function svgHasDrawableContent(DOMElement $element): bool
+    {
+        return ($this->svgHasDrawableContent)($element);
+    }
+
+    public function transformationEvidence(): TransformationEvidenceState
+    {
+        return ($this->transformationEvidence)();
+    }
+
+    public function transformationProvenance(): TransformationProvenanceState
+    {
+        return ($this->transformationProvenance)();
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializer.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializer.php
@@ -4,20 +4,39 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssStylesheetTransformer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolver;
 use Automattic\BlocksEngine\PhpTransformer\Support\StyleTagScanner;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
+use DOMDocument;
 use DOMElement;
+use DOMNode;
 
-trait SvgMaterializationTrait
+/**
+ * Materializes source SVG into emitted blocks: inline SVG hosts, decorative
+ * classification, casing restoration, box styling and asset extraction.
+ *
+ * Extracted from HtmlTransformer as a collaborator rather than a mixin: every
+ * dependency it needs from the transformer is declared on
+ * {@see SvgMaterializationContext}, so this class has no $this access to the
+ * transformer and can be exercised without constructing one.
+ */
+final class SvgMaterializer
 {
+    public function __construct(
+        private readonly SvgMaterializationContext $context,
+        private readonly StyleResolver $styleResolver,
+        private readonly Runtime $runtime
+    ) {
+    }
     /**
      * @return array<string, mixed>|null
      */
-    private function inlineSvgBlockFromElement(DOMElement $element): ?array
+    public function inlineSvgBlockFromElement(DOMElement $element): ?array
     {
         // Only preserve when there is actual artwork to keep. An SVG whose only
         // content is unsafe (e.g. a lone <script>) has nothing left to render
         // once sanitized, so it defers to the bounded fallback diagnostic.
-        if ( ! $this->svgHasDrawableContent($element) ) {
+        if ( ! $this->context->svgHasDrawableContent($element) ) {
             return null;
         }
 
@@ -27,13 +46,13 @@ trait SvgMaterializationTrait
         // the moment one unsafe attribute or element appears. The shape and
         // structure markup (svg/path/circle/rect/g/text/...) is kept so the
         // image renders, rather than collapsing to an empty block.
-        $html = $this->sanitizeInlineSvgMarkup($element);
+        $html = $this->context->sanitizeInlineSvgMarkup($element);
 
         // Safety gate: only emit raw inline SVG once the sanitized markup is
         // provably free of script/event-handler/javascript: vectors and still
         // contains an <svg>. If sanitization could not fully clean it, defer to
         // the bounded fallback metadata path rather than emit unsafe markup.
-        if ( ! $this->isSafeSvgContent($html) ) {
+        if ( ! $this->context->isSafeSvgContent($html) ) {
             return null;
         }
 
@@ -51,7 +70,7 @@ trait SvgMaterializationTrait
         // Honest floor: keep SVGs that need inline document context as sanitized
         // core/html, with viewBox-derived dimensions to avoid unbounded rendering.
         $this->recordGutenbergIncompatibility($element, 'svg_requires_inline_document_context', 'SVG uses behavior or external document features that cannot be represented as a static editable core/image asset.');
-        return $this->createBlock('core/html', array( 'content' => $html ), array(), $element);
+        return $this->context->createBlock('core/html', array( 'content' => $html ), array(), $element);
     }
 
     /**
@@ -64,7 +83,7 @@ trait SvgMaterializationTrait
             return null;
         }
 
-        return $this->createBlock('core/image', $attrs, array(), $element);
+        return $this->context->createBlock('core/image', $attrs, array(), $element);
     }
 
     /**
@@ -85,13 +104,13 @@ trait SvgMaterializationTrait
         $url = $this->sourceRelativeMaterializedSvgPath($path);
         $occurrence = array_filter(array(
             'source_path' => $this->transformSourcePath(),
-            'selector' => $this->elementSelector($element),
-            'fingerprint' => $this->reusableComponentFingerprintFor($element),
+            'selector' => $this->context->elementSelector($element),
+            'fingerprint' => $this->context->reusableComponentFingerprintFor($element),
         ), static fn (mixed $value): bool => is_string($value) && '' !== $value);
         $asset = array(
             'source'      => 'inline-svg',
             'source_path' => $this->transformSourcePath(),
-            'selector'    => $this->elementSelector($element),
+            'selector'    => $this->context->elementSelector($element),
             'path'        => $path,
             'target_path' => $path,
             'source_url'  => $url,
@@ -111,7 +130,7 @@ trait SvgMaterializationTrait
             'visual_payload' => $visualPayload . "\n",
         );
         if (array() !== $occurrence) $asset['component_occurrences'] = array($occurrence);
-        $this->materializedAssets()->registerInlineSvg($path, $asset, $occurrence, $visualPayload);
+        $this->context->materializedAssets()->registerInlineSvg($path, $asset, $occurrence, $visualPayload);
 
         $dimensions = $this->cssOwnsMediaBox($element) ? array() : $this->svgImageDimensions($element, $html);
         $presentation = $this->styleResolver->presentationDeclarations($element);
@@ -132,8 +151,8 @@ trait SvgMaterializationTrait
             ($isFlexOrGridItem && $parent instanceof DOMElement && $this->declarationsOwnMediaBox($parentPresentation))
             || ($isPositionedMediaBox && in_array($sourceObjectFit, array( 'contain', 'cover', 'fill', 'none', 'scale-down' ), true))
         )
-            && null !== $this->svgPercentageWidth(trim($this->attr($element, 'width')))
-            && null !== $this->svgPercentageWidth(trim($this->attr($element, 'height')));
+            && null !== $this->svgPercentageWidth(trim($this->context->attr($element, 'width')))
+            && null !== $this->svgPercentageWidth(trim($this->context->attr($element, 'height')));
         if ( $isResponsiveFillSvg ) {
             $dimensions = array();
             // This is generated fill geometry, not an authored image support.
@@ -146,12 +165,12 @@ trait SvgMaterializationTrait
             // rule wins without forcing intrinsic media outside this explicit
             // parent-fill path.
             $imgRule = '>img{width:100%;height:100%;-o-object-fit:' . $objectFit . ';object-fit:' . $objectFit . '}';
-            $fillClass = $this->layoutGeometry()->allocateCarrier($this->styleResolver->geometryStructuralPath($element) . "\n" . $figureRule . $imgRule);
-            $this->layoutGeometry()->registerRule($fillClass, '.' . $fillClass . $figureRule . '.wp-block-image.' . $fillClass . $imgRule);
+            $fillClass = $this->context->layoutGeometry()->allocateCarrier($this->styleResolver->geometryStructuralPath($element) . "\n" . $figureRule . $imgRule);
+            $this->context->layoutGeometry()->registerRule($fillClass, '.' . $fillClass . $figureRule . '.wp-block-image.' . $fillClass . $imgRule);
             $attrs = array(
                 'url'       => $url,
                 'alt'       => $this->svgImageAlt($element),
-                'className'  => $this->styleResolver->mergePresentationClassNames($this->attr($element, 'class'), $fillClass),
+                'className'  => $this->styleResolver->mergePresentationClassNames($this->context->attr($element, 'class'), $fillClass),
             );
 
             return array_filter($attrs, static fn ($value): bool => null !== $value && '' !== $value);
@@ -168,19 +187,19 @@ trait SvgMaterializationTrait
                 }
             }
             $rule = ($richTextImage ? '' : '>img') . '{display:' . $imageDisplay . ($preserveInlineGeometry ? ';vertical-align:baseline' : '') . $mediaBox . '}';
-            $geometryClass = $this->layoutGeometry()->allocateCarrier($this->styleResolver->geometryStructuralPath($element) . "\n" . $rule);
-            $this->layoutGeometry()->registerRule($geometryClass, ($preserveBlockDisplay ? '.' . $geometryClass . '{line-height:0}' : '') . '.' . $geometryClass . $rule);
+            $geometryClass = $this->context->layoutGeometry()->allocateCarrier($this->styleResolver->geometryStructuralPath($element) . "\n" . $rule);
+            $this->context->layoutGeometry()->registerRule($geometryClass, ($preserveBlockDisplay ? '.' . $geometryClass . '{line-height:0}' : '') . '.' . $geometryClass . $rule);
         } elseif ( ! $richTextImage ) {
             // Core/image rejects typography.lineHeight. A standalone SVG still
             // needs its source line box removed when it becomes a figure.
             $rule = '{line-height:0}';
-            $geometryClass = $this->layoutGeometry()->allocateCarrier($this->styleResolver->geometryStructuralPath($element) . "\n" . $rule);
-            $this->layoutGeometry()->registerRule($geometryClass, '.' . $geometryClass . $rule);
+            $geometryClass = $this->context->layoutGeometry()->allocateCarrier($this->styleResolver->geometryStructuralPath($element) . "\n" . $rule);
+            $this->context->layoutGeometry()->registerRule($geometryClass, '.' . $geometryClass . $rule);
         }
         $attrs = array_filter(array_merge(array(
             'url'          => $url,
             'alt'          => $this->svgImageAlt($element),
-            'className'    => $this->styleResolver->mergePresentationClassNames($this->attr($element, 'class'), $geometryClass),
+            'className'    => $this->styleResolver->mergePresentationClassNames($this->context->attr($element, 'class'), $geometryClass),
         ), $dimensions), static fn ($value): bool => null !== $value && '' !== $value);
 
         return $attrs;
@@ -191,14 +210,14 @@ trait SvgMaterializationTrait
      * The image is deliberately an object inside the surrounding RichText rather
      * than a core/image block figure, which would break phrasing flow.
      */
-    private function inlineSvgRichTextImageMarkup(DOMElement $element, bool $includeLink = true): ?string
+    public function inlineSvgRichTextImageMarkup(DOMElement $element, bool $includeLink = true): ?string
     {
-        if ( ! $this->svgHasDrawableContent($element) ) {
+        if ( ! $this->context->svgHasDrawableContent($element) ) {
             return null;
         }
 
-        $html = $this->sanitizeInlineSvgMarkup($element);
-        if ( ! $this->isSafeSvgContent($html) ) {
+        $html = $this->context->sanitizeInlineSvgMarkup($element);
+        if ( ! $this->context->isSafeSvgContent($html) ) {
             return null;
         }
 
@@ -212,10 +231,10 @@ trait SvgMaterializationTrait
             return null;
         }
 
-        $style = trim($this->attr($element, 'style'));
+        $style = trim($this->context->attr($element, 'style'));
         $sourceDimensions = array_filter(array(
-            'width' => trim($this->attr($element, 'width')),
-            'height' => trim($this->attr($element, 'height')),
+            'width' => trim($this->context->attr($element, 'width')),
+            'height' => trim($this->context->attr($element, 'height')),
         ), static fn (string $value): bool => '' !== $value);
         $resolvedSourceDimensions = $this->richTextSvgDimensions($element, $sourceDimensions);
         foreach ( array( 'width', 'height' ) as $dimension ) {
@@ -286,7 +305,7 @@ trait SvgMaterializationTrait
                     continue 2;
                 }
 
-                $sourceVisualDimension = trim($this->attr($parent, 'data-source-visual-' . $dimension));
+                $sourceVisualDimension = trim($this->context->attr($parent, 'data-source-visual-' . $dimension));
                 if ( '' === $fallback && is_numeric($sourceVisualDimension) && (float) $sourceVisualDimension > 0 ) {
                     $fallback = $this->normalizedSvgDimension((float) $sourceVisualDimension * $scale) . 'px';
                 }
@@ -320,22 +339,22 @@ trait SvgMaterializationTrait
             return array();
         }
 
-        $href = trim($this->attr($parent, 'href'));
+        $href = trim($this->context->attr($parent, 'href'));
         if ( '' === $href || preg_match('/^\s*javascript\s*:/i', $href) ) {
             return array();
         }
 
         return array_filter(array(
             'href' => $href,
-            'target' => trim($this->attr($parent, 'target')),
-            'rel' => trim($this->attr($parent, 'rel')),
-            'aria-label' => trim($this->attr($parent, 'aria-label')),
+            'target' => trim($this->context->attr($parent, 'target')),
+            'rel' => trim($this->context->attr($parent, 'rel')),
+            'aria-label' => trim($this->context->attr($parent, 'aria-label')),
         ), static fn (string $value): bool => '' !== $value);
     }
 
-    private function svgNeedsPhrasingHost(DOMElement $element): bool
+    public function svgNeedsPhrasingHost(DOMElement $element): bool
     {
-        if ( $this->isVisualLayerElement($element) || 'none' === strtolower(trim($this->attr($element, 'preserveaspectratio'))) ) {
+        if ( $this->context->isVisualLayerElement($element) || 'none' === strtolower(trim($this->context->attr($element, 'preserveaspectratio'))) ) {
             return false;
         }
 
@@ -345,10 +364,10 @@ trait SvgMaterializationTrait
             if ( 'p' === $parentTag ) {
                 return true;
             }
-            if ( 'article' === $parentTag && 'img' === strtolower(trim($this->attr($element, 'role'))) ) {
+            if ( 'article' === $parentTag && 'img' === strtolower(trim($this->context->attr($element, 'role'))) ) {
                 return false;
             }
-            if ( ( $this->isInlineContentElement($parentTag) || 'a' === $parentTag ) && '' !== trim($this->runtime->stripAllTags($this->innerHtmlWithoutTags($parent, array( 'svg' )))) ) {
+            if ( ( $this->context->isInlineContentElement($parentTag) || 'a' === $parentTag ) && '' !== trim($this->runtime->stripAllTags($this->context->innerHtmlWithoutTags($parent, array( 'svg' )))) ) {
                 return true;
             }
         }
@@ -364,13 +383,13 @@ trait SvgMaterializationTrait
         for ( $sibling = $element->previousSibling; null !== $sibling; $sibling = $sibling->previousSibling ) {
             if ( $sibling instanceof DOMElement ) {
                 $tag = strtolower($sibling->tagName);
-                return 'svg' !== $tag && ! $this->isInlineContentElement($tag);
+                return 'svg' !== $tag && ! $this->context->isInlineContentElement($tag);
             }
         }
         for ( $sibling = $element->nextSibling; null !== $sibling; $sibling = $sibling->nextSibling ) {
             if ( $sibling instanceof DOMElement ) {
                 $tag = strtolower($sibling->tagName);
-                return 'svg' !== $tag && ! $this->isInlineContentElement($tag);
+                return 'svg' !== $tag && ! $this->context->isInlineContentElement($tag);
             }
         }
 
@@ -419,9 +438,9 @@ trait SvgMaterializationTrait
             if ( ! $use instanceof DOMElement ) {
                 continue;
             }
-            $href = trim($this->attr($use, 'href'));
+            $href = trim($this->context->attr($use, 'href'));
             if ( '' === $href ) {
-                $href = trim($this->attr($use, 'xlink:href'));
+                $href = trim($this->context->attr($use, 'xlink:href'));
             }
             if ( preg_match('/^#(.+)$/', $href, $match) ) {
                 $references[$match[1]] = true;
@@ -437,8 +456,8 @@ trait SvgMaterializationTrait
                 continue;
             }
             foreach ( $defs->getElementsByTagName('*') as $definition ) {
-                if ( $definition instanceof DOMElement && isset($references[trim($this->attr($definition, 'id'))]) ) {
-                    $definitions[] = $this->safeFallbackHtml($defs);
+                if ( $definition instanceof DOMElement && isset($references[trim($this->context->attr($definition, 'id'))]) ) {
+                    $definitions[] = $this->context->safeFallbackHtml($defs);
                     break;
                 }
             }
@@ -561,7 +580,7 @@ trait SvgMaterializationTrait
         // selector. A content address lets every compatible instance share one
         // core/image asset while retaining its own alt text and presentation.
         $filename = 'inline-svg-' . substr(hash('sha256', $html), 0, 16) . '.svg';
-        return $this->materializedAssets()->rootedPath('assets/materialized-svg/' . $filename);
+        return $this->context->materializedAssets()->rootedPath('assets/materialized-svg/' . $filename);
     }
 
     private function sourceRelativeMaterializedSvgPath(string $path): string
@@ -578,7 +597,7 @@ trait SvgMaterializationTrait
     private function transformSourcePath(): string
     {
         foreach ( array( 'source', 'path' ) as $key ) {
-            $value = $this->transformationProvenance()->fallback()[$key] ?? '';
+            $value = $this->context->transformationProvenance()->fallback()[$key] ?? '';
             if ( '' !== trim((string) $value) ) {
                 return trim((string) $value);
             }
@@ -589,10 +608,10 @@ trait SvgMaterializationTrait
 
     private function recordGutenbergIncompatibility(DOMElement $element, string $reason, string $message): void
     {
-        $this->transformationEvidence()->recordGutenbergIncompatibility(array(
+        $this->context->transformationEvidence()->recordGutenbergIncompatibility(array(
             'type'     => 'svg_materialization_incompatibility',
             'element'  => 'svg',
-            'selector' => $this->elementSelector($element),
+            'selector' => $this->context->elementSelector($element),
             'reason'   => $reason,
             'message'  => $message,
         ));
@@ -615,7 +634,7 @@ trait SvgMaterializationTrait
             return false;
         }
         $boxProperties = array_flip(array( 'width', 'height', 'min-width', 'max-width', 'min-height', 'max-height', 'aspect-ratio' ));
-        foreach ( $this->styleResolver->cssDeclarations($this->attr($element, 'style')) as $property => $value ) {
+        foreach ( $this->styleResolver->cssDeclarations($this->context->attr($element, 'style')) as $property => $value ) {
             if ( preg_match('/var\s*\(/i', $value) && ! isset($boxProperties[strtolower($property)]) ) {
                 return false;
             }
@@ -632,7 +651,7 @@ trait SvgMaterializationTrait
      */
     private function svgImageDimensions(DOMElement $element, string $html): array
     {
-        $sourceWidth = trim($this->attr($element, 'width'));
+        $sourceWidth = trim($this->context->attr($element, 'width'));
         // A percentage SVG width has a used size from its containing block. Keep
         // that responsive width on the native image and let its viewBox provide
         // the intrinsic aspect ratio instead of pinning a viewBox-height value.
@@ -641,7 +660,7 @@ trait SvgMaterializationTrait
         }
 
         $width = $this->svgLengthAttributeForImage($sourceWidth);
-        $height = $this->svgLengthAttributeForImage($this->attr($element, 'height'));
+        $height = $this->svgLengthAttributeForImage($this->context->attr($element, 'height'));
         if ( '' !== $width && '' !== $height ) {
             return array( 'width' => $width, 'height' => $height );
         }
@@ -684,12 +703,12 @@ trait SvgMaterializationTrait
 
     private function svgImageAlt(DOMElement $element): string
     {
-        if ( 'true' === strtolower(trim($this->attr($element, 'aria-hidden'))) ) {
+        if ( 'true' === strtolower(trim($this->context->attr($element, 'aria-hidden'))) ) {
             return '';
         }
 
         foreach ( array( 'aria-label', 'title' ) as $attribute ) {
-            $value = trim($this->attr($element, $attribute));
+            $value = trim($this->context->attr($element, $attribute));
             if ( '' !== $value ) {
                 return $value;
             }
@@ -736,7 +755,7 @@ trait SvgMaterializationTrait
         return substr($html, 0, $insertAt) . ' width="' . $width . '" height="' . $height . '"' . substr($html, $insertAt);
     }
 
-    private function ensureInlineSvgBoxStyle(string $html, DOMElement $element): string
+    public function ensureInlineSvgBoxStyle(string $html, DOMElement $element): string
     {
         $boxProperties = array_flip(array(
             'aspect-ratio',
@@ -753,7 +772,7 @@ trait SvgMaterializationTrait
             return $html;
         }
 
-        $existingDeclarations = $this->styleResolver->cssDeclarations($this->attr($element, 'style'));
+        $existingDeclarations = $this->styleResolver->cssDeclarations($this->context->attr($element, 'style'));
         foreach ( array_keys($existingDeclarations) as $name ) {
             unset($boxDeclarations[$name]);
         }
@@ -792,7 +811,7 @@ trait SvgMaterializationTrait
      * scale to its viewport) and a lowercased `<lineargradient>` is an unknown
      * element the browser does not render (the gradient fill disappears).
      */
-    private function restoreSvgCasing(string $html): string
+    public function restoreSvgCasing(string $html): string
     {
         static $camelCaseAttributes = array(
             'viewBox', 'preserveAspectRatio', 'baseProfile', 'attributeName', 'attributeType',
@@ -831,14 +850,14 @@ trait SvgMaterializationTrait
         return $html;
     }
 
-    private function isSafeDecorativeSvgElement(DOMElement $element): bool
+    public function isSafeDecorativeSvgElement(DOMElement $element): bool
     {
-        if ( ! $this->isSafeSvgContent($this->outerHtml($element)) || ! $this->isPassiveSvgMarkup($element) ) {
+        if ( ! $this->context->isSafeSvgContent($this->context->outerHtml($element)) || ! $this->isPassiveSvgMarkup($element) ) {
             return false;
         }
 
-        $role = strtolower(trim($this->attr($element, 'role')));
-        if ( 'true' === strtolower(trim($this->attr($element, 'aria-hidden'))) || in_array($role, array( 'presentation', 'none' ), true) ) {
+        $role = strtolower(trim($this->context->attr($element, 'role')));
+        if ( 'true' === strtolower(trim($this->context->attr($element, 'aria-hidden'))) || in_array($role, array( 'presentation', 'none' ), true) ) {
             return true;
         }
 
@@ -849,10 +868,10 @@ trait SvgMaterializationTrait
     {
         for ( $current = $element; $current instanceof DOMElement; $current = $current->parentNode instanceof DOMElement ? $current->parentNode : null ) {
             $context = strtolower(trim(implode(' ', array(
-                $this->attr($current, 'class'),
-                $this->attr($current, 'id'),
-                $this->attr($current, 'aria-label'),
-                $this->attr($current, 'title'),
+                $this->context->attr($current, 'class'),
+                $this->context->attr($current, 'id'),
+                $this->context->attr($current, 'aria-label'),
+                $this->context->attr($current, 'title'),
             ))));
 
             if ( preg_match('/(?:^|[\s_-])(?:icon|logo)(?:$|[\s_-])/', $context) ) {
@@ -925,7 +944,7 @@ trait SvgMaterializationTrait
             return false;
         }
 
-        foreach ( $this->htmlAttributes($element) as $name => $value ) {
+        foreach ( $this->context->htmlAttributes($element) as $name => $value ) {
             $name = strtolower($name);
             $isInertDataAttribute = str_starts_with($name, 'data-') && 'data-dom-store' !== $name;
             if ( (! isset($allowedAttributes[$name]) && ! $isInertDataAttribute) || preg_match('/^on[a-z]+$/i', $name) || preg_match('/javascript\s*:|\b(?:expression|behavior)\s*:/i', $value) ) {


### PR DESCRIPTION
## Summary

- replace `SvgMaterializationTrait` with an explicit `SvgMaterializer` collaborator
- introduce `SvgMaterializationContext` to declare the transformer services and per-transform state the collaborator consumes
- route SVG conversion, rich-text image materialization, form icons, and logo casing through the collaborator
- preserve behavior on top of the selector-cache identity fix from #1342

## Verification

- `composer test`
- fresh CSS-attached corpus comparison against current `origin/trunk`: 383 documents, 87 fixtures, 0 throws, byte-identical records

## AI assistance

GPT-5.6 Sol was used through OpenCode to perform the collaborator extraction, diagnose implicit trait namespace dependencies, and run the unit, package-install, and corpus verification workflows. The implementation and evidence were reviewed and orchestrated by Chris Huber.