### PR TITLE
Preserve bounded visual iframe islands

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -68,6 +68,7 @@
       "php tests/unit/asset-reference-canonicalizer-memory.php",
       "php tests/unit/srcset-parser.php",
        "php tests/unit/responsive-media-block.php",
+       "php tests/unit/visual-iframe-block.php",
        "php tests/unit/authored-marquee-block.php",
        "php tests/unit/responsive-document-variants.php",
        "php tests/unit/editability-report.php",

--- a/php-transformer/src/HtmlToBlocks/Generators/VisualIframeBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/Generators/VisualIframeBlockGenerator.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators;
+
+/** Builds the typed companion block for bounded external visual iframe surfaces. */
+final class VisualIframeBlockGenerator
+{
+    public const LOCAL_NAME = 'visual-iframe';
+
+    /** @return array<string, mixed> */
+    public function blockJson(string $namespace): array
+    {
+        return array(
+            'apiVersion' => 3,
+            'name' => $namespace . '/' . self::LOCAL_NAME,
+            'title' => 'Embedded Content',
+            'category' => 'embed',
+            'description' => 'A bounded external visual surface.',
+            'editorScript' => 'file:./index.js',
+            'attributes' => array(
+                'src' => array( 'type' => 'string', 'default' => '' ),
+                'title' => array( 'type' => 'string', 'default' => '' ),
+                'width' => array( 'type' => 'string', 'default' => '' ),
+                'height' => array( 'type' => 'string', 'default' => '' ),
+                'className' => array( 'type' => 'string', 'default' => '' ),
+                'allow' => array( 'type' => 'string', 'default' => '' ),
+                'loading' => array( 'type' => 'string', 'default' => '' ),
+                'sandbox' => array( 'type' => 'string', 'default' => '' ),
+                'referrerPolicy' => array( 'type' => 'string', 'default' => '' ),
+                'allowFullScreen' => array( 'type' => 'boolean', 'default' => false ),
+            ),
+            'supports' => array( 'html' => false ),
+        );
+    }
+
+    /** @return array<string, string> */
+    public function assets(string $blockName): array
+    {
+        $namespace = strstr($blockName, '/', true) ?: '';
+        $script = <<<'JS'
+( function( blocks, blockEditor, element ) {
+    var createElement = element.createElement;
+    var attributes = __BLOCK_ATTRIBUTES__;
+    function iframeProps( attributes, editor ) {
+        var props = editor ? blockEditor.useBlockProps() : {};
+        [ 'src', 'title', 'width', 'height', 'allow', 'loading', 'sandbox', 'referrerPolicy' ].forEach( function( name ) { if ( attributes[ name ] ) { props[ name ] = attributes[ name ]; } } );
+        if ( attributes.className ) { props.className = attributes.className; }
+        if ( attributes.allowFullScreen ) { props.allowFullScreen = true; }
+        return props;
+    }
+    function edit( props ) { return createElement( 'iframe', iframeProps( props.attributes, true ) ); }
+    function save( props ) { return createElement( 'iframe', iframeProps( props.attributes, false ) ); }
+    blocks.registerBlockType( '__BLOCK_NAME__', { attributes: attributes, supports: { html: false }, edit: edit, save: save } );
+} )( window.wp.blocks, window.wp.blockEditor, window.wp.element );
+JS;
+
+        return array( 'index.js' => str_replace(
+            array( '__BLOCK_NAME__', '__BLOCK_ATTRIBUTES__' ),
+            array( $blockName, json_encode($this->blockJson($namespace)['attributes'], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES) ),
+            $script
+        ) );
+    }
+
+    /** @param array<string, mixed> $attributes */
+    public function markup(array $attributes): string
+    {
+        $names = array(
+            'className' => 'class', 'src' => 'src', 'title' => 'title', 'width' => 'width', 'height' => 'height',
+            'allow' => 'allow', 'loading' => 'loading', 'sandbox' => 'sandbox', 'referrerPolicy' => 'referrerpolicy',
+        );
+        $markup = '<iframe';
+        foreach ( $names as $attribute => $htmlName ) {
+            $value = trim((string) ($attributes[$attribute] ?? ''));
+            if ( '' !== $value ) {
+                $markup .= ' ' . $htmlName . '="' . htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"';
+            }
+        }
+        if ( true === ($attributes['allowFullScreen'] ?? false) ) {
+            $markup .= ' allowfullscreen=""';
+        }
+
+        return $markup . '></iframe>';
+    }
+
+    /** @return array<string, mixed> */
+    public function definition(string $namespace): array
+    {
+        return array(
+            'name' => self::LOCAL_NAME,
+            'block_json' => $this->blockJson($namespace),
+            'assets' => $this->assets($namespace . '/' . self::LOCAL_NAME),
+            'script_dependencies' => array( 'index.js' => array( 'wp-blocks', 'wp-block-editor', 'wp-element' ) ),
+        );
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -27,6 +27,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\DescriptionLi
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\LayoutShellBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\ResponsiveLayoutBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\ResponsiveMediaBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\VisualIframeBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolutionContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolver;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispatchContext;
@@ -12428,6 +12429,25 @@ if ( 'svg' === $tagName ) {
             )), static fn ($value): bool => '' !== $value), array(), $iframe);
         }
 
+        $visualIframeAttributes = $this->boundedVisualIframeAttributes($iframe, $url);
+        if ( null !== $visualIframeAttributes ) {
+            $this->runtimeIslands->recordRuntimeIsland($iframe, 'iframe', 'iframe_requires_embed_runtime', 'third_party_embed_runtime', array(
+                'preservation_strategy' => 'typed_visual_iframe_companion',
+                'attributes' => $this->safeEmbedAttributes($iframe),
+            ));
+            $generator = new VisualIframeBlockGenerator();
+            $this->generatedBlocks()->register(VisualIframeBlockGenerator::class, $generator->definition($this->generatedBlocks()->namespace()));
+            $block = $this->createBlock(
+                $this->generatedBlocks()->blockName(VisualIframeBlockGenerator::LOCAL_NAME),
+                $visualIframeAttributes,
+                array(),
+                $iframe
+            );
+            $block['innerHTML'] = $generator->markup($visualIframeAttributes);
+            $block['innerContent'] = array( $block['innerHTML'] );
+            return $block;
+        }
+
         $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($iframe));
         $this->runtimeIslands->recordRuntimeIsland($iframe, 'iframe', 'iframe_requires_embed_runtime', 'third_party_embed_runtime', array(
             'preservation_strategy' => 'sanitized_embed_markup',
@@ -12450,10 +12470,7 @@ if ( 'svg' === $tagName ) {
             'html_truncated'  => $boundedHtml['truncated'],
         ), $this->transformationProvenance()->fallback());
 
-        $visualIframe = $this->boundedVisualIframeHtml($iframe, $url);
-        return '' === $visualIframe
-            ? null
-            : $this->createBlock('core/html', array( 'content' => $visualIframe ), array(), $iframe);
+        return null;
     }
 
     /**
@@ -12461,28 +12478,32 @@ if ( 'svg' === $tagName ) {
      * proves they occupy a visible, finite surface. The emitted markup is built
      * from an iframe-specific allowlist rather than carrying source HTML.
      */
-    private function boundedVisualIframeHtml(DOMElement $iframe, string $url): string
+    /** @return array<string, mixed>|null */
+    private function boundedVisualIframeAttributes(DOMElement $iframe, string $url): ?array
     {
         if ( ! $this->isSafeVisualIframeUrl($url) || $this->sourceElementStartsHidden($iframe) ) {
-            return '';
+            return null;
         }
 
         $attributes = $this->safeEmbedAttributes($iframe);
         $width = $this->boundedVisualIframeDimension($iframe, 'width');
         $height = $this->boundedVisualIframeDimension($iframe, 'height');
         if ( null === $width || null === $height ) {
-            return '';
+            return null;
         }
 
-        $attributes['src'] = $url;
-        $attributes['width'] = $this->attr($iframe, 'width') ?: $width;
-        $attributes['height'] = $this->attr($iframe, 'height') ?: $height;
-        $markup = '<iframe';
-        foreach ( $attributes as $name => $value ) {
-            $markup .= ' ' . $name . '="' . htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"';
-        }
-
-        return $markup . '></iframe>';
+        return array_filter(array(
+            'src' => $url,
+            'title' => $attributes['title'] ?? '',
+            'width' => $this->attr($iframe, 'width') ?: $width,
+            'height' => $this->attr($iframe, 'height') ?: $height,
+            'className' => $attributes['class'] ?? '',
+            'allow' => $attributes['allow'] ?? '',
+            'loading' => $attributes['loading'] ?? '',
+            'sandbox' => $attributes['sandbox'] ?? '',
+            'referrerPolicy' => $attributes['referrerpolicy'] ?? '',
+            'allowFullScreen' => array_key_exists('allowfullscreen', $attributes),
+        ), static fn (mixed $value): bool => '' !== $value && false !== $value);
     }
 
     private function isSafeVisualIframeUrl(string $url): bool

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -12450,7 +12450,97 @@ if ( 'svg' === $tagName ) {
             'html_truncated'  => $boundedHtml['truncated'],
         ), $this->transformationProvenance()->fallback());
 
-        return null;
+        $visualIframe = $this->boundedVisualIframeHtml($iframe, $url);
+        return '' === $visualIframe
+            ? null
+            : $this->createBlock('core/html', array( 'content' => $visualIframe ), array(), $iframe);
+    }
+
+    /**
+     * Unknown iframe providers can only be retained when source presentation
+     * proves they occupy a visible, finite surface. The emitted markup is built
+     * from an iframe-specific allowlist rather than carrying source HTML.
+     */
+    private function boundedVisualIframeHtml(DOMElement $iframe, string $url): string
+    {
+        if ( ! $this->isSafeVisualIframeUrl($url) || $this->sourceElementStartsHidden($iframe) ) {
+            return '';
+        }
+
+        $attributes = $this->safeEmbedAttributes($iframe);
+        $width = $this->boundedVisualIframeDimension($iframe, 'width');
+        $height = $this->boundedVisualIframeDimension($iframe, 'height');
+        if ( null === $width || null === $height ) {
+            return '';
+        }
+
+        $attributes['src'] = $url;
+        $attributes['width'] = $this->attr($iframe, 'width') ?: $width;
+        $attributes['height'] = $this->attr($iframe, 'height') ?: $height;
+        $markup = '<iframe';
+        foreach ( $attributes as $name => $value ) {
+            $markup .= ' ' . $name . '="' . htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"';
+        }
+
+        return $markup . '></iframe>';
+    }
+
+    private function isSafeVisualIframeUrl(string $url): bool
+    {
+        $parts = parse_url($url);
+        return is_array($parts)
+            && 'https' === strtolower((string) ($parts['scheme'] ?? ''))
+            && '' !== trim((string) ($parts['host'] ?? ''));
+    }
+
+    private function boundedVisualIframeDimension(DOMElement $iframe, string $dimension): ?string
+    {
+        $attribute = trim($this->attr($iframe, $dimension));
+        if ( $this->isPositiveIframeDimension($attribute) ) {
+            return $attribute;
+        }
+
+        if ( $this->isRelativeIframeDimension($attribute) && $this->iframeHasBoundedAncestor($iframe) ) {
+            return $attribute;
+        }
+
+        $declaration = trim((string) ($this->styleResolver->presentationDeclarations($iframe)[$dimension] ?? ''));
+        if ( $this->isPositiveIframeDimension($declaration) ) {
+            return $declaration;
+        }
+
+        return $this->isRelativeIframeDimension($declaration) && $this->iframeHasBoundedAncestor($iframe)
+            ? $declaration
+            : null;
+    }
+
+    private function isPositiveIframeDimension(string $value): bool
+    {
+        if ( ! preg_match('/^(?:\d+|\d*\.\d+)(?:px)?$/i', $value, $matches) ) {
+            return false;
+        }
+
+        return (float) $matches[0] > 0;
+    }
+
+    private function isRelativeIframeDimension(string $value): bool
+    {
+        return (bool) preg_match('/^(?:\d+|\d*\.\d+)%$/', $value)
+            && (float) $value > 0;
+    }
+
+    private function iframeHasBoundedAncestor(DOMElement $iframe): bool
+    {
+        for ( $ancestor = $iframe->parentNode; $ancestor instanceof DOMElement; $ancestor = $ancestor->parentNode ) {
+            $declarations = $this->styleResolver->presentationDeclarations($ancestor);
+            $width = trim($this->attr($ancestor, 'width')) ?: trim((string) ($declarations['width'] ?? ''));
+            $height = trim($this->attr($ancestor, 'height')) ?: trim((string) ($declarations['height'] ?? ''));
+            if ( $this->isPositiveIframeDimension($width) && $this->isPositiveIframeDimension($height) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function safeImageUrl(string $url): string

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -2724,21 +2724,22 @@ $unknownIframe = ( new HtmlTransformer() )->transform(
 )->toArray();
 $unknownDiagnostics = $unknownIframe['source_reports']['conversion_report']['fallback_diagnostics'] ?? array();
 $unknownIframeDiagnostics = array_values(array_filter($unknownDiagnostics, static fn (array $diagnostic): bool => 'html_iframe_embed_fallback' === ($diagnostic['diagnostic_code'] ?? '')));
-$assert(1 === count($unknownIframeDiagnostics), 'unknown iframe emits one iframe fallback diagnostic');
-$assert('runtime_island_preserved' === ($unknownIframeDiagnostics[0]['conversion_classification'] ?? ''), 'unknown iframe fallback is classified as runtime island preservation');
-$assert('https://example.test/playground' === ($unknownIframe['fallbacks'][0]['attributes']['src'] ?? ''), 'unknown iframe fallback preserves bounded safe src metadata');
+$assert(array() === $unknownIframeDiagnostics, 'bounded visual iframe does not emit a fallback diagnostic');
+$assert(array() === ($unknownIframe['fallbacks'] ?? array()), 'bounded visual iframe does not increase fallback count');
 $unknownIframeIslands = array_values(array_filter($unknownIframe['source_reports']['runtime_islands'] ?? array(), static fn (array $island): bool => 'iframe' === ($island['kind'] ?? '')));
 $assert(1 === count($unknownIframeIslands), 'unknown iframe projects as a runtime island');
 $assert('iframe_requires_embed_runtime' === ($unknownIframeIslands[0]['preservation_reason'] ?? ''), 'unknown iframe runtime island exposes preservation reason');
+$unknownVisualIframeBlock = array_values(array_filter($unknownIframe['blocks'][0]['innerBlocks'] ?? array(), static fn (array $block): bool => 'custom/visual-iframe' === ($block['blockName'] ?? '')))[0] ?? array();
 $unknownSerialized = (string) ($unknownIframe['serialized_blocks'] ?? '');
 $assert(! str_contains($unknownSerialized, '<!-- wp:embed'), 'unknown iframe does not become a provider embed block');
-$assert(str_contains($unknownSerialized, '<!-- wp:html'), 'bounded visible unknown iframe is materialized as an editable HTML block');
-$assert(str_contains($unknownSerialized, '<iframe') && str_contains($unknownSerialized, 'width="640"') && str_contains($unknownSerialized, 'height="360"'), 'bounded iframe source dimensions survive HTML-block serialization');
-$assert(str_contains($unknownSerialized, 'title="Interactive demo"') && str_contains($unknownSerialized, 'loading="lazy"') && str_contains($unknownSerialized, 'sandbox="allow-scripts"') && str_contains($unknownSerialized, 'referrerpolicy="no-referrer"'), 'bounded iframe accessibility and safe runtime attributes survive HTML-block serialization');
+$assert('custom/visual-iframe' === ($unknownVisualIframeBlock['blockName'] ?? ''), 'bounded visible unknown iframe is materialized as the typed visual-iframe companion');
+$assert(! str_contains($unknownSerialized, '<!-- wp:html') && str_contains($unknownSerialized, '<!-- wp:custom/visual-iframe'), 'bounded visual iframe does not use a core HTML fallback');
+$assert(str_contains($unknownSerialized, '<iframe') && str_contains($unknownSerialized, 'width="640"') && str_contains($unknownSerialized, 'height="360"'), 'bounded iframe source dimensions survive companion save serialization');
+$assert(str_contains($unknownSerialized, 'title="Interactive demo"') && str_contains($unknownSerialized, 'loading="lazy"') && str_contains($unknownSerialized, 'sandbox="allow-scripts"') && str_contains($unknownSerialized, 'referrerpolicy="no-referrer"'), 'bounded iframe accessibility and safe runtime attributes survive companion save serialization');
 $assert(str_contains($unknownSerialized, 'Playground'), 'ancestor content around unknown iframe still converts heading content');
 $assert(str_contains($unknownSerialized, 'Before embed.'), 'ancestor content before unknown iframe still converts');
 $assert(str_contains($unknownSerialized, 'After embed.'), 'ancestor content after unknown iframe still converts');
-$assert('pass' === ($unknownIframe['source_reports']['wp_block_validity']['status'] ?? ''), 'bounded iframe HTML-block save shape is Gutenberg-valid');
+$assert('pass' === ($unknownIframe['source_reports']['wp_block_validity']['status'] ?? ''), 'bounded iframe companion save shape is Gutenberg-valid');
 
 $visualIframeGeometry = ( new HtmlTransformer() )->transform(
     '<main><div style="width:1280px;height:350px;margin:0 80px 10px"><iframe title="Map surface" src="https://example.test/map" width="100%" height="100%"></iframe></div><p>Following content</p></main>'

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -2720,7 +2720,7 @@ $assert('facebook' === ($facebookProviderBlock['attrs']['providerNameSlug'] ?? '
 $assert(array() === ($facebookProviderIframe['fallbacks'] ?? array()), 'Facebook plugin iframe does not emit fallback metadata');
 
 $unknownIframe = ( new HtmlTransformer() )->transform(
-    '<main><section><h2>Playground</h2><p>Before embed.</p><iframe title="Interactive demo" src="https://example.test/playground" width="640" height="360" allow="fullscreen"></iframe><p>After embed.</p></section></main>'
+    '<main><section><h2>Playground</h2><p>Before embed.</p><iframe title="Interactive demo" src="https://example.test/playground" width="640" height="360" allow="fullscreen" loading="lazy" sandbox="allow-scripts" referrerpolicy="no-referrer"></iframe><p>After embed.</p></section></main>'
 )->toArray();
 $unknownDiagnostics = $unknownIframe['source_reports']['conversion_report']['fallback_diagnostics'] ?? array();
 $unknownIframeDiagnostics = array_values(array_filter($unknownDiagnostics, static fn (array $diagnostic): bool => 'html_iframe_embed_fallback' === ($diagnostic['diagnostic_code'] ?? '')));
@@ -2732,10 +2732,27 @@ $assert(1 === count($unknownIframeIslands), 'unknown iframe projects as a runtim
 $assert('iframe_requires_embed_runtime' === ($unknownIframeIslands[0]['preservation_reason'] ?? ''), 'unknown iframe runtime island exposes preservation reason');
 $unknownSerialized = (string) ($unknownIframe['serialized_blocks'] ?? '');
 $assert(! str_contains($unknownSerialized, '<!-- wp:embed'), 'unknown iframe does not become a provider embed block');
-$assert(! str_contains($unknownSerialized, '<!-- wp:html'), 'unknown iframe does not force raw HTML fallback materialization');
+$assert(str_contains($unknownSerialized, '<!-- wp:html'), 'bounded visible unknown iframe is materialized as an editable HTML block');
+$assert(str_contains($unknownSerialized, '<iframe') && str_contains($unknownSerialized, 'width="640"') && str_contains($unknownSerialized, 'height="360"'), 'bounded iframe source dimensions survive HTML-block serialization');
+$assert(str_contains($unknownSerialized, 'title="Interactive demo"') && str_contains($unknownSerialized, 'loading="lazy"') && str_contains($unknownSerialized, 'sandbox="allow-scripts"') && str_contains($unknownSerialized, 'referrerpolicy="no-referrer"'), 'bounded iframe accessibility and safe runtime attributes survive HTML-block serialization');
 $assert(str_contains($unknownSerialized, 'Playground'), 'ancestor content around unknown iframe still converts heading content');
 $assert(str_contains($unknownSerialized, 'Before embed.'), 'ancestor content before unknown iframe still converts');
 $assert(str_contains($unknownSerialized, 'After embed.'), 'ancestor content after unknown iframe still converts');
+$assert('pass' === ($unknownIframe['source_reports']['wp_block_validity']['status'] ?? ''), 'bounded iframe HTML-block save shape is Gutenberg-valid');
+
+$visualIframeGeometry = ( new HtmlTransformer() )->transform(
+    '<main><div style="width:1280px;height:350px;margin:0 80px 10px"><iframe title="Map surface" src="https://example.test/map" width="100%" height="100%"></iframe></div><p>Following content</p></main>'
+)->toArray();
+$visualIframeGeometryMarkup = (string) ($visualIframeGeometry['serialized_blocks'] ?? '');
+$visualIframeGeometryCss = (string) ($visualIframeGeometry['css'] ?? '');
+$assert(str_contains($visualIframeGeometryMarkup, 'width="100%"') && str_contains($visualIframeGeometryMarkup, 'height="100%"') && str_contains($visualIframeGeometryMarkup, 'title="Map surface"'), 'bounded iframe retains source sizing and title within its geometry-owning wrapper');
+$assert((str_contains($visualIframeGeometryMarkup, 'margin-bottom:10px') || str_contains($visualIframeGeometryCss, 'margin-bottom:10px')) && str_contains($visualIframeGeometryMarkup, 'Following content'), 'iframe wrapper margins and following content layout remain serialized');
+
+$suppressedIframe = ( new HtmlTransformer() )->transform(
+    '<main><iframe src="https://example.test/tag-manager" width="0" height="0" style="display:none"></iframe><iframe src="https://example.test/worker" width="1" height="1" style="visibility:hidden"></iframe><iframe src="javascript:alert(1)" width="640" height="360" srcdoc="<p>unsafe</p>"></iframe><iframe src="https://example.test/unbounded"></iframe></main>'
+)->toArray();
+$suppressedIframeMarkup = (string) ($suppressedIframe['serialized_blocks'] ?? '');
+$assert(! str_contains($suppressedIframeMarkup, '<iframe'), 'hidden, zero-size, unsafe, and unbounded iframes remain suppressed');
 
 $staticTemplate = ( new HtmlTransformer() )->transform(
     '<main><section><h2>Visible</h2><template><article><h3>Deferred article</h3><p>Readable metadata.</p></article></template><p>After.</p></section></main>'

--- a/php-transformer/tests/unit/inert-capture-scaffolding.php
+++ b/php-transformer/tests/unit/inert-capture-scaffolding.php
@@ -40,5 +40,6 @@ $assert('https://forms.hsforms.com/widget' === ($iframeFallbacks[0]['attributes'
 
 $hiddenSourcedIframe = $transform('<main><iframe title="third-party embed" style="display:none" src="https://example.test/embed"></iframe></main>');
 $assert(1 === count($hiddenSourcedIframe['fallbacks'] ?? array()), 'hidden sourced iframe remains preserved');
+$assert(! str_contains((string) ($hiddenSourcedIframe['serialized_blocks'] ?? ''), '<iframe'), 'hidden sourced iframe remains a suppressed runtime island');
 
 echo "OK: inert capture scaffolding passed ({$assertions} assertions)\n";

--- a/php-transformer/tests/unit/inert-capture-scaffolding.php
+++ b/php-transformer/tests/unit/inert-capture-scaffolding.php
@@ -34,9 +34,10 @@ $generatedRender = implode("\n", array_map(static fn (array $block): string => (
 $assert('' !== $generatedRender && ! str_contains($generatedRender, '<link'), 'generated custom blocks strip captured stylesheet links from nested SVG markup');
 
 $visibleIframe = $transform('<main><iframe title="HubSpot form" src="https://forms.hsforms.com/widget" width="600" height="400"></iframe></main>');
-$iframeFallbacks = array_values(array_filter($visibleIframe['fallbacks'] ?? array(), static fn (array $fallback): bool => 'iframe' === ($fallback['tag'] ?? '')));
-$assert(1 === count($iframeFallbacks), 'visible HubSpot iframe remains a bounded external embed');
-$assert('https://forms.hsforms.com/widget' === ($iframeFallbacks[0]['attributes']['src'] ?? ''), 'visible HubSpot iframe source is retained');
+$visibleIframeBlock = $visibleIframe['blocks'][0] ?? array();
+$assert('custom/visual-iframe' === ($visibleIframeBlock['blockName'] ?? ''), 'visible HubSpot iframe becomes a bounded companion embed');
+$assert('https://forms.hsforms.com/widget' === ($visibleIframeBlock['attrs']['src'] ?? ''), 'visible HubSpot iframe source is retained structurally');
+$assert(array() === ($visibleIframe['fallbacks'] ?? array()), 'visible bounded iframe does not add a fallback');
 
 $hiddenSourcedIframe = $transform('<main><iframe title="third-party embed" style="display:none" src="https://example.test/embed"></iframe></main>');
 $assert(1 === count($hiddenSourcedIframe['fallbacks'] ?? array()), 'hidden sourced iframe remains preserved');

--- a/php-transformer/tests/unit/visual-iframe-block.php
+++ b/php-transformer/tests/unit/visual-iframe-block.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\CompanionPluginPayload;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\VisualIframeBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$assertions = 0;
+$assert = static function (bool $condition, string $message) use (&$assertions): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        throw new RuntimeException($message);
+    }
+};
+
+$generator = new VisualIframeBlockGenerator();
+$definition = $generator->definition('ssi-example');
+$attributes = $definition['block_json']['attributes'] ?? array();
+$assert('ssi-example/visual-iframe' === ($definition['block_json']['name'] ?? null), 'visual iframe has a namespaced companion block type');
+$assert(false === ($definition['block_json']['supports']['html'] ?? null), 'visual iframe disables raw HTML editing');
+$assert(array('src', 'title', 'width', 'height', 'className', 'allow', 'loading', 'sandbox', 'referrerPolicy', 'allowFullScreen') === array_keys($attributes), 'visual iframe has a bounded structured attribute schema');
+$assert('boolean' === ($attributes['allowFullScreen']['type'] ?? null), 'visual iframe fullscreen permission is typed');
+$editor = (string) ($definition['assets']['index.js'] ?? '');
+$assert(str_contains($editor, "registerBlockType( 'ssi-example/visual-iframe'") && str_contains($editor, "createElement( 'iframe'") && ! str_contains($editor, 'RawHTML') && ! str_contains($editor, 'TextareaControl'), 'editor renders a bounded iframe preview instead of raw HTML editing');
+$assert(array('wp-blocks', 'wp-block-editor', 'wp-element') === ($definition['script_dependencies']['index.js'] ?? null), 'visual iframe declares its editor dependencies');
+$payload = (new CompanionPluginPayload())->fromBlockTypes(array(), array(), array(), array($definition));
+$assert('ssi-example/visual-iframe' === ($payload['blocks'][0]['block_json']['name'] ?? null), 'visual iframe companion definition survives payload packaging');
+
+$source = '<main><iframe class="map" title="Map" src="https://example.test/map" width="1280" height="350" allow="fullscreen" loading="lazy" sandbox="allow-scripts" referrerpolicy="no-referrer" allowfullscreen></iframe></main>';
+$result = (new HtmlTransformer())->transform($source)->toArray();
+$block = $result['blocks'][0] ?? array();
+$markup = (string) ($result['serialized_blocks'] ?? '');
+$assert('custom/visual-iframe' === ($block['blockName'] ?? null), 'bounded HTTPS iframe uses the direct-transform companion block');
+$assert('https://example.test/map' === ($block['attrs']['src'] ?? null) && '1280' === ($block['attrs']['width'] ?? null) && '350' === ($block['attrs']['height'] ?? null), 'companion reference retains source URL and dimensions structurally');
+$assert('Map' === ($block['attrs']['title'] ?? null) && true === ($block['attrs']['allowFullScreen'] ?? null), 'companion reference retains accessibility and fullscreen metadata structurally');
+$assert(! str_contains($markup, '<!-- wp:html') && str_contains($markup, '<iframe class="map" src="https://example.test/map" title="Map" width="1280" height="350"'), 'companion save markup is static and contains no core HTML fallback');
+$assert(array() === ($result['fallbacks'] ?? array()) && 'pass' === ($result['source_reports']['wp_block_validity']['status'] ?? null), 'bounded companion iframe adds no fallback and has a valid Gutenberg save shape');
+
+$repeated = (new HtmlTransformer())->transform($source . $source)->toArray();
+$assert(1 === count($repeated['source_reports']['generated_blocks'] ?? array()), 'multiple visual iframe instances share one generated companion definition');
+
+echo "Visual iframe companion tests passed ({$assertions} assertions)\n";


### PR DESCRIPTION
Closes #747.

## Summary
- materialize visible, finite unknown HTTPS iframe surfaces as a generated `visual-iframe` companion block with typed URL, title, dimensions, class, permission, loading, sandbox, and referrer-policy attributes
- the companion uses a bounded iframe preview and static save output; raw HTML editing is disabled
- retain only a strict iframe attribute allowlist; keep hidden, zero-size, unsafe, and unbounded frames diagnostic-only

## Verification
- `composer test` in `php-transformer`
- WordPress 7.1 reference checked; generated block uses API v3 static save output and `supports.html: false`
- SSI development package built from this branch at commit `42c419468d4ee837f6bf8680b194cb9a458f8b63` with `--blocks-engine-ref HEAD`

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode was used to inspect the conversion path, implement the bounded iframe policy and contracts, run verification, and prepare this pull request. The author reviewed the resulting changes and remains responsible for them.