### PR TITLE
Store author selectors once

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1738,8 +1738,8 @@ final class HtmlTransformer
 
         $authorAnalysis = $this->composedAuthorSelectorAnalysis($this->authorStylesheetPayloads($html, $staticCss));
         $sourceTagSelectorNames = $authorAnalysis['source_tags'];
-        $authorSelectors = $authorAnalysis['selectors'];
         $authorStyleRules = $authorAnalysis['rules'];
+        $authorSelectors = array_merge(...array_column($authorStyleRules, 'selectors'));
         foreach ( array_keys($sourceTagSelectorNames) as $tagName ) {
             $this->authorSelectorProjections()->ensureTagMarker($tagName);
         }
@@ -2147,10 +2147,10 @@ final class HtmlTransformer
         return array('root' => $root, 'fallback' => $fallback);
     }
 
-    /** @return array{source_tags: array<string, bool>, selectors: list<array{selector: string, parsed: array<string, mixed>}>, rules: list<array<string, mixed>>} */
+    /** @return array{source_tags: array<string, bool>, rules: list<array<string, mixed>>} */
     private function composedAuthorSelectorAnalysis(array $payloads): array
     {
-        $composed = array('source_tags' => array(), 'selectors' => array(), 'rules' => array());
+        $composed = array('source_tags' => array(), 'rules' => array());
         foreach ( $payloads as $payload ) {
             $key = hash('sha256', $payload['content']);
             $analysis = $this->analysisCache->authorSelectors($key);
@@ -2163,7 +2163,6 @@ final class HtmlTransformer
                 ++$this->analysisCache->authorSelectorHits;
             }
             $composed['source_tags'] += $analysis['source_tags'];
-            $composed['selectors'] = array_merge($composed['selectors'], $analysis['selectors']);
             foreach ( $analysis['rules'] as $rule ) {
                 $rule['order'] = count($composed['rules']);
                 $rule['source_path'] = $payload['source_path'];
@@ -2175,17 +2174,15 @@ final class HtmlTransformer
         return $composed;
     }
 
-    /** @return array{source_tags: array<string, bool>, selectors: list<array{selector: string, parsed: array<string, mixed>}>, rules: list<array<string, mixed>>} */
+    /** @return array{source_tags: array<string, bool>, rules: list<array<string, mixed>>} */
     private function authorSelectorAnalysis(string $css): array
     {
         $sourceTags = array();
-        $selectors = array();
         $rules = array();
-        (new CssStylesheetTransformer())->transform($css, function (string $prelude, string $body) use (&$sourceTags, &$selectors, &$rules): string {
+        (new CssStylesheetTransformer())->transform($css, function (string $prelude, string $body) use (&$sourceTags, &$rules): string {
             $ruleSelectors = array();
             foreach ( CssStylesheetTransformer::splitSelectorList($prelude) ?? array() as $selector ) {
                 $parsed = $this->parsedCssSelector($selector);
-                $selectors[] = array('selector' => $selector, 'parsed' => $parsed);
                 $directSelector = preg_replace('/::[a-z-]+(?:\([^)]*\))?$/i', '', trim($selector)) ?? $selector;
                 $ruleSelectors[] = array('selector' => $selector, 'parsed' => $parsed, 'direct_child_parsed' => $this->parsedCssSelector($directSelector));
                 foreach ( $parsed['type_spans'] ?? array() as $typeSpan ) {
@@ -2202,7 +2199,7 @@ final class HtmlTransformer
             return $prelude;
         });
 
-        return array('source_tags' => $sourceTags, 'selectors' => $selectors, 'rules' => $rules);
+        return array('source_tags' => $sourceTags, 'rules' => $rules);
     }
 
     /** @param array<string, mixed> $options @return list<array{path: string, source_path: string, content: string, source_hash: string, media: string}> */

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerAnalysisCache.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerAnalysisCache.php
@@ -138,7 +138,7 @@ final class HtmlTransformerAnalysisCache
         return $analysis;
     }
 
-    /** @param array{source_tags: array<string, bool>, selectors: list<array{selector: string, parsed: array<string, mixed>}>, rules: list<array<string, mixed>>} $analysis */
+    /** @param array{source_tags: array<string, bool>, rules: list<array<string, mixed>>} $analysis */
     public function rememberAuthorSelectors(string $key, array $analysis): void
     {
         $this->remember(


### PR DESCRIPTION
## Summary

- make author style rules the sole owner of parsed selector state
- derive the transient flat selector list from those rules only when semantic discovery needs it
- remove the duplicate selector list from composed and cached analyses

This is a follow-up simplification for #1338. The same parsed selector was previously retained both globally and inside its owning rule.

## Verification

- `composer test` passes, including 289 PHP transformer parity fixtures and package-install proof
- 54-page cache contract passes
- cached author-analysis bytes: 35,108 to 23,895 (-31.9%)
- byte-budget retained author state: 1,196,923 to 819,807 bytes (-31.5%)
- byte-budget evicted author state: 9,575,384 to 6,558,456 bytes (-31.5%)
- exact 625-file one-page receipt SHA-256 remains `ada4bc4e55091b3041b78b8fd8386154449369e5b8070b7691c2f71fcd2e9c2b`
- exact two-page receipt SHA-256 remains `d0e16074759b79f4f68502bec02a25a6a2766e5c5f401633116c4597eaa7b336`
- exact same-base two-page peak memory drops from 231.09 MiB to 229.09 MiB
- whole-page CPU varied across runs, so this PR claims no CPU improvement

## AI Assistance

GPT-5.6 Sol was used through OpenCode to inspect duplicated author-selector state, implement the refactor, run parity/memory/performance verification, and prepare this PR.