### PR TITLE
fix(php-transformer): diagnose empty compiled site documents

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -22,6 +22,7 @@ use Automattic\BlocksEngine\PhpTransformer\StaticSite\MaterializationPlanBuilder
 use Automattic\BlocksEngine\PhpTransformer\Support\DeterministicRowDeduplicator;
 use Automattic\BlocksEngine\PhpTransformer\Support\StyleTagScanner;
 use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlan;
+use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\DocumentIdentityException;
 use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\ValidationException;
 use DOMDocument;
 use DOMElement;
@@ -698,6 +699,10 @@ final class ArtifactCompiler
             );
         }
         $sourceReports['compiled_site'] = $this->compiledSiteReport($normalized, $entryPath, $documents['documents'], $assets, $blockTypes, $serializedBlocks, $entryBlocks['shell_artifacts'], $compiledHtmlDocuments);
+        $identityFailures = WordPressSitePlan::compiledSiteIdentityFailures($sourceReports['compiled_site']);
+        foreach ( WordPressSitePlan::documentIdentityDiagnostics($identityFailures) as $identityDiagnostic ) {
+            $diagnostics[] = array_merge($identityDiagnostic, array('source' => self::class));
+        }
         $fileMetadata = array_column($normalized['files'], null, 'path');
         $entryFile = $fileMetadata[$entryPath] ?? array();
         $editabilityDocuments = array($entryPath => array('blocks' => $entryBlocks['blocks'], 'serialized_blocks' => $entryBlocks['serialized_blocks'], 'generated_carrier_css' => $this->cssAssetContent($entryBlocks['assets']), 'runtime_block_paths' => $entryBlocks['runtime_block_paths'] ?? array(), 'visual_block_paths' => $entryBlocks['visual_block_paths'] ?? array(), 'editability_report' => $entryBlocks['editability_report'] ?? null, 'template_surface' => $entryFile['metadata']['template_surface'] ?? null, 'provenance' => $entryFile['provenance'] ?? null));
@@ -779,7 +784,7 @@ final class ArtifactCompiler
         );
         // Editability failures retain a failed-quality plan as review evidence;
         // all other failures have no materializable source identity or site plan.
-        if ( 'failed' !== $this->statusFromDiagnostics($diagnostics) || 'failed' === ($sourceReports['editability_policy']['status'] ?? null) ) {
+        if ( array() === $identityFailures && ( 'failed' !== $this->statusFromDiagnostics($diagnostics) || 'failed' === ($sourceReports['editability_policy']['status'] ?? null) ) ) {
             $sourceReports['conversion_report'] = ConversionReportProjection::fromResultParts('artifact', $entryBlocks['blocks'], $allFallbacks, $sourceReports, $assets, $provenance, $metrics);
             try {
                 $sourceReports['wordpress_site_plan'] = ( new WordPressSitePlan() )->fromResult(array(
@@ -800,6 +805,10 @@ final class ArtifactCompiler
                     'metrics' => $metrics,
                 ));
                 $sourceReports['editability_report'] = (new EditabilityReport())->withTemplateSurfaceSelection($sourceReports['editability_report'], $sourceReports['wordpress_site_plan']['templates']);
+            } catch (DocumentIdentityException $exception) {
+                foreach ( $exception->diagnostics() as $identityDiagnostic ) {
+                    $diagnostics[] = array_merge($identityDiagnostic, array('source' => self::class));
+                }
             } catch (\InvalidArgumentException $exception) {
                 $diagnostics[] = $exception instanceof ValidationException
                     ? array_merge($exception->diagnostic(), array('severity' => 'error', 'source' => self::class))

--- a/php-transformer/src/Contract/ConversionFindingContract.php
+++ b/php-transformer/src/Contract/ConversionFindingContract.php
@@ -286,6 +286,7 @@ final class ConversionFindingContract
             'preserved_runtime_island'          => 'runtime_island',
             'html_static_script_metadata'       => 'static_script_metadata',
             'html_to_blocks_core_slice'         => 'conversion_summary',
+            'wordpress_site_plan_not_self_contained' => 'site_plan_document',
             default                             => '' !== $tag ? 'html_' . $tag : ( '' !== $code ? $code : 'html_fallback' ),
         };
     }
@@ -345,6 +346,7 @@ final class ConversionFindingContract
             'inert_template_metadata', 'static_script_metadata' => 'preserve_static_metadata',
             'inline_svg'                    => 'materialize_static_asset',
             'conversion_summary'            => 'no_repair_needed',
+            'site_plan_document'            => 'restore_compiled_document_identity',
             default                         => str_starts_with($patternFamily, 'unsupported_')
                 ? 'add_generic_pattern_recognizer'
                 : 'review_generic_mapping',

--- a/php-transformer/src/WordPressSitePlan/DocumentIdentityException.php
+++ b/php-transformer/src/WordPressSitePlan/DocumentIdentityException.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan;
+
+use InvalidArgumentException;
+
+/** A fail-closed identity failure that carries every offending compiled document. */
+final class DocumentIdentityException extends InvalidArgumentException
+{
+    /**
+     * @param array<int,array{source_path:string,reason:string,document_kind:string}> $failures
+     */
+    public function __construct(private array $failures)
+    {
+        parent::__construct(self::summary($failures));
+    }
+
+    /**
+     * @return array<int,array{source_path:string,reason:string,document_kind:string}>
+     */
+    public function failures(): array
+    {
+        return $this->failures;
+    }
+
+    /** @return array<int,array<string,mixed>> */
+    public function diagnostics(): array
+    {
+        return WordPressSitePlan::documentIdentityDiagnostics($this->failures);
+    }
+
+    /**
+     * @param array<int,array{source_path:string,reason:string,document_kind:string}> $failures
+     */
+    private static function summary(array $failures): string
+    {
+        $count = count($failures);
+        $empty = count(array_filter($failures, static fn (array $failure): bool => 'empty_block_markup' === $failure['reason']));
+        $paths = array_slice(array_values(array_filter(array_column($failures, 'source_path'), static fn (mixed $path): bool => is_string($path) && '' !== $path)), 0, 3);
+        $listed = implode(', ', $paths);
+        $more = $count > count($paths) ? sprintf(' (+%d more)', $count - count($paths)) : '';
+
+        return sprintf(
+            '%d compiled site document(s) lack a safe identity or block markup (%d empty markup, %d unsafe identity): %s%s',
+            $count,
+            $empty,
+            $count - $empty,
+            $listed,
+            $more
+        );
+    }
+}

--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
@@ -17,6 +17,7 @@ final class WordPressSitePlan
     public const SCHEMA = 'blocks-engine/wordpress-site-plan/v2';
     public const IDENTITY_SCHEMA = 'blocks-engine/wordpress-site-plan-identity/v1';
     public const TOKEN_PREFIX = '{{wordpress-site-plan:asset:';
+    public const MAX_DOCUMENT_IDENTITY_DIAGNOSTICS = 50;
     public const EDITOR_CORE_IMAGE_INTERACTION_CSS = ':root .block-editor-block-list__block.wp-block-image img{pointer-events:auto!important}';
     private string $sourceOrigin = '';
     /** @var array<string,string> */
@@ -66,6 +67,10 @@ final class WordPressSitePlan
         $materialization = $data['source_reports']['materialization_plan'] ?? null;
         if ( ! is_array($compiled) || ! is_array($materialization) ) {
             throw new InvalidArgumentException('WordPress site plan requires compiled-site and materialization-plan reports.');
+        }
+        $identityFailures = self::compiledSiteIdentityFailures($compiled);
+        if ( array() !== $identityFailures ) {
+            throw new DocumentIdentityException($identityFailures);
         }
 
         $runtimeDeclarations = $compiled['runtime_declarations'] ?? array();
@@ -328,17 +333,126 @@ final class WordPressSitePlan
         }
     }
 
+    /**
+     * Collect every compiled page or template part that cannot become a site-plan document.
+     *
+     * @param array<string,mixed> $compiledSite
+     * @return array<int,array{source_path:string,reason:string,document_kind:string}>
+     */
+    public static function compiledSiteIdentityFailures(array $compiledSite): array
+    {
+        $pages = is_array($compiledSite['pages'] ?? null) ? $compiledSite['pages'] : array();
+        $parts = is_array($compiledSite['template_parts'] ?? null) ? $compiledSite['template_parts'] : array();
+        $parts = array_values(array_filter($parts, static fn (mixed $part): bool => is_array($part) && 'entry_shell' !== ($part['placement']['kind'] ?? null)));
+
+        return array_merge(
+            self::documentIdentityFailures($pages, 'page'),
+            self::documentIdentityFailures($parts, 'template_part')
+        );
+    }
+
+    /**
+     * @param mixed $documents
+     * @return array<int,array{source_path:string,reason:string,document_kind:string}>
+     */
+    public static function documentIdentityFailures(mixed $documents, string $documentKind): array
+    {
+        if ( ! is_array($documents) ) {
+            return array();
+        }
+        $failures = array();
+        foreach ( $documents as $document ) {
+            if ( ! is_array($document) || ! self::safePath($document['source_path'] ?? null) ) {
+                $failures[] = array(
+                    'source_path' => is_array($document) && is_string($document['source_path'] ?? null) ? $document['source_path'] : '',
+                    'reason' => 'unsafe_identity',
+                    'document_kind' => $documentKind,
+                );
+                continue;
+            }
+            if ( ! is_string($document['block_markup'] ?? null) || '' === trim($document['block_markup']) ) {
+                $failures[] = array(
+                    'source_path' => $document['source_path'],
+                    'reason' => 'empty_block_markup',
+                    'document_kind' => $documentKind,
+                );
+            }
+        }
+
+        return $failures;
+    }
+
+    /**
+     * @param array<int,array{source_path:string,reason:string,document_kind:string}> $failures
+     * @return array<int,array<string,mixed>>
+     */
+    public static function documentIdentityDiagnostics(array $failures): array
+    {
+        $total = count($failures);
+        if ( 0 === $total ) {
+            return array();
+        }
+        $retained = array_slice($failures, 0, self::MAX_DOCUMENT_IDENTITY_DIAGNOSTICS);
+        $diagnostics = array();
+        foreach ( $retained as $failure ) {
+            $diagnostics[] = self::documentIdentityDiagnostic($failure, $total);
+        }
+        if ( $total > count($retained) ) {
+            $diagnostics[] = array(
+                'code' => 'wordpress_site_plan_not_self_contained',
+                'severity' => 'error',
+                'message' => sprintf('%d compiled site documents lack a safe identity or block markup; %d omitted from this diagnostic list.', $total, $total - count($retained)),
+                'reason' => 'truncated',
+                'document_count' => $total,
+                'omitted_count' => $total - count($retained),
+                'reason_code' => 'wordpress_site_plan_not_self_contained',
+                'pattern_family' => 'site_plan_document',
+                'repair_bucket' => 'restore_compiled_document_identity',
+            );
+        }
+
+        return $diagnostics;
+    }
+
+    /**
+     * @param array{source_path:string,reason:string,document_kind:string} $failure
+     * @return array<string,mixed>
+     */
+    private static function documentIdentityDiagnostic(array $failure, int $documentCount): array
+    {
+        $path = substr($failure['source_path'], 0, 256);
+        $kind = 'template_part' === $failure['document_kind'] ? 'template part' : 'page';
+        $named = '' === $path ? 'Compiled ' . $kind : 'Compiled ' . $kind . ' "' . $path . '"';
+        $message = 'unsafe_identity' === $failure['reason']
+            ? $named . ' lacks a safe source path.'
+            : $named . ' has empty block markup.';
+
+        return array(
+            'code' => 'wordpress_site_plan_not_self_contained',
+            'severity' => 'error',
+            'message' => substr($message, 0, 256),
+            'source_path' => $path,
+            'document_kind' => substr($failure['document_kind'], 0, 64),
+            'reason' => substr($failure['reason'], 0, 64),
+            'document_count' => $documentCount,
+            'reason_code' => 'wordpress_site_plan_not_self_contained',
+            'pattern_family' => 'site_plan_document',
+            'repair_bucket' => 'restore_compiled_document_identity',
+        );
+    }
+
     /** @param mixed $documents @param array<int,array<string,string>> $tokens @return array<int,array<string,mixed>> */
     private function documents(mixed $documents, bool $part, array $tokens, AssetReferenceCanonicalizer $references, array $routes): array
     {
         if ( ! is_array($documents) ) {
             throw new InvalidArgumentException('Compiled site documents must be an array.');
         }
+        $failures = self::documentIdentityFailures($documents, $part ? 'template_part' : 'page');
+        if ( array() !== $failures ) {
+            throw new DocumentIdentityException($failures);
+        }
         $rows = array();
         foreach ( $documents as $document ) {
-            if ( ! is_array($document) || ! self::safePath($document['source_path'] ?? null) || ! is_string($document['block_markup'] ?? null) || '' === trim($document['block_markup']) ) {
-                throw new InvalidArgumentException('Compiled site document lacks a safe identity or block markup.');
-            }
             $markup = $references->content($document['block_markup'], $document['source_path']);
             $canonical = $this->routeLinks($markup, $document['source_path'], $routes);
             $target = $part ? 'parts/' . self::value($document, 'slug') . '.html' : self::value($document, 'source_path');

--- a/php-transformer/tests/contract/finding-contract.php
+++ b/php-transformer/tests/contract/finding-contract.php
@@ -287,6 +287,23 @@ $assert(
     'artifact runtime dependency parity records the shared-script dependency row'
 );
 
+$emptyDocumentResult = ( new ArtifactCompiler() )->compile(array(
+    'entrypoint' => 'website/index.html',
+    'files'      => array(
+        'website/index.html' => '',
+        'website/about.html' => '',
+    ),
+))->toArray();
+$totalFindings += $walk($emptyDocumentResult, 'artifact:empty-documents');
+$emptyDocumentFindings = array_values(array_filter(
+    $emptyDocumentResult['diagnostics'],
+    static fn (array $diagnostic): bool => 'wordpress_site_plan_not_self_contained' === ConversionFindingContract::findingCode($diagnostic)
+));
+$assert(2 === count($emptyDocumentFindings), 'empty compiled documents emit per-document identity findings');
+$emptyDocumentClassified = ConversionFindingContract::classify(array('code' => 'wordpress_site_plan_not_self_contained'));
+$assert('site_plan_document' === ($emptyDocumentClassified['pattern_family'] ?? null), 'empty-document findings cluster under site_plan_document');
+$assert('restore_compiled_document_identity' === ($emptyDocumentClassified['repair_bucket'] ?? null), 'empty-document findings route to a concrete identity repair bucket');
+
 $assert($totalFindings > 0, 'the contract walk validated a non-empty set of real conversion findings');
 
 fwrite(STDOUT, "Conversion finding contract passed: {$totalFindings} finding(s) validated.\n");

--- a/php-transformer/tests/contract/wordpress-site-plan.php
+++ b/php-transformer/tests/contract/wordpress-site-plan.php
@@ -6,8 +6,10 @@ require __DIR__ . '/support/ResolvedPlanProjection.php';
 
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\RuntimeDeclarations;
+use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionFindingContract;
 use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlan;
 use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanResolver;
+use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\DocumentIdentityException;
 use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\ValidationException;
 use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\AssetReferenceCanonicalizer;
 
@@ -581,6 +583,72 @@ $assert('/about' === ($wrappedPages['website/about/index.html']['route']['path']
 $routeCollision = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => '<main>Home</main>', 'nested/about.html' => '<main>One</main>', 'nested/about.htm' => '<main>Two</main>')))->toArray();
 $routeCollisionDiagnostics = array_values(array_filter($routeCollision['diagnostics'], static fn(array $diagnostic): bool => 'wordpress_site_plan_not_self_contained' === ($diagnostic['code'] ?? null)));
 $assert('failed' === ($routeCollision['status'] ?? null) && !isset($routeCollision['source_reports']['wordpress_site_plan']) && 1 === count($routeCollisionDiagnostics) && 'error' === ($routeCollisionDiagnostics[0]['severity'] ?? null) && ArtifactCompiler::class === ($routeCollisionDiagnostics[0]['source'] ?? null) && count($routeCollision['diagnostics']) === ($routeCollision['metrics']['diagnostic_count'] ?? null) && count($routeCollision['diagnostics']) === ($routeCollision['source_reports']['conversion_report']['metrics']['diagnostic_count'] ?? null) && count($routeCollision['diagnostics']) === ($routeCollision['source_reports']['conversion_report']['source_summary']['diagnostic_count'] ?? null) && $routeCollisionDiagnostics === ($routeCollision['source_reports']['wordpress_site_plan_diagnostics'] ?? null), 'Route collisions fail closed with one canonical plan diagnostic shared by status, metrics, and conversion-report projections.');
+$emptyIdentityFiles = array();
+$emptyIdentityPaths = array();
+for ($emptyPage = 0; $emptyPage < 16; ++$emptyPage) {
+    $emptyPath = 0 === $emptyPage ? 'website/index.html' : 'website/page-' . $emptyPage . '.html';
+    $emptyIdentityPaths[] = $emptyPath;
+    $emptyIdentityFiles[$emptyPath] = '';
+}
+$emptyIdentityFiles['parts/sidebar.html'] = '';
+$emptyIdentity = (new ArtifactCompiler())->compile(array('entrypoint' => 'website/index.html', 'files' => $emptyIdentityFiles))->toArray();
+$emptyIdentityDiagnostics = array_values(array_filter($emptyIdentity['diagnostics'], static fn(array $diagnostic): bool => 'wordpress_site_plan_not_self_contained' === ($diagnostic['code'] ?? null)));
+$emptyIdentityByPath = array();
+foreach ($emptyIdentityDiagnostics as $diagnostic) {
+    if (is_string($diagnostic['source_path'] ?? null) && '' !== $diagnostic['source_path']) {
+        $emptyIdentityByPath[$diagnostic['source_path']] = $diagnostic;
+    }
+}
+ConversionFindingContract::assertFindings($emptyIdentityDiagnostics, 'empty document identity diagnostics');
+$assert('failed' === ($emptyIdentity['status'] ?? null) && !isset($emptyIdentity['source_reports']['wordpress_site_plan']) && 17 === count($emptyIdentityDiagnostics) && 17 === count($emptyIdentityByPath) && $emptyIdentityDiagnostics === ($emptyIdentity['source_reports']['wordpress_site_plan_diagnostics'] ?? null), 'Empty compiled documents fail closed with one diagnostic per page and template part.');
+foreach ($emptyIdentityPaths as $emptyPath) {
+    $diagnostic = $emptyIdentityByPath[$emptyPath] ?? array();
+    $assert('empty_block_markup' === ($diagnostic['reason'] ?? null) && 'page' === ($diagnostic['document_kind'] ?? null) && 17 === ($diagnostic['document_count'] ?? null) && str_contains((string) ($diagnostic['message'] ?? ''), $emptyPath) && str_contains((string) ($diagnostic['message'] ?? ''), 'empty block markup') && 'site_plan_document' === ($diagnostic['pattern_family'] ?? null) && ArtifactCompiler::class === ($diagnostic['source'] ?? null) && '' === (string) ($emptyIdentity['source_reports']['compiled_site']['pages'][array_search($emptyPath, array_column($emptyIdentity['source_reports']['compiled_site']['pages'], 'source_path'), true)]['block_markup'] ?? 'missing'), 'Empty page diagnostics name the source path, empty-markup condition, and total document count.');
+}
+$emptyPartDiagnostic = $emptyIdentityByPath['parts/sidebar.html'] ?? array();
+$assert('empty_block_markup' === ($emptyPartDiagnostic['reason'] ?? null) && 'template_part' === ($emptyPartDiagnostic['document_kind'] ?? null) && str_contains((string) ($emptyPartDiagnostic['message'] ?? ''), 'parts/sidebar.html'), 'Empty template parts are named with the markup condition and document kind.');
+$mixedIdentity = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => '<main>Home</main>', 'about.html' => '', 'contact.html' => '')))->toArray();
+$mixedIdentityDiagnostics = array_values(array_filter($mixedIdentity['diagnostics'], static fn(array $diagnostic): bool => 'wordpress_site_plan_not_self_contained' === ($diagnostic['code'] ?? null)));
+$assert(array('about.html', 'contact.html') === array_column($mixedIdentityDiagnostics, 'source_path') && array('empty_block_markup', 'empty_block_markup') === array_column($mixedIdentityDiagnostics, 'reason') && 2 === ($mixedIdentityDiagnostics[0]['document_count'] ?? null), 'Identity diagnostics name every empty document and omit pages that compiled to block markup.');
+$unsafeIdentityInput = $first;
+$unsafeIdentityInput['source_reports']['compiled_site']['pages'][0]['source_path'] = '../escape.html';
+$unsafeIdentityInput['source_reports']['compiled_site']['pages'][1]['source_path'] = '/absolute.html';
+try {
+    (new WordPressSitePlan())->fromResult($unsafeIdentityInput);
+    $assert(false, 'Unsafe compiled identities fail closed before site-plan assembly.');
+} catch (DocumentIdentityException $unsafeIdentityException) {
+    $unsafeIdentityDiagnostics = $unsafeIdentityException->diagnostics();
+    ConversionFindingContract::assertFindings($unsafeIdentityDiagnostics, 'unsafe document identity diagnostics');
+    $assert(array('../escape.html', '/absolute.html') === array_column($unsafeIdentityDiagnostics, 'source_path') && array('unsafe_identity', 'unsafe_identity') === array_column($unsafeIdentityDiagnostics, 'reason') && 2 === ($unsafeIdentityDiagnostics[0]['document_count'] ?? null) && str_contains((string) ($unsafeIdentityDiagnostics[0]['message'] ?? ''), 'safe source path') && str_contains($unsafeIdentityException->getMessage(), '2 compiled site document'), 'Unsafe identities name every offending source path and the unsafe-identity condition.');
+}
+$emptyPlanInput = $first;
+foreach ($emptyPlanInput['source_reports']['compiled_site']['pages'] as &$emptyPlanPage) {
+    $emptyPlanPage['block_markup'] = '';
+}
+unset($emptyPlanPage);
+try {
+    (new WordPressSitePlan())->fromResult($emptyPlanInput);
+    $assert(false, 'Empty compiled markup fails closed during site-plan assembly.');
+} catch (DocumentIdentityException $emptyPlanException) {
+    $emptyPlanDiagnostics = $emptyPlanException->diagnostics();
+    $assert(count($emptyPlanInput['source_reports']['compiled_site']['pages']) === count($emptyPlanDiagnostics) && array('empty_block_markup') === array_values(array_unique(array_column($emptyPlanDiagnostics, 'reason'))) && $emptyPlanInput['source_reports']['compiled_site']['pages'][0]['source_path'] === ($emptyPlanDiagnostics[0]['source_path'] ?? null), 'Site-plan assembly reports every empty compiled page, not only the first.');
+}
+$boundedIdentityInput = $first;
+$boundedIdentityPages = array();
+for ($boundedPage = 0; $boundedPage < WordPressSitePlan::MAX_DOCUMENT_IDENTITY_DIAGNOSTICS + 10; ++$boundedPage) {
+    $boundedIdentityPages[] = array('source_path' => 'page-' . $boundedPage . '.html', 'block_markup' => '', 'slug' => 'page-' . $boundedPage, 'title' => 'Page ' . $boundedPage);
+}
+$boundedIdentityInput['source_reports']['compiled_site']['pages'] = $boundedIdentityPages;
+$boundedIdentityInput['source_reports']['compiled_site']['template_parts'] = array();
+try {
+    (new WordPressSitePlan())->fromResult($boundedIdentityInput);
+    $assert(false, 'Oversized empty-document sets fail closed with bounded diagnostics.');
+} catch (DocumentIdentityException $boundedIdentityException) {
+    $boundedIdentityDiagnostics = $boundedIdentityException->diagnostics();
+    $boundedRetained = array_values(array_filter($boundedIdentityDiagnostics, static fn(array $diagnostic): bool => 'truncated' !== ($diagnostic['reason'] ?? null)));
+    $boundedTruncation = array_values(array_filter($boundedIdentityDiagnostics, static fn(array $diagnostic): bool => 'truncated' === ($diagnostic['reason'] ?? null)));
+    $assert(WordPressSitePlan::MAX_DOCUMENT_IDENTITY_DIAGNOSTICS === count($boundedRetained) && 1 === count($boundedTruncation) && (WordPressSitePlan::MAX_DOCUMENT_IDENTITY_DIAGNOSTICS + 10) === ($boundedTruncation[0]['document_count'] ?? null) && 10 === ($boundedTruncation[0]['omitted_count'] ?? null) && !isset($boundedIdentityDiagnostics[0]['block_markup']), 'Identity diagnostics stay bounded by document count and omit compiled markup payloads.');
+}
 $encodedRoute = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => '<main>Home</main>', 'nested%2fabout.html' => '<main>Encoded</main>')))->toArray();
 $assert(isset($encodedRoute['source_reports']['wordpress_site_plan_diagnostics']), 'Encoded source paths fail closed before they can become ambiguous page routes.');
 $routeLinks = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => '<main>Home</main>', 'about.html' => '<main>About</main>', 'nested/about.html' => '<!doctype html><head><link rel="alternate" href="../about.html?from=nested#bio"></head><body><main><a href="../about.html?from=nested#bio">Root about</a><form action="../about.html?from=form#submit" method="post"><label>Email <input name="email" type="email"></label><button type="submit">Submit</button></form></main></body>', 'nested/deep/about.html' => '<main><a href="/nested/about.html?from=root#top">Nested about</a></main>')))->toArray();


### PR DESCRIPTION
## Problem

A real website import compiled every page to empty block markup, then failed with one unactionable line:

```
wordpress_site_plan_not_self_contained: Compiled site document lacks a safe identity or block markup.
```

That diagnostic named no document. It did not say which page, how many pages, or whether the markup was empty versus the path unsafe. Diagnosing it required a custom harness to dump every compiled page's markup length. Any future source with a conversion problem would pay that same cost.

The proven case: importing https://www.360chiro.co.uk/ produced a corrupted website artifact (every closing HTML tag destroyed by an upstream capture bug). Blocks Engine compiled all 16 pages to empty `block_markup` (`source_path` values such as `website/index.html`) and then threw inside `WordPressSitePlan::documents()` on the first bad document.

This PR does not fix the upstream capture corruption. It makes Blocks Engine explain itself.

## Fix

Empty or unidentifiable compiled documents are now a loud, per-document, bounded finding on the existing `wordpress_site_plan_*` diagnostic channel.

- **Compile time (root-cause signal):** after `compiled_site` is built, every page and non-entry-shell template part is inspected. Empty block markup or an unsafe source path becomes an error diagnostic immediately, while the empty result is first observable and before site-plan assembly is skipped.
- **Site-plan assembly (fail-closed gate):** `WordPressSitePlan::fromResult()` collects every failing document and throws `DocumentIdentityException` instead of stopping at the first one. Direct `fromResult()` callers get the same per-document evidence.
- Each diagnostic names `source_path`, states the failing condition (`empty_block_markup` vs `unsafe_identity`), and carries `document_count` so 16 empty pages is visibly different from 1.
- Evidence stays bounded: no markup payloads, paths capped at 256 characters, at most 50 per-document rows plus a truncation diagnostic.
- Findings classify through `ConversionFindingContract` as `pattern_family: site_plan_document` / `repair_bucket: restore_compiled_document_identity`.

## Validation

- `composer validate --strict`
- `composer test:canonical`
- `composer test:parity` (289 fixtures)
- `composer test:packaging`
- `php ../tests/contract/production-acceptance-matrix.php`

New contract coverage in `tests/contract/wordpress-site-plan.php` and `tests/contract/finding-contract.php` proves:

- 16 empty pages plus an empty template part emit 17 named diagnostics
- mixed good/empty pages name only the empty documents
- unsafe identities name every offending path and the unsafe-identity condition
- site-plan assembly reports every empty page, not only the first
- oversized sets stay bounded and omit markup payloads

## AI assistance disclosure

This change was implemented by grok-4.6 running in OpenCode, operated by @chubes4. The AI read the WordPress site plan and result-envelope contracts, traced `WordPressSitePlan::documents()` and `ArtifactCompiler` diagnostic projection, designed the compile-time plus fail-closed identity check, implemented the diagnostics and regression tests, and ran the php-transformer canonical, parity, packaging, and acceptance-matrix gates. Reviewed by a human before merge.