### PR TITLE
Simplify candidate rule ordering

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/AuthorStyleAnalysis.php
+++ b/php-transformer/src/HtmlToBlocks/Style/AuthorStyleAnalysis.php
@@ -217,7 +217,6 @@ final class AuthorStyleAnalysis
                 $entry = array(
                     'order' => $rule['order'],
                     'sequence' => $sequence++,
-                    'key' => $rule['order'] . ':' . $selectorIndex,
                     'rule' => array_merge($selector, array('declarations' => $rule['declarations'], 'rule_order' => $rule['order'], 'key' => $rule['order'] . ':' . $selectorIndex, 'source_path' => $rule['source_path'] ?? '', 'source_hash' => $rule['source_hash'] ?? '')),
                 );
                 if ( 'universal' === $target ) {

--- a/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatchCache.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatchCache.php
@@ -171,12 +171,8 @@ final class CssSelectorMatchCache
             $candidates = array_merge($candidates, $index['attributes'][$name] ?? array());
         }
 
-        $ordered = array();
-        foreach ( $candidates as $candidate ) {
-            $ordered[(string) ($candidate['key'] ?? $candidate['order'])] = $candidate;
-        }
-        uasort($ordered, static fn (array $left, array $right): int => $left['order'] <=> $right['order'] ?: (($left['sequence'] ?? $left['order']) <=> ($right['sequence'] ?? $right['order'])));
-        $rules = array_column($ordered, 'rule');
+        uasort($candidates, static fn (array $left, array $right): int => $left['order'] <=> $right['order'] ?: (($left['sequence'] ?? $left['order']) <=> ($right['sequence'] ?? $right['order'])));
+        $rules = array_column($candidates, 'rule');
         $this->candidateRuleChecks += count($rules);
         $this->candidateRulesSkipped += $index['total'] - count($rules);
 


### PR DESCRIPTION
## Summary

- remove the associative deduplication pass from candidate-rule ordering
- sort the already-disjoint candidate buckets directly
- remove the candidate-entry key that only supported that pass

Both candidate index builders assign each rule entry to exactly one precedence bucket, so rebuilding the merged list as a keyed map was redundant.

Closes #1338.

## Verification

- `composer test` passes, including 289 PHP transformer parity fixtures and package-install proof
- exact 625-file one-page receipt SHA-256 remains `ada4bc4e55091b3041b78b8fd8386154449369e5b8070b7691c2f71fcd2e9c2b`
- exact two-page receipt SHA-256 remains `d0e16074759b79f4f68502bec02a25a6a2766e5c5f401633116c4597eaa7b336`
- peak memory is unchanged at 210.17 MiB for one page and 231.09 MiB for two pages
- alternating one-page comparisons reduced user CPU from 65.97s to 57.24s (13.2%) and from 57.26s to 49.21s (14.1%)
- the two-page timing pair was noisy (+4.0% user CPU), with large per-page wall-time redistribution; deterministic parity and memory remained exact

## AI Assistance

GPT-5.6 Sol was used through OpenCode to inspect the candidate indexes, implement the simplification, run parity/performance verification, and prepare this PR.