### PR TITLE
Handle non-anchor brands in navigation carriers

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -109,6 +109,7 @@
       "php tests/unit/navigation-author-rule-memory.php",
       "php tests/unit/navigation-projection-state-isolation.php",
       "php tests/unit/navigation-direct-cluster-parity.php",
+      "php tests/unit/navigation-non-anchor-brand-carrier.php",
       "php tests/unit/navigation-block-normalizer.php",
       "php tests/unit/navigation-inline-margin-carry.php",
       "php tests/unit/navigation-source-provenance.php",

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -140,20 +140,22 @@ final class NavigationPattern implements PatternRecognizerInterface
     }
 
     /**
-     * A nav container that holds a branding anchor beside its link cluster
-     * authors THREE elements — the landmark, the brand, and the menu — each with
-     * its own CSS rule. Folding all three into one core/navigation makes the
-     * brand a menu item: the landmark's own box rules then compete with the
-     * menu list's rules on a single element, and would require a source-only
-     * attribute that core/navigation-link does not register.
+     * A nav container that holds a brand beside its link cluster authors THREE
+     * elements — the landmark, the brand, and the menu — each with its own CSS
+     * rule. Folding all three into one core/navigation makes the brand a menu
+     * item: the landmark's own box rules then compete with the menu list's rules
+     * on a single element, and would require a source-only attribute that
+     * core/navigation-link does not register.
      *
      * Emit the landmark as a carrier group instead, holding the brand block and
      * a core/navigation built from the link cluster alone. Structural position
-     * does the work a class allowlist used to do — a direct-child anchor outside
+     * does the work a class allowlist used to do — a direct-child brand outside
      * the cluster — but position alone cannot tell a brand from an ordinary menu
-     * item that happens to sit outside the list, so the anchor must also read as
+     * item that happens to sit outside the list, so the brand must also read as
      * a brand: a lockup (element children) or a brand/logo cue. A bare
-     * `<a>Home</a>` beside the list stays a menu item.
+     * `<a>Home</a>` beside the list stays a menu item. A non-anchor wordmark
+     * such as `<span class="brand">Northwind</span>` qualifies by that same cue
+     * and is emitted as its own native block rather than a synthetic paragraph.
      *
      * Not covered: an anchor holding only an image with no accessible name is
      * classified as navigation chrome before it reaches the brand test, so an
@@ -189,7 +191,17 @@ final class NavigationPattern implements PatternRecognizerInterface
         $extras = array();
         $order = array();
         $buttonSignals = new ButtonSignalClassifier();
-        foreach ( $element->childNodes as $child ) {
+        $nonAnchorShape = $this->nonAnchorBrandNavigationShape($element);
+        if ( null !== $nonAnchorShape ) {
+            $anchor = $nonAnchorShape['brand'];
+            $cluster = $nonAnchorShape['cluster'];
+            $brandLeads = $nonAnchorShape['brand_leads'];
+            $order = $brandLeads
+                ? array( array( 'kind' => 'brand' ), array( 'kind' => 'cluster' ) )
+                : array( array( 'kind' => 'cluster' ), array( 'kind' => 'brand' ) );
+        }
+
+        foreach ( null === $nonAnchorShape ? $element->childNodes : array() as $child ) {
             if ( XML_COMMENT_NODE === $child->nodeType ) {
                 continue;
             }
@@ -267,14 +279,31 @@ final class NavigationPattern implements PatternRecognizerInterface
             return null;
         }
 
-        $links = $this->navigationBlocks($cluster, $presentationAttributes, $innerHtml, $createBlock, $navigationContext, false, true);
+        $links = array();
+        if ( $cluster->isSameNode($element) ) {
+            foreach ( $element->childNodes as $child ) {
+                if ( $child instanceof DOMElement && 'a' === strtolower($child->tagName) && '' !== $this->anchorLabel($child, $innerHtml) ) {
+                    $links[] = $this->navigationLinkBlock($child, $presentationAttributes, $innerHtml, $createBlock, $child, $navigationContext);
+                }
+            }
+        } else {
+            $links = $this->navigationBlocks($cluster, $presentationAttributes, $innerHtml, $createBlock, $navigationContext, false, true);
+        }
         if ( 2 > count($links) ) {
             return null;
         }
 
         // An anchor that only converts to an HTML fallback would trade a menu
         // item for raw markup; keep today's shape rather than lose the block.
-        $brand = $converter->element($anchor, $fallbacks, true);
+        // A phrasing wordmark is created without a source element so the
+        // inline-to-paragraph path does not attach the synthetic wrapper class.
+        $brand = null !== $nonAnchorShape && in_array(strtolower($anchor->tagName), array( 'span', 'strong', 'em', 'b', 'i', 'small' ), true)
+            ? $createBlock(
+                'core/paragraph',
+                array_merge($presentationAttributes($anchor), array( 'content' => $innerHtml($anchor) )),
+                array()
+            )
+            : $converter->element($anchor, $fallbacks, true);
         $brandName = is_array($brand) ? (string) ($brand['blockName'] ?? '') : '';
         if ( '' === $brandName || 'core/html' === $brandName ) {
             return null;
@@ -283,7 +312,9 @@ final class NavigationPattern implements PatternRecognizerInterface
         // The link cluster owns the navigation block's presentation: it is the
         // element core/navigation stands in for, so the menu list's className
         // stays with the menu instead of being copied onto the landmark.
-        $navigationAttrs = $this->navigationContainerAttributes($cluster, $presentationAttributes);
+        $navigationAttrs = $cluster->isSameNode($element)
+            ? array()
+            : $this->navigationContainerAttributes($cluster, $presentationAttributes);
         if ( null !== $navigationContext && $this->isListNavigationSource($cluster) ) {
             $clusterSpacing = $this->resolvedNavigationSpacing($navigationContext->resolvedStyle($cluster));
             $blockGap = trim((string) ($clusterSpacing['blockGap'] ?? ''));
@@ -505,6 +536,55 @@ final class NavigationPattern implements PatternRecognizerInterface
         }
 
         return $this->hasBrandAnchorSignal($anchor);
+    }
+
+    /**
+     * Recognize an explicitly named non-link brand beside one unambiguous menu.
+     *
+     * @return array{brand: DOMElement, cluster: DOMElement, brand_leads: bool}|null
+     */
+    private function nonAnchorBrandNavigationShape(DOMElement $element): ?array
+    {
+        $children = array_values(array_filter(
+            iterator_to_array($element->childNodes),
+            static fn ($child): bool => $child instanceof DOMElement
+        ));
+        $brands = array_values(array_filter(
+            $children,
+            function (DOMElement $child): bool {
+                $tagName = strtolower($child->tagName);
+                return 'a' !== $tagName
+                    && ! in_array($tagName, array( 'ul', 'ol' ), true)
+                    && 0 === $child->getElementsByTagName('a')->length
+                    && '' !== trim($child->textContent ?? '')
+                    && $this->hasBrandAnchorSignal($child);
+            }
+        ));
+        if ( 1 !== count($brands) ) {
+            return null;
+        }
+
+        $brand = $brands[0];
+        $menuChildren = array_values(array_filter($children, static fn (DOMElement $child): bool => ! $child->isSameNode($brand)));
+        $directAnchors = array_values(array_filter($menuChildren, static fn (DOMElement $child): bool => 'a' === strtolower($child->tagName)));
+        if ( count($directAnchors) === count($menuChildren) && 2 <= count($directAnchors) ) {
+            $firstMenu = $directAnchors[0];
+            return array(
+                'brand'       => $brand,
+                'cluster'     => $element,
+                'brand_leads' => array_search($brand, $children, true) < array_search($firstMenu, $children, true),
+            );
+        }
+
+        if ( 1 !== count($menuChildren) || 2 > $menuChildren[0]->getElementsByTagName('a')->length ) {
+            return null;
+        }
+
+        return array(
+            'brand'       => $brand,
+            'cluster'     => $menuChildren[0],
+            'brand_leads' => array_search($brand, $children, true) < array_search($menuChildren[0], $children, true),
+        );
     }
 
     private function directSectionLabel(DOMElement $element): ?DOMElement

--- a/php-transformer/tests/unit/navigation-non-anchor-brand-carrier.php
+++ b/php-transformer/tests/unit/navigation-non-anchor-brand-carrier.php
@@ -1,0 +1,170 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Contract for a non-anchor brand beside a direct link cluster.
+ *
+ * Northwind authors a `<nav>` landmark, a text wordmark, and a wrapping cluster
+ * of destination anchors:
+ *
+ *     <nav class="nav">
+ *       <span class="brand">Northwind</span>
+ *       <div>
+ *         <a href="/">Home</a>
+ *         <a href="/about.html">About</a>
+ *       </div>
+ *     </nav>
+ *
+ * `brandAnchorCarrier()` used to require the brand to be an `<a>`, so this
+ * shape declined and generic lowering emitted the brand plus each menu link as
+ * separate synthetic paragraphs. The links stacked vertically and the imported
+ * editor lost `core/navigation` semantics.
+ *
+ * The carrier now recognizes an explicitly named non-anchor wordmark beside one
+ * unambiguous menu and emits the brand as its own native block next to
+ * `core/navigation` / `core/navigation-link` children. Anchor brands and
+ * standalone generic inline spans keep their existing paths.
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$failures = 0;
+$passes = 0;
+
+$assert = static function (bool $condition, string $message, string $detail = '') use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ('' !== $detail ? ' - ' . $detail : '') . PHP_EOL);
+};
+
+$transform = static fn (string $html): array => ( new HtmlTransformer() )->transform($html, array())->toArray();
+
+/** @param array<int, array<string, mixed>> $blocks */
+$findBlocks = static function (array $blocks, string $name) use (&$findBlocks): array {
+    $found = array();
+    foreach ( $blocks as $block ) {
+        if ( $name === ($block['blockName'] ?? '') ) {
+            $found[] = $block;
+        }
+        $found = array_merge($found, $findBlocks(is_array($block['innerBlocks'] ?? null) ? $block['innerBlocks'] : array(), $name));
+    }
+
+    return $found;
+};
+
+$northwind = $transform(
+    '<nav class="nav">'
+    . '<span class="brand">Northwind</span>'
+    . '<div>'
+    . '<a href="/">Home</a>'
+    . '<a href="/about.html">About</a>'
+    . '</div>'
+    . '</nav>'
+);
+$northwindBlocks = is_array($northwind['blocks'] ?? null) ? $northwind['blocks'] : array();
+$northwindMarkup = (string) ($northwind['serialized_blocks'] ?? '');
+$northwindNavigations = $findBlocks($northwindBlocks, 'core/navigation');
+$northwindLinks = $findBlocks($northwindBlocks, 'core/navigation-link');
+$northwindCarriers = array_values(array_filter(
+    $findBlocks($northwindBlocks, 'core/group'),
+    static fn (array $block): bool => 'nav' === (string) ($block['attrs']['tagName'] ?? '')
+));
+
+$assert(
+    1 === count($northwindNavigations) && 1 === count($northwindCarriers),
+    'Northwind: one nav carrier holds one core/navigation',
+    $northwindMarkup
+);
+$assert(
+    2 === count($northwindLinks)
+        && 'Home' === (string) ($northwindLinks[0]['attrs']['label'] ?? '')
+        && '/' === (string) ($northwindLinks[0]['attrs']['url'] ?? '')
+        && 'About' === (string) ($northwindLinks[1]['attrs']['label'] ?? '')
+        && '/about.html' === (string) ($northwindLinks[1]['attrs']['url'] ?? ''),
+    'Northwind: the cluster becomes core/navigation-link children with authored labels and URLs',
+    json_encode($northwindLinks)
+);
+$assert(
+    str_contains($northwindMarkup, 'Northwind')
+        && str_contains($northwindMarkup, 'class="brand"')
+        && ! str_contains($northwindMarkup, 'blocks-engine-synthetic-paragraph')
+        && ! str_contains($northwindMarkup, 'blocks-engine-synthetic-anchor-undecorated')
+        && 0 === count($findBlocks($northwindBlocks, 'core/html'))
+        && ! str_contains($northwindMarkup, '<!-- wp:html'),
+    'Northwind: the wordmark stays native with no synthetic paragraphs or HTML fallback',
+    $northwindMarkup
+);
+$assert(
+    'core/paragraph' === (string) ($northwindCarriers[0]['innerBlocks'][0]['blockName'] ?? '')
+        && 'core/navigation' === (string) ($northwindCarriers[0]['innerBlocks'][1]['blockName'] ?? ''),
+    'Northwind: authored order is the brand block then the navigation',
+    json_encode($northwindCarriers[0]['innerBlocks'] ?? array())
+);
+$assert(
+    'pass' === ($northwind['source_reports']['wp_block_validity']['status'] ?? ''),
+    'Northwind: the carrier remains Gutenberg-valid',
+    json_encode($northwind['source_reports']['wp_block_validity'] ?? array())
+);
+
+$direct = $transform(
+    '<nav class="nav"><span class="brand">Northwind</span>'
+    . '<a href="/">Home</a><a href="/about.html">About</a></nav>'
+);
+$directBlocks = is_array($direct['blocks'] ?? null) ? $direct['blocks'] : array();
+$directMarkup = (string) ($direct['serialized_blocks'] ?? '');
+$assert(
+    1 === count($findBlocks($directBlocks, 'core/navigation'))
+        && 2 === count($findBlocks($directBlocks, 'core/navigation-link'))
+        && ! str_contains($directMarkup, 'blocks-engine-synthetic-paragraph'),
+    'Northwind direct cluster: sibling anchors use the same native carrier semantics',
+    $directMarkup
+);
+
+$anchorBrand = $transform(
+    '<nav class="nav">'
+    . '<a class="brand" href="/">Northwind</a>'
+    . '<div><a href="/">Home</a><a href="/about.html">About</a></div>'
+    . '</nav>'
+);
+$anchorBrandBlocks = is_array($anchorBrand['blocks'] ?? null) ? $anchorBrand['blocks'] : array();
+$anchorBrandMarkup = (string) ($anchorBrand['serialized_blocks'] ?? '');
+$assert(
+    1 === count($findBlocks($anchorBrandBlocks, 'core/navigation'))
+        && 2 === count($findBlocks($anchorBrandBlocks, 'core/navigation-link'))
+        && str_contains($anchorBrandMarkup, 'Northwind')
+        && str_contains($anchorBrandMarkup, '<a href="/">Northwind</a>'),
+    'anchor brand beside a cluster keeps the existing linked-wordmark carrier',
+    $anchorBrandMarkup
+);
+
+$genericInline = $transform('<span class="brand">Northwind</span>');
+$genericMarkup = (string) ($genericInline['serialized_blocks'] ?? '');
+$assert(
+    str_contains($genericMarkup, '<mark class="brand"')
+        && ! str_contains($genericMarkup, '<!-- wp:navigation'),
+    'standalone brand span keeps the generic inline mark fallback',
+    $genericMarkup
+);
+
+$ordinaryLabel = $transform(
+    '<nav class="nav"><span>Browse</span><div><a href="/">Home</a><a href="/about.html">About</a></div></nav>'
+);
+$ordinaryMarkup = (string) ($ordinaryLabel['serialized_blocks'] ?? '');
+$assert(
+    ! str_contains($ordinaryMarkup, '<!-- wp:navigation'),
+    'an ordinary non-link label does not infer a brand carrier',
+    $ordinaryMarkup
+);
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, "Navigation non-anchor brand carrier contract: {$failures} failed, {$passes} passed\n");
+    exit(1);
+}
+
+fwrite(STDOUT, "Navigation non-anchor brand carrier contract passed: {$passes} assertions\n");


### PR DESCRIPTION
## Summary

- extend the existing navigation carrier to recognize an explicitly cued non-anchor brand beside one unambiguous link cluster
- emit wrapped and direct sibling anchors as native `core/navigation` / `core/navigation-link` blocks
- preserve the brand as a native block without synthetic paragraph or `core/html` fallback output
- retain existing anchor-brand and ordinary inline fallback behavior

Fixes #1344.

## Verification

- `composer test`
- 289 PHP transformer parity fixtures passed
- dedicated Northwind contract: 9 assertions
- existing brand-anchor, brand-cue, and direct-cluster navigation contracts passed

## AI assistance

GPT-5.6-sol via OpenCode helped trace the navigation recognizer, implement the owning-layer carrier extension, reconcile concurrent changes, and run the repository verification suite. Chris Huber directed the architecture and reviewed the resulting behavior.