### PR TITLE
Extract form control metadata builder

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Elements/FormControlMetadataBuilder.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FormControlMetadataBuilder.php
@@ -1,0 +1,265 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
+use Closure;
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+
+/** Builds provider-neutral form and control metadata from source DOM. */
+final class FormControlMetadataBuilder
+{
+    /** @param Closure(DOMElement): string $elementSelector */
+    public function __construct(private readonly Closure $elementSelector)
+    {
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function controls(DOMElement $form): array
+    {
+        $controls = array();
+        $order = 0;
+        foreach ( FormControlClassifier::controlElements($form) as $control ) {
+            $metadata = $this->control($control);
+            if ( array() !== $metadata ) {
+                $metadata['order'] = $order;
+                $controls[] = $metadata;
+                ++$order;
+            }
+        }
+
+        return $controls;
+    }
+
+    /** @return array<string, mixed> */
+    public function form(DOMElement $form): array
+    {
+        $metadata = array_filter(array(
+            'id'           => $this->attr($form, 'id'),
+            'name'         => $this->attr($form, 'name'),
+            'class'        => $this->attr($form, 'class'),
+            'aria_label'   => $this->attr($form, 'aria-label'),
+            'action'       => $this->attr($form, 'action'),
+            'method'       => strtolower($this->attr($form, 'method')),
+            'enctype'      => $this->attr($form, 'enctype'),
+            'target'       => $this->attr($form, 'target'),
+            'autocomplete' => $this->attr($form, 'autocomplete'),
+        ), static fn (string $value): bool => '' !== $value);
+
+        if ( $form->hasAttribute('novalidate') ) {
+            $metadata['novalidate'] = true;
+        }
+
+        return $metadata;
+    }
+
+    /** @return array<string, mixed> */
+    public function control(DOMElement $control): array
+    {
+        if ( ! FormControlClassifier::isControlElement($control) ) {
+            return array();
+        }
+
+        $tagName = strtolower($control->tagName);
+        $type = FormControlClassifier::controlType($control);
+        if ( 'button' === $type && FormControlClassifier::isSubmitLikeControl($control) ) {
+            $type = 'submit';
+        }
+        $metadata = array_filter(array(
+            'tag'          => $tagName,
+            'selector'     => ($this->elementSelector)($control),
+            'id'           => $this->attr($control, 'id'),
+            'name'         => $this->attr($control, 'name'),
+            'type'         => $type,
+            'label'        => $this->label($control),
+            'placeholder'  => $this->attr($control, 'placeholder'),
+            'autocomplete' => $this->attr($control, 'autocomplete'),
+            'pattern'      => $this->attr($control, 'pattern'),
+            'min'          => $this->attr($control, 'min'),
+            'max'          => $this->attr($control, 'max'),
+            'step'         => $this->attr($control, 'step'),
+            'maxlength'    => $this->attr($control, 'maxlength'),
+            'rows'         => $this->attr($control, 'rows'),
+        ), static fn (string $value): bool => '' !== $value);
+
+        if ( in_array($type, array( 'button', 'reset', 'submit' ), true) ) {
+            $text = $this->buttonText($control);
+            if ( '' !== $text ) {
+                $metadata['text'] = $text;
+            }
+        }
+
+        if ( $control->hasAttribute('required') || 'true' === strtolower(trim($this->attr($control, 'aria-required'))) ) {
+            $metadata['required'] = true;
+        }
+        foreach ( array( 'disabled', 'readonly', 'checked', 'multiple' ) as $attribute ) {
+            if ( $control->hasAttribute($attribute) ) {
+                $metadata[$attribute] = true;
+            }
+        }
+
+        $value = $this->attr($control, 'value');
+        if ( '' !== $value && 'select' !== $tagName ) {
+            $metadata['value'] = $value;
+        }
+
+        if ( 'select' === $tagName ) {
+            $options = $this->options($control);
+            if ( array() !== $options ) {
+                $metadata['options'] = $options;
+            }
+        }
+
+        return $metadata;
+    }
+
+    public function label(DOMElement $control): string
+    {
+        $ariaLabel = trim($this->attr($control, 'aria-label'));
+        if ( '' !== $ariaLabel ) {
+            return $ariaLabel;
+        }
+
+        $id = $this->attr($control, 'id');
+        if ( '' !== $id && $control->ownerDocument instanceof DOMDocument ) {
+            foreach ( $control->ownerDocument->getElementsByTagName('label') as $label ) {
+                if ( $label instanceof DOMElement && $id === $this->attr($label, 'for') ) {
+                    return $this->labelText($label);
+                }
+            }
+        }
+
+        for ( $parent = $control->parentNode; $parent instanceof DOMElement; $parent = $parent->parentNode ) {
+            if ( 'label' === strtolower($parent->tagName) ) {
+                return $this->labelText($parent);
+            }
+        }
+
+        return '';
+    }
+
+    public function readableLabel(DOMElement $control): string
+    {
+        $label = $this->label($control);
+        if ( '' === $label ) {
+            $label = $this->attr($control, 'aria-label');
+        }
+        foreach ( array( 'placeholder', 'name' ) as $attribute ) {
+            if ( '' === $label ) {
+                $label = $this->attr($control, $attribute);
+            }
+        }
+
+        $type = FormControlClassifier::controlType($control);
+        if ( '' === $label && FormControlClassifier::isSubmitLikeControl($control) ) {
+            $label = trim(preg_replace('/\s+/', ' ', $control->textContent ?? '') ?? '');
+        }
+
+        return '' !== $label ? $label : ( 'select' === $type ? 'Select option' : ucfirst($type) );
+    }
+
+    /** Label associated by `for`; wrapping labels are handled with their control. */
+    public function associatedLabel(DOMElement $control): ?DOMElement
+    {
+        $id = $this->attr($control, 'id');
+        if ( '' === $id || ! $control->ownerDocument instanceof DOMDocument ) {
+            return null;
+        }
+
+        foreach ( $control->ownerDocument->getElementsByTagName('label') as $label ) {
+            if ( $label instanceof DOMElement && $id === $this->attr($label, 'for') ) {
+                return $label;
+            }
+        }
+
+        return null;
+    }
+
+    public function submitText(DOMElement $control, string $fallback): string
+    {
+        $text = trim(preg_replace('/\s+/', ' ', $control->textContent ?? '') ?? '');
+        if ( '' !== $text ) {
+            return $text;
+        }
+
+        $value = trim($this->attr($control, 'value'));
+        return '' !== $value ? $value : $fallback;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function options(DOMElement $select): array
+    {
+        $options = array();
+        foreach ( $select->getElementsByTagName('option') as $option ) {
+            if ( ! $option instanceof DOMElement ) {
+                continue;
+            }
+
+            $value = $this->attr($option, 'value');
+            $optionMetadata = array(
+                'label' => trim(preg_replace('/\s+/', ' ', $option->textContent ?? '') ?? ''),
+                // An explicit empty value is a placeholder semantic, not a missing value.
+                'value' => $option->hasAttribute('value') ? $value : trim($option->textContent ?? ''),
+            );
+            if ( $option->hasAttribute('selected') ) {
+                $optionMetadata['selected'] = true;
+            }
+            if ( $option->hasAttribute('disabled') ) {
+                $optionMetadata['disabled'] = true;
+            }
+            if ( '' === trim($value) && ( $option->hasAttribute('disabled') || $option->hasAttribute('selected') ) ) {
+                $optionMetadata['placeholder'] = true;
+            }
+
+            $options[] = $optionMetadata;
+        }
+
+        return $options;
+    }
+
+    public function labelText(DOMElement $label): string
+    {
+        return trim(preg_replace('/\s+/', ' ', $this->labelTextWithoutControls($label)) ?? '');
+    }
+
+    private function labelTextWithoutControls(DOMNode $node): string
+    {
+        if ( XML_TEXT_NODE === $node->nodeType ) {
+            return $node->textContent ?? '';
+        }
+        if ( $node instanceof DOMElement && 'true' === strtolower($this->attr($node, 'aria-hidden')) ) {
+            return '';
+        }
+        if ( $node instanceof DOMElement && FormControlClassifier::isControlElement($node) ) {
+            return '';
+        }
+
+        $text = '';
+        foreach ( $node->childNodes as $child ) {
+            $text .= $this->labelTextWithoutControls($child);
+        }
+
+        return $text;
+    }
+
+    private function buttonText(DOMElement $control): string
+    {
+        foreach ( array( 'aria-label', 'title' ) as $attribute ) {
+            $label = trim($this->attr($control, $attribute));
+            if ( '' !== $label ) {
+                return $label;
+            }
+        }
+
+        $text = trim(preg_replace('/\s+/', ' ', $control->textContent ?? '') ?? '');
+        return '' !== $text ? $text : trim($this->attr($control, 'value'));
+    }
+
+    private function attr(DOMElement $element, string $name): string
+    {
+        return $element->hasAttribute($name) ? $element->getAttribute($name) : '';
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Elements/SearchBlockConversionContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/SearchBlockConversionContext.php
@@ -14,8 +14,6 @@ final class SearchBlockConversionContext
      * @param Closure(DOMElement, string): string                                                    $attr
      * @param Closure(DOMElement): array<string, mixed>                                              $eventMetadata
      * @param Closure(DOMElement, DOMElement): bool                                                  $hasSearchFormSignal
-     * @param Closure(DOMElement): string                                                            $formControlLabel
-     * @param Closure(DOMElement): string                                                            $submitButtonText
      * @param Closure(DOMElement): array<string, mixed>                                              $presentationAttributes
      * @param Closure(DOMElement): array<string, string>                                             $presentationDeclarations
      * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
@@ -31,8 +29,6 @@ final class SearchBlockConversionContext
         private readonly Closure $attr,
         private readonly Closure $eventMetadata,
         private readonly Closure $hasSearchFormSignal,
-        private readonly Closure $formControlLabel,
-        private readonly Closure $submitButtonText,
         private readonly Closure $presentationAttributes,
         private readonly Closure $presentationDeclarations,
         private readonly Closure $createBlock,
@@ -60,16 +56,6 @@ final class SearchBlockConversionContext
     public function hasSearchFormSignal(DOMElement $form, DOMElement $input): bool
     {
         return ($this->hasSearchFormSignal)($form, $input);
-    }
-
-    public function formControlLabel(DOMElement $element): string
-    {
-        return ($this->formControlLabel)($element);
-    }
-
-    public function submitButtonText(DOMElement $element): string
-    {
-        return ($this->submitButtonText)($element);
     }
 
     /** @return array<string, mixed> */

--- a/php-transformer/src/HtmlToBlocks/Elements/SearchBlockConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/SearchBlockConverter.php
@@ -9,8 +9,10 @@ use DOMElement;
 /** Converts static search controls into native core/search blocks. */
 final class SearchBlockConverter
 {
-    public function __construct(private readonly SearchBlockConversionContext $context)
-    {
+    public function __construct(
+        private readonly SearchBlockConversionContext $context,
+        private readonly FormControlMetadataBuilder $formControlMetadataBuilder
+    ) {
     }
 
     /** @return array<string, mixed>|null */
@@ -57,7 +59,7 @@ final class SearchBlockConverter
             return null;
         }
 
-        $label = $this->context->formControlLabel($textInput);
+        $label = $this->formControlMetadataBuilder->label($textInput);
         $showLabel = '' !== $label;
         if ( '' === $label ) {
             $label = trim($this->context->attr($form, 'aria-label'));
@@ -73,7 +75,7 @@ final class SearchBlockConverter
         ));
         if ( $submitControl instanceof DOMElement ) {
             $attrs['buttonPosition'] = 'button-outside';
-            $attrs['buttonText'] = $this->context->submitButtonText($submitControl);
+            $attrs['buttonText'] = $this->formControlMetadataBuilder->submitText($submitControl, 'Search');
             if ( $this->isIconOnlySearchControl($submitControl) ) {
                 $attrs['buttonUseIcon'] = true;
             }
@@ -363,7 +365,7 @@ final class SearchBlockConverter
             return null;
         }
 
-        $label = $this->context->formControlLabel($searchInput);
+        $label = $this->formControlMetadataBuilder->label($searchInput);
         if ( '' === $label ) {
             $label = $this->context->attr($searchInput, 'aria-label');
         }

--- a/php-transformer/src/HtmlToBlocks/Elements/UnsupportedElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/UnsupportedElementContext.php
@@ -21,7 +21,6 @@ final class UnsupportedElementContext
      * @param Closure(DOMElement): array<string, mixed>   $eventMetadata
      * @param Closure(DOMElement): int                    $childElementCount
      * @param Closure(DOMElement): string                 $safeFallbackHtml
-     * @param Closure(DOMElement): array<string, mixed>   $formControlMetadata
      * @param Closure(array<string, mixed>): array<string, mixed> $buildFallbackDiagnostic
      */
     public function __construct(
@@ -34,7 +33,6 @@ final class UnsupportedElementContext
         private readonly Closure $eventMetadata,
         private readonly Closure $childElementCount,
         private readonly Closure $safeFallbackHtml,
-        private readonly Closure $formControlMetadata,
         private readonly Closure $buildFallbackDiagnostic
     ) {
     }
@@ -101,14 +99,6 @@ final class UnsupportedElementContext
     public function safeFallbackHtml(DOMElement $element): string
     {
         return ($this->safeFallbackHtml)($element);
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    public function formControlMetadata(DOMElement $element): array
-    {
-        return ($this->formControlMetadata)($element);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Elements/UnsupportedElementRecorder.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/UnsupportedElementRecorder.php
@@ -16,8 +16,10 @@ use DOMElement;
  */
 final class UnsupportedElementRecorder
 {
-    public function __construct(private readonly UnsupportedElementContext $context)
-    {
+    public function __construct(
+        private readonly UnsupportedElementContext $context,
+        private readonly FormControlMetadataBuilder $formControlMetadataBuilder
+    ) {
     }
 
     /**
@@ -63,7 +65,7 @@ final class UnsupportedElementRecorder
             'html'            => $this->context->safeFallbackHtml($element),
         );
 
-        $control = $this->context->formControlMetadata($element);
+        $control = $this->formControlMetadataBuilder->control($element);
         if ( array() !== $control ) {
             $fallback['control'] = $control;
         }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -33,6 +33,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolutionCon
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolver;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispatchContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispatcher;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormControlMetadataBuilder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TableElementContext;
@@ -261,6 +262,8 @@ final class HtmlTransformer
 
     private readonly RuntimeIslandAnalyzer $runtimeIslands;
 
+    private readonly FormControlMetadataBuilder $formControlMetadataBuilder;
+
     private readonly SearchBlockConverter $searchBlockConverter;
 
     private readonly ButtonLinkDispatcher $buttonLinkDispatcher;
@@ -400,10 +403,11 @@ final class HtmlTransformer
             $this->runtime
         );
         $this->runtimeIslands = new RuntimeIslandAnalyzer($this->createRuntimeIslandContext());
-        $this->searchBlockConverter = new SearchBlockConverter($this->createSearchBlockConversionContext());
+        $this->formControlMetadataBuilder = new FormControlMetadataBuilder(fn (DOMElement $element): string => $this->elementSelector($element));
+        $this->searchBlockConverter = new SearchBlockConverter($this->createSearchBlockConversionContext(), $this->formControlMetadataBuilder);
         $this->buttonLinkDispatcher = new ButtonLinkDispatcher($this->createButtonLinkDispatchContext());
         $this->tableConverter = new TableElementConverter($this->createTableElementContext());
-        $this->unsupportedRecorder = new UnsupportedElementRecorder($this->createUnsupportedElementContext());
+        $this->unsupportedRecorder = new UnsupportedElementRecorder($this->createUnsupportedElementContext(), $this->formControlMetadataBuilder);
     }
 
 
@@ -534,8 +538,6 @@ final class HtmlTransformer
             fn (DOMElement $element, string $name): string => $this->attr($element, $name),
             fn (DOMElement $element): array => $this->eventMetadata($element),
             fn (DOMElement $form, DOMElement $input): bool => $this->hasSearchFormSignal($form, $input),
-            fn (DOMElement $element): string => $this->formControlLabel($element),
-            fn (DOMElement $element): string => $this->submitButtonText($element),
             fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
             fn (DOMElement $element): array => $this->styleResolver->presentationDeclarations($element),
             fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
@@ -663,7 +665,6 @@ final class HtmlTransformer
             fn (DOMElement $element): array => $this->eventMetadata($element),
             fn (DOMElement $element): int => $this->childElementCount($element),
             fn (DOMElement $element): string => $this->safeFallbackHtml($element),
-            fn (DOMElement $element): array => $this->formControlMetadata($element),
             fn (array $fallback): array => FallbackDiagnostic::build($fallback, $this->transformationProvenance()->fallback())
         );
     }
@@ -8303,7 +8304,7 @@ if ( 'svg' === $tagName ) {
         }
 
         if ( 'form' === $tagName ) {
-            $metadata = $this->formMetadata($element);
+            $metadata = $this->formControlMetadataBuilder->form($element);
             $candidates[] = $this->interactionCandidate($element, 'form', 'submit', (string) ($metadata['action'] ?? ''), array_filter(array('form_element', (string) ($metadata['method'] ?? ''))), 'high', 'form_submission');
         }
 

--- a/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
@@ -78,60 +78,15 @@ trait FormDispatchTrait
      */
     private function recordFormRuntimeIsland(DOMElement $element, ?array $readableFormBlock): void
     {
-        $controls = $this->formControls($element);
+        $controls = $this->formControlMetadataBuilder->controls($element);
         $this->runtimeIslands->recordRuntimeIsland($element, 'form', 'form_requires_runtime', 'server_or_client_form_handler', array(
-            'form'             => $this->formMetadata($element),
+            'form'             => $this->formControlMetadataBuilder->form($element),
             'controls'         => $controls,
             'control_count'    => count($controls),
             'events'           => $this->eventMetadata($element),
             'readable_blocks'  => null !== $readableFormBlock ? array( $readableFormBlock ) : array(),
             'required_scripts' => $this->requiredScriptsForElement($element),
         ));
-    }
-
-    private function formControls(DOMElement $form): array
-    {
-        $controls = array();
-        $order = 0;
-        foreach ( FormControlClassifier::controlElements($form) as $control ) {
-            $metadata = $this->formControlMetadata($control);
-            if ( array() !== $metadata ) {
-                $metadata['order'] = $order;
-                $controls[] = $metadata;
-                ++$order;
-            }
-        }
-
-        return $controls;
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function formMetadata(DOMElement $form): array
-    {
-        $metadata = array_filter(
-            array(
-                'id'         => $this->attr($form, 'id'),
-                'name'       => $this->attr($form, 'name'),
-                'class'      => $this->attr($form, 'class'),
-                'aria_label' => $this->attr($form, 'aria-label'),
-                'action'     => $this->attr($form, 'action'),
-                'method'     => strtolower($this->attr($form, 'method')),
-                'enctype'    => $this->attr($form, 'enctype'),
-                'target'     => $this->attr($form, 'target'),
-                'autocomplete' => $this->attr($form, 'autocomplete'),
-            ),
-            static fn (string $value): bool => '' !== $value
-        );
-
-        foreach ( array( 'novalidate' ) as $attribute ) {
-            if ( $form->hasAttribute($attribute) ) {
-                $metadata[$attribute] = true;
-            }
-        }
-
-        return $metadata;
     }
 
     /**
@@ -152,14 +107,14 @@ trait FormDispatchTrait
 
             if ( FormControlClassifier::isSubmitLikeControl($control) ) {
                 $buttonBlocks[] = $this->createBlock('core/button', array_merge($this->styleResolver->presentationAttributes($control), array(
-                    'text' => $this->runtime->escapeHtml($this->readableSubmitText($control)),
+                    'text' => $this->runtime->escapeHtml($this->formControlMetadataBuilder->submitText($control, 'Submit')),
                 )), array(), $control);
                 continue;
             }
 
             if ( $this->runtimeIslands->isRuntimeDomTarget($control) ) {
                 $this->runtimeIslands->recordRuntimeIsland($control, 'control', 'runtime_dom_target', 'client_script_execution', array(
-                    'control'          => $this->formControlMetadata($control),
+                    'control'          => $this->formControlMetadataBuilder->control($control),
                     'events'           => $this->eventMetadata($control),
                     'required_scripts' => $this->requiredScriptsForElement($control),
                 ));
@@ -171,7 +126,7 @@ trait FormDispatchTrait
             }
 
             $fieldBlocks = array();
-            $associatedLabel = $this->associatedLabelElement($control);
+            $associatedLabel = $this->formControlMetadataBuilder->associatedLabel($control);
             if ( $associatedLabel instanceof DOMElement && AuthoredInputBlockGenerator::NAME === ($readableControlBlock['blockName'] ?? '') ) {
                 $labelBlock = $this->readableFormControlBlockFromElement($associatedLabel);
                 if ( null !== $labelBlock ) {
@@ -286,7 +241,7 @@ trait FormDispatchTrait
                 return array() !== $blocks ? $this->createBlock('core/group', $this->styleResolver->presentationAttributes($element), $blocks, $element) : null;
             }
 
-            $label = $this->normalizedControlLabelText($element);
+            $label = $this->formControlMetadataBuilder->labelText($element);
             if ( '' === $label ) {
                 $label = trim(preg_replace('/\s+/', ' ', $element->textContent ?? '') ?? '');
             }
@@ -299,7 +254,7 @@ trait FormDispatchTrait
         }
 
         if ( 'input' === $tagName && 'search' === FormControlClassifier::controlType($element) ) {
-            $label = $this->formControlLabel($element);
+            $label = $this->formControlMetadataBuilder->label($element);
             if ( '' === $label ) {
                 $label = $this->attr($element, 'aria-label');
             }
@@ -340,7 +295,7 @@ trait FormDispatchTrait
     private function recordRuntimeControlIsland(DOMElement $element): void
     {
         $this->runtimeIslands->recordRuntimeIsland($element, 'control', 'runtime_dom_target', 'client_script_execution', array(
-            'control'          => $this->formControlMetadata($element),
+            'control'          => $this->formControlMetadataBuilder->control($element),
             'events'           => $this->eventMetadata($element),
             'required_scripts' => $this->requiredScriptsForElement($element),
         ));
@@ -368,7 +323,7 @@ trait FormDispatchTrait
         }
 
         $this->runtimeIslands->recordRuntimeIsland($element, 'control', 'form_control_requires_runtime', 'client_form_control_runtime', array(
-            'control'          => $this->formControlMetadata($element),
+            'control'          => $this->formControlMetadataBuilder->control($element),
             'events'           => $this->eventMetadata($element),
             'required_scripts' => $this->requiredScriptsForElement($element),
         ));
@@ -381,9 +336,9 @@ trait FormDispatchTrait
      */
     private function readableSelectBlockFromElement(DOMElement $select): ?array
     {
-        $label = $this->readableFormControlLabel($select);
+        $label = $this->formControlMetadataBuilder->readableLabel($select);
         $this->registerFormControlEcho($label);
-        $options = $this->selectOptions($select);
+        $options = $this->formControlMetadataBuilder->options($select);
         if ( array() === $options ) {
             return null;
         }
@@ -586,7 +541,7 @@ trait FormDispatchTrait
      */
     private function formFallbackFinding(DOMElement $element, ?array $readableFormBlock, ?array $bindingBlock = null): array
     {
-        $controls = $this->formControls($element);
+        $controls = $this->formControlMetadataBuilder->controls($element);
         $controlTopology = (new FormControlTopologyBuilder())->build($element);
         $layoutGraph = (new FormLayoutGraphBuilder())->build($element, $this->authorStyles()->stylesheetAssets(), $this->sourceStyles()->formLayoutCss());
         $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($element));
@@ -604,7 +559,7 @@ trait FormDispatchTrait
             'tag'             => strtolower($element->tagName),
             'selector'        => $this->elementSelector($element),
             'attributes'      => $this->htmlAttributes($element),
-            'form'            => $this->formMetadata($element),
+            'form'            => $this->formControlMetadataBuilder->form($element),
             'success_panel'   => $this->formSuccessPanelMetadata($element),
             'context'         => $this->sourceContext($element),
             'classification'  => $this->fallbackEmitter()->classifyFallbackSubtree($element),
@@ -762,7 +717,7 @@ trait FormDispatchTrait
         foreach ( FormControlClassifier::controlElements($element) as $control ) {
             if ( FormControlClassifier::isPseudoFormDataEntryControl($control) && ! $this->hasStandaloneSearchSignal($element, $control) ) {
                 $hasDataEntry = true;
-                $hasFieldLabel = $hasFieldLabel || '' !== trim($this->formControlLabel($control)) || '' !== trim($this->attr($control, 'aria-label')) || '' !== trim($this->attr($control, 'name'));
+                $hasFieldLabel = $hasFieldLabel || '' !== trim($this->formControlMetadataBuilder->label($control)) || '' !== trim($this->attr($control, 'aria-label')) || '' !== trim($this->attr($control, 'name'));
             } elseif ( 'button' === strtolower($control->tagName) || ( 'input' === strtolower($control->tagName) && ! in_array(FormControlClassifier::controlType($control), array( 'reset', 'button' ), true) ) ) {
                 $hasActionControl = true;
                 $hasSubmit = $hasSubmit || FormControlClassifier::isPseudoFormSubmitControl($control);
@@ -816,7 +771,7 @@ trait FormDispatchTrait
 
     private function readableFormControlText(DOMElement $control): string
     {
-        $label = $this->readableFormControlLabel($control);
+        $label = $this->formControlMetadataBuilder->readableLabel($control);
 
         $type = FormControlClassifier::controlType($control);
         if ( '' === $label ) {
@@ -827,7 +782,7 @@ trait FormDispatchTrait
         if ( 'select' === strtolower($control->tagName) ) {
             $options = array();
             $selected = array();
-            foreach ( $this->selectOptions($control) as $option ) {
+            foreach ( $this->formControlMetadataBuilder->options($control) as $option ) {
                 $optionLabel = (string) ($option['label'] ?? '');
                 if ( '' === $optionLabel ) {
                     continue;
@@ -895,61 +850,6 @@ trait FormDispatchTrait
         $this->transformationEvidence()->recordFormControlEcho($text);
     }
 
-    private function readableFormControlLabel(DOMElement $control): string
-    {
-        $label = $this->formControlLabel($control);
-        if ( '' === $label ) {
-            $label = $this->attr($control, 'aria-label');
-        }
-        if ( '' === $label ) {
-            $label = $this->attr($control, 'placeholder');
-        }
-        if ( '' === $label ) {
-            $label = $this->attr($control, 'name');
-        }
-
-        $type = FormControlClassifier::controlType($control);
-        if ( '' === $label && FormControlClassifier::isSubmitLikeControl($control) ) {
-            $label = trim(preg_replace('/\s+/', ' ', $control->textContent ?? '') ?? '');
-        }
-        if ( '' === $label ) {
-            return 'select' === $type ? 'Select option' : ucfirst($type);
-        }
-
-        return $label;
-    }
-
-    /**
-     * Label associated by `for`, not a wrapping parent label. Wrapping labels
-     * are converted with the control they contain.
-     */
-    private function associatedLabelElement(DOMElement $control): ?DOMElement
-    {
-        $id = $this->attr($control, 'id');
-        if ( '' === $id || ! $control->ownerDocument instanceof DOMDocument ) {
-            return null;
-        }
-
-        foreach ( $control->ownerDocument->getElementsByTagName('label') as $label ) {
-            if ( $label instanceof DOMElement && $id === $this->attr($label, 'for') ) {
-                return $label;
-            }
-        }
-
-        return null;
-    }
-
-    private function readableSubmitText(DOMElement $control): string
-    {
-        $text = trim(preg_replace('/\s+/', ' ', $control->textContent ?? '') ?? '');
-        if ( '' !== $text ) {
-            return $text;
-        }
-
-        $value = trim($this->attr($control, 'value'));
-        return '' !== $value ? $value : 'Submit';
-    }
-
     private function hasSearchFormSignal(DOMElement $form, DOMElement $input): bool
     {
         if ( 'search' === FormControlClassifier::controlType($input) || 'search' === strtolower(trim($this->attr($form, 'role'))) ) {
@@ -989,189 +889,6 @@ trait FormDispatchTrait
         )));
 
         return str_contains($haystack, 'search');
-    }
-
-    private function submitButtonText(DOMElement $control): string
-    {
-        $text = trim(preg_replace('/\s+/', ' ', $control->textContent ?? '') ?? '');
-        if ( '' !== $text ) {
-            return $text;
-        }
-
-        $value = trim($this->attr($control, 'value'));
-        return '' !== $value ? $value : 'Search';
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function formControlMetadata(DOMElement $control): array
-    {
-        if ( ! FormControlClassifier::isControlElement($control) ) {
-            return array();
-        }
-
-        $tagName = strtolower($control->tagName);
-        $type = FormControlClassifier::controlType($control);
-        if ( 'button' === $type && FormControlClassifier::isSubmitLikeControl($control) ) {
-            $type = 'submit';
-        }
-        $metadata = array_filter(array(
-            'tag'         => $tagName,
-            'selector'    => $this->elementSelector($control),
-            'id'          => $this->attr($control, 'id'),
-            'name'        => $this->attr($control, 'name'),
-            'type'        => $type,
-            'label'       => $this->formControlLabel($control),
-            'placeholder' => $this->attr($control, 'placeholder'),
-            'autocomplete' => $this->attr($control, 'autocomplete'),
-            'pattern'     => $this->attr($control, 'pattern'),
-            'min'         => $this->attr($control, 'min'),
-            'max'         => $this->attr($control, 'max'),
-            'step'        => $this->attr($control, 'step'),
-            'maxlength'   => $this->attr($control, 'maxlength'),
-            'rows'        => $this->attr($control, 'rows'),
-        ), static fn (string $value): bool => '' !== $value);
-
-        if ( in_array($type, array( 'button', 'reset', 'submit' ), true) ) {
-            $text = $this->formButtonText($control);
-            if ( '' !== $text ) {
-                $metadata['text'] = $text;
-            }
-        }
-
-        if ( $control->hasAttribute('required') || 'true' === strtolower(trim($this->attr($control, 'aria-required'))) ) {
-            $metadata['required'] = true;
-        }
-        if ( $control->hasAttribute('disabled') ) {
-            $metadata['disabled'] = true;
-        }
-        if ( $control->hasAttribute('readonly') ) {
-            $metadata['readonly'] = true;
-        }
-        if ( $control->hasAttribute('checked') ) {
-            $metadata['checked'] = true;
-        }
-        if ( $control->hasAttribute('multiple') ) {
-            $metadata['multiple'] = true;
-        }
-
-        $value = $this->attr($control, 'value');
-        if ( '' !== $value && 'select' !== $tagName ) {
-            $metadata['value'] = $value;
-        }
-
-        if ( 'select' === $tagName ) {
-            $options = $this->selectOptions($control);
-            if ( array() !== $options ) {
-                $metadata['options'] = $options;
-            }
-        }
-
-        return $metadata;
-    }
-
-    private function formControlLabel(DOMElement $control): string
-    {
-        $ariaLabel = trim($this->attr($control, 'aria-label'));
-        if ( '' !== $ariaLabel ) {
-            return $ariaLabel;
-        }
-
-        $id = $this->attr($control, 'id');
-        if ( '' !== $id && $control->ownerDocument instanceof DOMDocument ) {
-            foreach ( $control->ownerDocument->getElementsByTagName('label') as $label ) {
-                if ( $label instanceof DOMElement && $id === $this->attr($label, 'for') ) {
-                    return $this->normalizedControlLabelText($label);
-                }
-            }
-        }
-
-        for ( $parent = $control->parentNode; $parent instanceof DOMElement; $parent = $parent->parentNode ) {
-            if ( 'label' === strtolower($parent->tagName) ) {
-                return $this->normalizedControlLabelText($parent);
-            }
-        }
-
-        return '';
-    }
-
-    private function normalizedControlLabelText(DOMElement $label): string
-    {
-        return trim(preg_replace('/\s+/', ' ', $this->labelTextWithoutControls($label)) ?? '');
-    }
-
-    private function labelTextWithoutControls(DOMNode $node): string
-    {
-        if ( XML_TEXT_NODE === $node->nodeType ) {
-            return $node->textContent ?? '';
-        }
-
-        if ( $node instanceof DOMElement && 'true' === strtolower($this->attr($node, 'aria-hidden')) ) {
-            return '';
-        }
-
-        if ( $node instanceof DOMElement && FormControlClassifier::isControlElement($node) ) {
-            return '';
-        }
-
-        $text = '';
-        foreach ( $node->childNodes as $child ) {
-            $text .= $this->labelTextWithoutControls($child);
-        }
-
-        return $text;
-    }
-
-    private function formButtonText(DOMElement $control): string
-    {
-        foreach ( array( 'aria-label', 'title' ) as $attribute ) {
-            $label = trim($this->attr($control, $attribute));
-            if ( '' !== $label ) {
-                return $label;
-            }
-        }
-
-        $text = trim(preg_replace('/\s+/', ' ', $control->textContent ?? '') ?? '');
-        if ( '' !== $text ) {
-            return $text;
-        }
-
-        return trim($this->attr($control, 'value'));
-    }
-
-    /**
-     * @return array<int, array<string, mixed>>
-     */
-    private function selectOptions(DOMElement $select): array
-    {
-        $options = array();
-        foreach ( $select->getElementsByTagName('option') as $option ) {
-            if ( ! $option instanceof DOMElement ) {
-                continue;
-            }
-
-            $value = $this->attr($option, 'value');
-            $optionMetadata = array(
-                'label' => trim(preg_replace('/\s+/', ' ', $option->textContent ?? '') ?? ''),
-                // An explicit empty value is a select placeholder semantic, not
-                // a missing value to replace with the visible option label.
-                'value' => $option->hasAttribute('value') ? $value : trim($option->textContent ?? ''),
-            );
-            if ( $option->hasAttribute('selected') ) {
-                $optionMetadata['selected'] = true;
-            }
-            if ( $option->hasAttribute('disabled') ) {
-                $optionMetadata['disabled'] = true;
-            }
-            if ( '' === trim($this->attr($option, 'value')) && ( $option->hasAttribute('disabled') || $option->hasAttribute('selected') ) ) {
-                $optionMetadata['placeholder'] = true;
-            }
-
-            $options[] = $optionMetadata;
-        }
-
-        return $options;
     }
 
 }

--- a/php-transformer/tests/unit/unsupported-element-recorder.php
+++ b/php-transformer/tests/unit/unsupported-element-recorder.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 require __DIR__ . '/../../vendor/autoload.php';
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormControlMetadataBuilder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\UnsupportedElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\UnsupportedElementRecorder;
 
@@ -45,11 +46,11 @@ $makeRecorder = static function (array $overrides = array()): UnsupportedElement
         'events'          => static fn (DOMElement $e): array => array(),
         'childCount'      => static fn (DOMElement $e): int => $e->childNodes->length,
         'safeHtml'        => static fn (DOMElement $e): string => '<safe/>',
-        'formControl'     => static fn (DOMElement $e): array => array(),
         'buildDiagnostic' => static fn (array $f): array => $f + array('built' => true),
     );
     $c = array_merge($defaults, $overrides);
 
+    $metadataBuilder = new FormControlMetadataBuilder($c['selector']);
     return new UnsupportedElementRecorder(new UnsupportedElementContext(
         $c['maybeGenerate'],
         $c['generatedBlock'],
@@ -60,9 +61,8 @@ $makeRecorder = static function (array $overrides = array()): UnsupportedElement
         $c['events'],
         $c['childCount'],
         $c['safeHtml'],
-        $c['formControl'],
         $c['buildDiagnostic']
-    ));
+    ), $metadataBuilder);
 };
 
 // A high-confidence custom block short-circuits the fallback entirely: a block
@@ -93,9 +93,8 @@ $assert(! array_key_exists('control', $row), 'non-control-fallback-omits-control
 
 // Form-control metadata is attached only when the element actually has it.
 $fallbacks = array();
-$makeRecorder(array('formControl' => static fn (DOMElement $e): array => array('role' => 'textbox')))
-    ->record($elementFrom('<x-input></x-input>'), 'x-input', $fallbacks);
-$assert(array('role' => 'textbox') === ($fallbacks[0]['control'] ?? null), 'control-metadata-attached-when-present');
+$makeRecorder()->record($elementFrom('<input aria-label="Email">'), 'input', $fallbacks);
+$assert(array('tag' => 'input', 'selector' => 'input.sel', 'type' => 'text', 'label' => 'Email') === ($fallbacks[0]['control'] ?? null), 'control-metadata-attached-when-present');
 
 if ($failures) {
     fwrite(STDERR, implode("\n", $failures) . "\n");


### PR DESCRIPTION
## Summary

- move form and control metadata, label resolution, submit text, associated-label lookup, and select-option extraction into a stateless `FormControlMetadataBuilder`
- inject the builder into search conversion and unsupported-element recording instead of routing metadata through transformer context closures
- reduce `FormDispatchTrait` to form conversion orchestration while preserving centralized form-control and submit classification

Part of #242.

## Verification

- `composer test`
- PHP transformer parity: 289 fixtures passed
- fresh CSS-attached corpus comparison against current `origin/trunk`: 383 documents, 87 fixtures, 82 fixtures with CSS, 0 throws, byte-identical records

## AI assistance

OpenAI GPT-5.6 Sol was used through OpenCode to identify the metadata boundary, extract and rewire the collaborator, preserve concurrent trunk behavior during rebase, and run the focused, contract, package-install, and corpus verification workflows. The implementation and evidence were reviewed and orchestrated by Chris Huber.