### PR TITLE
Consolidate form submit classification

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Classification/FormControlClassifier.php
+++ b/php-transformer/src/HtmlToBlocks/Classification/FormControlClassifier.php
@@ -107,4 +107,86 @@ final class FormControlClassifier
 
         return 'button' === $tagName || ( 'input' === $tagName && in_array(self::controlType($control), array( 'checkbox', 'email', 'number', 'radio', 'range', 'search', 'submit', 'tel', 'text', 'url' ), true) );
     }
+
+    public static function isSubmitLikeControl(DOMElement $control): bool
+    {
+        $tagName = strtolower($control->tagName);
+        if ( 'button' !== $tagName && 'input' !== $tagName ) {
+            return false;
+        }
+
+        $type = self::controlType($control);
+        if ( in_array($type, array( 'submit', 'image' ), true) ) {
+            return true;
+        }
+        if ( 'reset' === $type ) {
+            return false;
+        }
+
+        // Data-entry inputs never become submit controls through labels alone.
+        if ( 'input' === $tagName && 'button' !== $type ) {
+            return false;
+        }
+
+        return self::hasSubmitSemantics($control) || self::isSoleFormActionControl($control);
+    }
+
+    public static function hasSubmitSemantics(DOMElement $control): bool
+    {
+        $values = array( $control->textContent ?? '' );
+        foreach ( array( 'value', 'class', 'id', 'name', 'aria-label', 'data-hook', 'data-field-type', 'data-testid' ) as $attribute ) {
+            $values[] = $control->hasAttribute($attribute) ? $control->getAttribute($attribute) : '';
+        }
+        $haystack = strtolower(implode(' ', $values));
+
+        foreach ( array( 'submit', 'subscribe', 'sign up', 'sign-up', 'signup', 'send' ) as $needle ) {
+            if ( str_contains($haystack, $needle) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static function isPseudoFormSubmitControl(DOMElement $control): bool
+    {
+        return in_array(self::controlType($control), array( 'submit', 'image' ), true)
+            || self::hasSubmitSemantics($control);
+    }
+
+    public static function isPseudoFormDataEntryControl(DOMElement $control): bool
+    {
+        return self::isDataEntryControl($control) && 'search' !== self::controlType($control);
+    }
+
+    private static function isSoleFormActionControl(DOMElement $control): bool
+    {
+        $form = null;
+        for ( $parent = $control->parentNode; $parent instanceof DOMElement; $parent = $parent->parentNode ) {
+            if ( 'form' === strtolower($parent->tagName) ) {
+                $form = $parent;
+                break;
+            }
+        }
+        if ( ! $form instanceof DOMElement ) {
+            return false;
+        }
+
+        $actions = 0;
+        foreach ( self::controlElements($form) as $candidate ) {
+            $tagName = strtolower($candidate->tagName);
+            $type = self::controlType($candidate);
+            if ( 'reset' === $type ) {
+                continue;
+            }
+            if ( 'button' === $tagName || ( 'input' === $tagName && in_array($type, array( 'submit', 'image', 'button' ), true) ) ) {
+                ++$actions;
+                if ( 1 < $actions ) {
+                    return false;
+                }
+            }
+        }
+
+        return 1 === $actions;
+    }
 }

--- a/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
@@ -150,7 +150,7 @@ trait FormDispatchTrait
                 return null;
             }
 
-            if ( $this->isSubmitLikeControl($control) ) {
+            if ( FormControlClassifier::isSubmitLikeControl($control) ) {
                 $buttonBlocks[] = $this->createBlock('core/button', array_merge($this->styleResolver->presentationAttributes($control), array(
                     'text' => $this->runtime->escapeHtml($this->readableSubmitText($control)),
                 )), array(), $control);
@@ -526,7 +526,7 @@ trait FormDispatchTrait
     private function formHasCommerceSubmissionSignal(DOMElement $form): bool
     {
         foreach ( FormControlClassifier::controlElements($form) as $control ) {
-            if ( ! $this->isSubmitLikeControl($control) ) {
+            if ( ! FormControlClassifier::isSubmitLikeControl($control) ) {
                 continue;
             }
 
@@ -760,12 +760,12 @@ trait FormDispatchTrait
         $hasContainerAction = '' !== trim($this->attr($element, 'action')) || '' !== trim($this->attr($element, 'method')) || '' !== trim($this->attr($element, 'data-action'));
 
         foreach ( FormControlClassifier::controlElements($element) as $control ) {
-            if ( $this->isPseudoFormDataEntryControl($control) && ! $this->hasStandaloneSearchSignal($element, $control) ) {
+            if ( FormControlClassifier::isPseudoFormDataEntryControl($control) && ! $this->hasStandaloneSearchSignal($element, $control) ) {
                 $hasDataEntry = true;
                 $hasFieldLabel = $hasFieldLabel || '' !== trim($this->formControlLabel($control)) || '' !== trim($this->attr($control, 'aria-label')) || '' !== trim($this->attr($control, 'name'));
             } elseif ( 'button' === strtolower($control->tagName) || ( 'input' === strtolower($control->tagName) && ! in_array(FormControlClassifier::controlType($control), array( 'reset', 'button' ), true) ) ) {
                 $hasActionControl = true;
-                $hasSubmit = $hasSubmit || $this->isPseudoFormSubmitControl($control);
+                $hasSubmit = $hasSubmit || FormControlClassifier::isPseudoFormSubmitControl($control);
             }
 
             if ( $hasDataEntry && $hasFieldLabel && ( $hasSubmit || ( $hasContainerAction && $hasActionControl ) ) ) {
@@ -774,16 +774,6 @@ trait FormDispatchTrait
         }
 
         return false;
-    }
-
-    private function isPseudoFormSubmitControl(DOMElement $control): bool
-    {
-        $type = FormControlClassifier::controlType($control);
-        if ( in_array($type, array( 'submit', 'image' ), true) ) {
-            return true;
-        }
-
-        return $this->hasSubmitSemantics($control);
     }
 
     private function pseudoFormContainsUnrelatedLandmark(DOMElement $element): bool
@@ -822,109 +812,6 @@ trait FormDispatchTrait
             'selection_basis' => array( 'local_controls', 'associated_label', 'submit_semantics' ),
             'rejected_ancestors' => $rejectedAncestors,
         );
-    }
-
-    /**
-     * A data-entry control that anchors a pseudo-form. Reuses #315's
-     * isDataEntryControl and additionally excludes search inputs, which already
-     * have dedicated standalone-search handling and should not be promoted into a
-     * form fallback.
-     */
-    private function isPseudoFormDataEntryControl(DOMElement $control): bool
-    {
-        return FormControlClassifier::isDataEntryControl($control) && 'search' !== FormControlClassifier::controlType($control);
-    }
-
-    /**
-     * Whether a control submits a form: an explicit submit/image control, or a
-     * button/input whose text/value/type/class/id/name/aria carries submit,
-     * subscribe, sign-up, or send semantics. A plain <button> defaults to type
-     * "submit" and qualifies directly; a type="reset" control never does.
-     */
-    private function isSubmitLikeControl(DOMElement $control): bool
-    {
-        $tagName = strtolower($control->tagName);
-        if ( 'button' !== $tagName && 'input' !== $tagName ) {
-            return false;
-        }
-
-        $type = FormControlClassifier::controlType($control);
-        if ( in_array($type, array( 'submit', 'image' ), true) ) {
-            return true;
-        }
-        if ( 'reset' === $type ) {
-            return false;
-        }
-
-        // Only generic clickable controls (button-typed) fall through to the
-        // semantic check; data-entry input types are never submit controls.
-        if ( 'input' === $tagName && 'button' !== $type ) {
-            return false;
-        }
-
-        return $this->hasSubmitSemantics($control) || $this->isSoleFormActionControl($control);
-    }
-
-    /**
-     * The only non-reset button-like control in the enclosing form is the form's
-     * action, even when its type is `button` and its label is not a submit verb.
-     */
-    private function isSoleFormActionControl(DOMElement $control): bool
-    {
-        $form = null;
-        for ( $parent = $control->parentNode; $parent instanceof DOMElement; $parent = $parent->parentNode ) {
-            if ( 'form' === strtolower($parent->tagName) ) {
-                $form = $parent;
-                break;
-            }
-        }
-        if ( ! $form instanceof DOMElement ) {
-            return false;
-        }
-
-        $actions = 0;
-        foreach ( FormControlClassifier::controlElements($form) as $candidate ) {
-            $tagName = strtolower($candidate->tagName);
-            $type = FormControlClassifier::controlType($candidate);
-            if ( 'reset' === $type ) {
-                continue;
-            }
-            if ( 'button' === $tagName || ( 'input' === $tagName && in_array($type, array( 'submit', 'image', 'button' ), true) ) ) {
-                ++$actions;
-                if ( 1 < $actions ) {
-                    return false;
-                }
-            }
-        }
-
-        return 1 === $actions;
-    }
-
-    /**
-     * Whether a control's text/attributes carry submit-like intent. Structural
-     * vocabulary only — no fixture-specific identifiers.
-     */
-    private function hasSubmitSemantics(DOMElement $control): bool
-    {
-        $haystack = strtolower(implode(' ', array(
-            $control->textContent ?? '',
-            $this->attr($control, 'value'),
-            $this->attr($control, 'class'),
-            $this->attr($control, 'id'),
-            $this->attr($control, 'name'),
-            $this->attr($control, 'aria-label'),
-            $this->attr($control, 'data-hook'),
-            $this->attr($control, 'data-field-type'),
-            $this->attr($control, 'data-testid'),
-        )));
-
-        foreach ( array( 'submit', 'subscribe', 'sign up', 'sign-up', 'signup', 'send' ) as $needle ) {
-            if ( str_contains($haystack, $needle) ) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private function readableFormControlText(DOMElement $control): string
@@ -1022,7 +909,7 @@ trait FormDispatchTrait
         }
 
         $type = FormControlClassifier::controlType($control);
-        if ( '' === $label && $this->isSubmitLikeControl($control) ) {
+        if ( '' === $label && FormControlClassifier::isSubmitLikeControl($control) ) {
             $label = trim(preg_replace('/\s+/', ' ', $control->textContent ?? '') ?? '');
         }
         if ( '' === $label ) {


### PR DESCRIPTION
## Summary

- move submit-like control detection, semantic submit signals, and sole-action inference onto `FormControlClassifier`
- centralize pseudo-form submit and data-entry control predicates on the same classifier
- route form dispatch through those classifier methods
- remove the superseded classification methods from `FormDispatchTrait`

## Verification

- `composer test`
- PHP transformer parity: 289 fixtures passed
- fresh CSS-attached corpus comparison against current `origin/trunk`: 383 documents, 87 fixtures, 82 fixtures with CSS, 0 throws, byte-identical records

## AI assistance

GPT-5.6 Sol was used through OpenCode to identify the residual submit-classification seam, consolidate it onto the existing classifier, and run the contract, package-install, and corpus verification workflows. The implementation and evidence were reviewed and orchestrated by Chris Huber.