### PR TITLE
Extract pseudo-form analyzer

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -151,6 +151,7 @@
             "php tests/unit/rich-text-element-converter.php",
             "php tests/unit/table-element-converter.php",
             "php tests/unit/unsupported-element-recorder.php",
+            "php tests/unit/pseudo-form-analyzer.php",
             "php tests/unit/runtime-island-analyzer.php",
             "php tests/unit/button-link-dispatcher.php"
     ],

--- a/php-transformer/src/HtmlToBlocks/Elements/PseudoFormAnalyzer.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/PseudoFormAnalyzer.php
@@ -1,0 +1,136 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
+use Closure;
+use DOMElement;
+
+/** Identifies bounded non-form containers that behave as forms. */
+final class PseudoFormAnalyzer
+{
+    /** @param Closure(DOMElement): string $elementSelector */
+    public function __construct(
+        private readonly FormControlMetadataBuilder $formControlMetadataBuilder,
+        private readonly Closure $elementSelector
+    ) {
+    }
+
+    public function isPseudoForm(DOMElement $element): bool
+    {
+        if ( 'form' === strtolower($element->tagName) ) {
+            return false;
+        }
+
+        // A real form owns its entire subtree and must emit the finding once.
+        if ( FormControlClassifier::hasFormAncestor($element) || 0 < $element->getElementsByTagName('form')->length ) {
+            return false;
+        }
+
+        if ( $this->containsUnrelatedLandmark($element) || ! $this->pairsDataEntryWithSubmit($element) ) {
+            return false;
+        }
+
+        // Select the tightest coherent container rather than a surrounding shell.
+        foreach ( $element->getElementsByTagName('*') as $descendant ) {
+            if ( $descendant instanceof DOMElement
+                && ! FormControlClassifier::isControlElement($descendant)
+                && $this->pairsDataEntryWithSubmit($descendant) ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /** @return array<string, mixed> */
+    public function boundaryMetadata(DOMElement $element): array
+    {
+        $rejectedAncestors = array();
+        for ( $ancestor = $element->parentNode; $ancestor instanceof DOMElement && count($rejectedAncestors) < 4; $ancestor = $ancestor->parentNode ) {
+            if ( ! $this->containsUnrelatedLandmark($ancestor) && ! $this->pairsDataEntryWithSubmit($ancestor) ) {
+                continue;
+            }
+            $rejectedAncestors[] = array(
+                'selector' => ($this->elementSelector)($ancestor),
+                'reason'   => $this->containsUnrelatedLandmark($ancestor) ? 'contains_unrelated_landmark' : 'contains_nested_coherent_form',
+            );
+        }
+
+        return array(
+            'schema'             => 'generic/form-boundary/v1',
+            'selector'           => ($this->elementSelector)($element),
+            'selection_basis'    => array( 'local_controls', 'associated_label', 'submit_semantics' ),
+            'rejected_ancestors' => $rejectedAncestors,
+        );
+    }
+
+    public function hasStandaloneSearchSignal(DOMElement $element, DOMElement $input): bool
+    {
+        if ( 'search' === FormControlClassifier::controlType($input) || 'search' === strtolower(trim($this->attr($element, 'role'))) ) {
+            return true;
+        }
+
+        $haystack = strtolower(implode(' ', array(
+            $this->attr($element, 'aria-label'),
+            $this->attr($element, 'id'),
+            $this->attr($element, 'class'),
+            $this->attr($input, 'aria-label'),
+            $this->attr($input, 'id'),
+            $this->attr($input, 'class'),
+            $this->attr($input, 'name'),
+            $this->attr($input, 'placeholder'),
+        )));
+
+        return str_contains($haystack, 'search');
+    }
+
+    private function pairsDataEntryWithSubmit(DOMElement $element): bool
+    {
+        $hasDataEntry = false;
+        $hasFieldLabel = false;
+        $hasSubmit = false;
+        $hasActionControl = false;
+        $hasContainerAction = '' !== trim($this->attr($element, 'action')) || '' !== trim($this->attr($element, 'method')) || '' !== trim($this->attr($element, 'data-action'));
+
+        foreach ( FormControlClassifier::controlElements($element) as $control ) {
+            if ( FormControlClassifier::isPseudoFormDataEntryControl($control) && ! $this->hasStandaloneSearchSignal($element, $control) ) {
+                $hasDataEntry = true;
+                $hasFieldLabel = $hasFieldLabel || '' !== trim($this->formControlMetadataBuilder->label($control)) || '' !== trim($this->attr($control, 'aria-label')) || '' !== trim($this->attr($control, 'name'));
+            } elseif ( 'button' === strtolower($control->tagName) || ( 'input' === strtolower($control->tagName) && ! in_array(FormControlClassifier::controlType($control), array( 'reset', 'button' ), true) ) ) {
+                $hasActionControl = true;
+                $hasSubmit = $hasSubmit || FormControlClassifier::isPseudoFormSubmitControl($control);
+            }
+
+            if ( $hasDataEntry && $hasFieldLabel && ( $hasSubmit || ( $hasContainerAction && $hasActionControl ) ) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function containsUnrelatedLandmark(DOMElement $element): bool
+    {
+        foreach ( $element->getElementsByTagName('*') as $descendant ) {
+            if ( ! $descendant instanceof DOMElement ) {
+                continue;
+            }
+
+            $tagName = strtolower($descendant->tagName);
+            $role = strtolower($this->attr($descendant, 'role'));
+            if ( in_array($tagName, array( 'article', 'nav', 'header', 'footer', 'main' ), true)
+                || in_array($role, array( 'article', 'navigation', 'banner', 'contentinfo', 'main' ), true) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function attr(DOMElement $element, string $name): string
+    {
+        return $element->hasAttribute($name) ? $element->getAttribute($name) : '';
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Elements/RuntimeIslandAnalyzer.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/RuntimeIslandAnalyzer.php
@@ -43,8 +43,10 @@ final class RuntimeIslandAnalyzer
         'simulator', 'stage', 'studio', 'terminal', 'viewport', 'workspace', 'world',
     );
 
-    public function __construct(private readonly RuntimeIslandContext $context)
-    {
+    public function __construct(
+        private readonly RuntimeIslandContext $context,
+        private readonly PseudoFormAnalyzer $pseudoFormAnalyzer
+    ) {
     }
 
     /**
@@ -248,7 +250,7 @@ final class RuntimeIslandAnalyzer
         // pseudo-form, not an editor surface. Only a non-control target inside
         // that same candidate upgrades it to a runtime workspace.
         for ( $ancestor = $textarea->parentNode; $ancestor instanceof DOMElement; $ancestor = $ancestor->parentNode ) {
-            if ( $this->context->isDivBasedPseudoForm($ancestor) ) {
+            if ( $this->pseudoFormAnalyzer->isPseudoForm($ancestor) ) {
                 return $ancestor === $root && $this->hasNonFormControlRuntimeTarget($ancestor);
             }
             if ( $ancestor === $root ) {

--- a/php-transformer/src/HtmlToBlocks/Elements/RuntimeIslandContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/RuntimeIslandContext.php
@@ -30,7 +30,6 @@ final class RuntimeIslandContext
      * @param Closure(DOMElement): array<int, array<string, mixed>>           $requiredScriptsForElement
      * @param Closure(string): ?DOMElement                                    $preservedHtmlRootElement
      * @param Closure(DOMElement): bool                                       $hasWorkspaceSurface
-     * @param Closure(DOMElement): bool                                       $isDivBasedPseudoForm
      * @param Closure(string): bool                                           $isInlineContentElement
      * @param Closure(string): bool                                           $isPresentationalAnimationSelector
      * @param Closure(array<int, array<string, mixed>>): array<int, array<string, mixed>> $dedupeArrayRows
@@ -46,7 +45,6 @@ final class RuntimeIslandContext
         private readonly Closure $requiredScriptsForElement,
         private readonly Closure $preservedHtmlRootElement,
         private readonly Closure $hasWorkspaceSurface,
-        private readonly Closure $isDivBasedPseudoForm,
         private readonly Closure $isInlineContentElement,
         private readonly Closure $isPresentationalAnimationSelector,
         private readonly Closure $dedupeArrayRows
@@ -110,11 +108,6 @@ final class RuntimeIslandContext
     public function hasWorkspaceSurface(DOMElement $element): bool
     {
         return ($this->hasWorkspaceSurface)($element);
-    }
-
-    public function isDivBasedPseudoForm(DOMElement $element): bool
-    {
-        return ($this->isDivBasedPseudoForm)($element);
     }
 
     public function isInlineContentElement(string $tagName): bool

--- a/php-transformer/src/HtmlToBlocks/Elements/SearchBlockConversionContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/SearchBlockConversionContext.php
@@ -22,7 +22,6 @@ final class SearchBlockConversionContext
      * @param Closure(): GeneratedSupportStylesheetState                                             $generatedSupportStyles
      * @param Closure(DOMElement): int                                                               $childElementCount
      * @param Closure(DOMElement): bool                                                              $isRuntimeDomTarget
-     * @param Closure(DOMElement, DOMElement): bool                                                  $hasStandaloneSearchSignal
      * @param Closure(DOMElement): array<string, mixed>                                              $htmlPreservationBlock
      */
     public function __construct(
@@ -37,7 +36,6 @@ final class SearchBlockConversionContext
         private readonly Closure $generatedSupportStyles,
         private readonly Closure $childElementCount,
         private readonly Closure $isRuntimeDomTarget,
-        private readonly Closure $hasStandaloneSearchSignal,
         private readonly Closure $htmlPreservationBlock
     ) {
     }
@@ -103,11 +101,6 @@ final class SearchBlockConversionContext
     public function isRuntimeDomTarget(DOMElement $element): bool
     {
         return ($this->isRuntimeDomTarget)($element);
-    }
-
-    public function hasStandaloneSearchSignal(DOMElement $element, DOMElement $input): bool
-    {
-        return ($this->hasStandaloneSearchSignal)($element, $input);
     }
 
     /** @return array<string, mixed> */

--- a/php-transformer/src/HtmlToBlocks/Elements/SearchBlockConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/SearchBlockConverter.php
@@ -11,7 +11,8 @@ final class SearchBlockConverter
 {
     public function __construct(
         private readonly SearchBlockConversionContext $context,
-        private readonly FormControlMetadataBuilder $formControlMetadataBuilder
+        private readonly FormControlMetadataBuilder $formControlMetadataBuilder,
+        private readonly PseudoFormAnalyzer $pseudoFormAnalyzer
     ) {
     }
 
@@ -361,7 +362,7 @@ final class SearchBlockConverter
         }
 
         $searchInput = $inputs[0];
-        if ( ! $this->context->hasStandaloneSearchSignal($element, $searchInput) ) {
+        if ( ! $this->pseudoFormAnalyzer->hasStandaloneSearchSignal($element, $searchInput) ) {
             return null;
         }
 

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -34,6 +34,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolver;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispatchContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispatcher;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormControlMetadataBuilder;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\PseudoFormAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TableElementContext;
@@ -264,6 +265,8 @@ final class HtmlTransformer
 
     private readonly FormControlMetadataBuilder $formControlMetadataBuilder;
 
+    private readonly PseudoFormAnalyzer $pseudoFormAnalyzer;
+
     private readonly SearchBlockConverter $searchBlockConverter;
 
     private readonly ButtonLinkDispatcher $buttonLinkDispatcher;
@@ -402,9 +405,10 @@ final class HtmlTransformer
             $this->styleResolver,
             $this->runtime
         );
-        $this->runtimeIslands = new RuntimeIslandAnalyzer($this->createRuntimeIslandContext());
         $this->formControlMetadataBuilder = new FormControlMetadataBuilder(fn (DOMElement $element): string => $this->elementSelector($element));
-        $this->searchBlockConverter = new SearchBlockConverter($this->createSearchBlockConversionContext(), $this->formControlMetadataBuilder);
+        $this->pseudoFormAnalyzer = new PseudoFormAnalyzer($this->formControlMetadataBuilder, fn (DOMElement $element): string => $this->elementSelector($element));
+        $this->runtimeIslands = new RuntimeIslandAnalyzer($this->createRuntimeIslandContext(), $this->pseudoFormAnalyzer);
+        $this->searchBlockConverter = new SearchBlockConverter($this->createSearchBlockConversionContext(), $this->formControlMetadataBuilder, $this->pseudoFormAnalyzer);
         $this->buttonLinkDispatcher = new ButtonLinkDispatcher($this->createButtonLinkDispatchContext());
         $this->tableConverter = new TableElementConverter($this->createTableElementContext());
         $this->unsupportedRecorder = new UnsupportedElementRecorder($this->createUnsupportedElementContext(), $this->formControlMetadataBuilder);
@@ -546,7 +550,6 @@ final class HtmlTransformer
             fn (): GeneratedSupportStylesheetState => $this->generatedSupportStyles(),
             fn (DOMElement $element): int => $this->childElementCount($element),
             fn (DOMElement $element): bool => $this->runtimeIslands->isRuntimeDomTarget($element),
-            fn (DOMElement $element, DOMElement $input): bool => $this->hasStandaloneSearchSignal($element, $input),
             fn (DOMElement $element): array => $this->htmlPreservationBlock($element)
         );
     }
@@ -623,7 +626,6 @@ final class HtmlTransformer
             fn (DOMElement $element): array => $this->requiredScriptsForElement($element),
             fn (string $html): ?DOMElement => $this->preservedHtmlRootElement($html),
             fn (DOMElement $element): bool => $this->hasWorkspaceSurface($element),
-            fn (DOMElement $element): bool => $this->isDivBasedPseudoForm($element),
             fn (string $tagName): bool => $this->isInlineContentElement($tagName),
             fn (string $selector): bool => $this->isPresentationalAnimationSelector($selector),
             fn (array $rows): array => $this->dedupeArrayRows($rows)

--- a/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
@@ -68,7 +68,7 @@ trait FormDispatchTrait
     {
         // Some signup/contact widgets pair data-entry controls with a submit-like
         // control inside a plain container. Emit the same finding as a real form.
-        if ( $this->isDivBasedPseudoForm($element) ) {
+        if ( $this->pseudoFormAnalyzer->isPseudoForm($element) ) {
             $fallbacks[] = $this->formFallbackFinding($element, $this->readableFormBlockFromForm($element, true));
         }
     }
@@ -577,7 +577,7 @@ trait FormDispatchTrait
             'html_truncated'  => $boundedHtml['truncated'],
         );
         if ( 'form' !== strtolower($element->tagName) ) {
-            $finding['form_boundary'] = $this->pseudoFormBoundaryMetadata($element);
+            $finding['form_boundary'] = $this->pseudoFormAnalyzer->boundaryMetadata($element);
         }
 
         return FallbackDiagnostic::build($finding, $this->transformationProvenance()->fallback());
@@ -649,124 +649,6 @@ trait FormDispatchTrait
 
         $tokens = strtolower(trim($this->attr($element, 'id') . ' ' . $this->attr($element, 'class') . ' ' . $this->attr($element, 'aria-live')));
         return (bool) preg_match('/(?:^|[^a-z0-9])(?:success|sent|submitted|thank|thanks|confirmation|confirmed)(?:[^a-z0-9]|$)/', $tokens);
-    }
-
-    /**
-     * Whether a non-<form> container behaves as a form: it is the tightest
-     * container that pairs at least one data-entry control with a submit-like
-     * control, and no real <form> owns the subtree.
-     *
-     * Structural only — the signal is "data-entry control + submit-like control in
-     * one bounded container", never a fixture id/class/name. Conservative: a lone
-     * search box or a stray input with no submit control never qualifies, and a
-     * subtree owned by a real <form> (as ancestor or descendant) is left to the
-     * <form> path so the finding is emitted exactly once.
-     */
-    private function isDivBasedPseudoForm(DOMElement $element): bool
-    {
-        if ( 'form' === strtolower($element->tagName) ) {
-            return false;
-        }
-
-        // A real <form> ancestor or descendant owns the controls; let the <form>
-        // path emit the finding so it is never double-counted.
-        if ( FormControlClassifier::hasFormAncestor($element) ) {
-            return false;
-        }
-        if ( 0 < $element->getElementsByTagName('form')->length ) {
-            return false;
-        }
-
-        // A pseudo-form must be a local interaction region, never the page shell
-        // that happens to contain navigation or editorial content plus controls.
-        if ( $this->pseudoFormContainsUnrelatedLandmark($element) ) {
-            return false;
-        }
-
-        if ( ! $this->containerPairsDataEntryWithSubmit($element) ) {
-            return false;
-        }
-
-        // Bound the container to the tightest one: if a descendant container also
-        // pairs the controls, defer to it so a wrapper does not swallow a nested
-        // pseudo-form (and sibling pseudo-forms each emit their own finding).
-        foreach ( $element->getElementsByTagName('*') as $descendant ) {
-            if ( $descendant instanceof DOMElement
-                && ! FormControlClassifier::isControlElement($descendant)
-                && $this->containerPairsDataEntryWithSubmit($descendant) ) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Whether a container holds a local, labeled data-entry control and a submit
-     * action. Unlike a real form, a div gives a plain button no submit ownership,
-     * so its action must be explicit in type or semantics.
-     */
-    private function containerPairsDataEntryWithSubmit(DOMElement $element): bool
-    {
-        $hasDataEntry = false;
-        $hasFieldLabel = false;
-        $hasSubmit = false;
-        $hasActionControl = false;
-        $hasContainerAction = '' !== trim($this->attr($element, 'action')) || '' !== trim($this->attr($element, 'method')) || '' !== trim($this->attr($element, 'data-action'));
-
-        foreach ( FormControlClassifier::controlElements($element) as $control ) {
-            if ( FormControlClassifier::isPseudoFormDataEntryControl($control) && ! $this->hasStandaloneSearchSignal($element, $control) ) {
-                $hasDataEntry = true;
-                $hasFieldLabel = $hasFieldLabel || '' !== trim($this->formControlMetadataBuilder->label($control)) || '' !== trim($this->attr($control, 'aria-label')) || '' !== trim($this->attr($control, 'name'));
-            } elseif ( 'button' === strtolower($control->tagName) || ( 'input' === strtolower($control->tagName) && ! in_array(FormControlClassifier::controlType($control), array( 'reset', 'button' ), true) ) ) {
-                $hasActionControl = true;
-                $hasSubmit = $hasSubmit || FormControlClassifier::isPseudoFormSubmitControl($control);
-            }
-
-            if ( $hasDataEntry && $hasFieldLabel && ( $hasSubmit || ( $hasContainerAction && $hasActionControl ) ) ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function pseudoFormContainsUnrelatedLandmark(DOMElement $element): bool
-    {
-        foreach ( $this->descendantElements($element) as $descendant ) {
-            $tagName = strtolower($descendant->tagName);
-            $role = strtolower($this->attr($descendant, 'role'));
-            if ( in_array($tagName, array( 'article', 'nav', 'header', 'footer', 'main' ), true)
-                || in_array($role, array( 'article', 'navigation', 'banner', 'contentinfo', 'main' ), true) ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function pseudoFormBoundaryMetadata(DOMElement $element): array
-    {
-        $rejectedAncestors = array();
-        for ( $ancestor = $element->parentNode; $ancestor instanceof DOMElement && count($rejectedAncestors) < 4; $ancestor = $ancestor->parentNode ) {
-            if ( ! $this->pseudoFormContainsUnrelatedLandmark($ancestor) && ! $this->containerPairsDataEntryWithSubmit($ancestor) ) {
-                continue;
-            }
-            $rejectedAncestors[] = array(
-                'selector' => $this->elementSelector($ancestor),
-                'reason'   => $this->pseudoFormContainsUnrelatedLandmark($ancestor) ? 'contains_unrelated_landmark' : 'contains_nested_coherent_form',
-            );
-        }
-
-        return array(
-            'schema' => 'generic/form-boundary/v1',
-            'selector' => $this->elementSelector($element),
-            'selection_basis' => array( 'local_controls', 'associated_label', 'submit_semantics' ),
-            'rejected_ancestors' => $rejectedAncestors,
-        );
     }
 
     private function readableFormControlText(DOMElement $control): string
@@ -866,26 +748,6 @@ trait FormDispatchTrait
             $this->attr($form, 'aria-label'),
             $this->attr($form, 'id'),
             $this->attr($form, 'class'),
-        )));
-
-        return str_contains($haystack, 'search');
-    }
-
-    private function hasStandaloneSearchSignal(DOMElement $element, DOMElement $input): bool
-    {
-        if ( 'search' === FormControlClassifier::controlType($input) || 'search' === strtolower(trim($this->attr($element, 'role'))) ) {
-            return true;
-        }
-
-        $haystack = strtolower(implode(' ', array(
-            $this->attr($element, 'aria-label'),
-            $this->attr($element, 'id'),
-            $this->attr($element, 'class'),
-            $this->attr($input, 'aria-label'),
-            $this->attr($input, 'id'),
-            $this->attr($input, 'class'),
-            $this->attr($input, 'name'),
-            $this->attr($input, 'placeholder'),
         )));
 
         return str_contains($haystack, 'search');

--- a/php-transformer/tests/unit/pseudo-form-analyzer.php
+++ b/php-transformer/tests/unit/pseudo-form-analyzer.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormControlMetadataBuilder;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\PseudoFormAnalyzer;
+
+$assertions = 0;
+$failures = array();
+$assert = static function (bool $condition, string $label) use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']';
+    }
+};
+
+$elementFrom = static function (string $html): DOMElement {
+    $document = new DOMDocument();
+    $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+    foreach ( $document->getElementsByTagName('body')->item(0)->childNodes as $node ) {
+        if ( $node instanceof DOMElement ) {
+            return $node;
+        }
+    }
+    throw new RuntimeException('No element parsed');
+};
+
+$selector = static function (DOMElement $element): string {
+    $id = $element->getAttribute('id');
+    return '' !== $id ? '#' . $id : strtolower($element->tagName);
+};
+$metadataBuilder = new FormControlMetadataBuilder($selector);
+$analyzer = new PseudoFormAnalyzer($metadataBuilder, $selector);
+
+$local = $elementFrom('<div id="signup"><label>Email<input name="email"></label><button type="submit">Join</button></div>');
+$assert($analyzer->isPseudoForm($local), 'labeled-entry-and-submit-is-pseudo-form');
+
+$plainButton = $elementFrom('<div><label>Email<input name="email"></label><button type="button">Join</button></div>');
+$assert(! $analyzer->isPseudoForm($plainButton), 'explicit-button-has-no-submit-ownership');
+
+$containerAction = $elementFrom('<div data-action="subscribe"><label>Email<input name="email"></label><button type="button">Join</button></div>');
+$assert($analyzer->isPseudoForm($containerAction), 'container-action-owns-plain-button');
+
+$search = $elementFrom('<div><input type="search" aria-label="Search"><button type="submit">Go</button></div>');
+$assert(! $analyzer->isPseudoForm($search), 'standalone-search-is-not-pseudo-form');
+
+$landmark = $elementFrom('<div><nav>Menu</nav><label>Email<input name="email"></label><button type="submit">Join</button></div>');
+$assert(! $analyzer->isPseudoForm($landmark), 'unrelated-landmark-rejects-page-shell');
+
+$nested = $elementFrom('<div id="outer"><div id="inner"><label>Email<input name="email"></label><button type="submit">Join</button></div></div>');
+$inner = $nested->getElementsByTagName('div')->item(0);
+$assert($inner instanceof DOMElement && $analyzer->isPseudoForm($inner), 'tightest-container-is-pseudo-form');
+$assert(! $analyzer->isPseudoForm($nested), 'ancestor-defers-to-tightest-container');
+
+$boundary = $inner instanceof DOMElement ? $analyzer->boundaryMetadata($inner) : array();
+$assert('#inner' === ($boundary['selector'] ?? ''), 'boundary-identifies-selected-container');
+$assert('contains_nested_coherent_form' === ($boundary['rejected_ancestors'][0]['reason'] ?? ''), 'boundary-explains-rejected-ancestor');
+
+$form = $elementFrom('<form><label>Email<input name="email"></label><button type="submit">Join</button></form>');
+$assert(! $analyzer->isPseudoForm($form), 'real-form-is-not-pseudo-form');
+
+$formOwner = $elementFrom('<form><div><label>Email<input name="email"></label><button type="submit">Join</button></div></form>');
+$ownedContainer = $formOwner->getElementsByTagName('div')->item(0);
+$assert($ownedContainer instanceof DOMElement && ! $analyzer->isPseudoForm($ownedContainer), 'real-form-ancestor-owns-controls');
+
+$searchRegion = $elementFrom('<div role="search"><input type="text"></div>');
+$searchInput = $searchRegion->getElementsByTagName('input')->item(0);
+$assert($searchInput instanceof DOMElement && $analyzer->hasStandaloneSearchSignal($searchRegion, $searchInput), 'search-role-identifies-standalone-search');
+
+if ( $failures ) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Pseudo-form analyzer tests: ' . $assertions . " passed\n";

--- a/php-transformer/tests/unit/runtime-island-analyzer.php
+++ b/php-transformer/tests/unit/runtime-island-analyzer.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 require __DIR__ . '/../../vendor/autoload.php';
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormControlMetadataBuilder;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\PseudoFormAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeDomState;
@@ -79,13 +81,14 @@ $makeAnalyzer = static function (array $domSelectors = array(), array $presentat
         'requiredScripts'  => static fn (DOMElement $e): array => array(),
         'preservedRoot'    => static fn (string $h): ?DOMElement => null,
         'hasWorkspace'     => static fn (DOMElement $e): bool => false,
-        'isPseudoForm'     => static fn (DOMElement $e): bool => false,
         'isInline'         => static fn (string $t): bool => in_array($t, array('span', 'em', 'strong', 'a'), true),
         'isPresentational' => static fn (string $s): bool => in_array($s, $presentationalSelectors, true),
         'dedupe'           => static fn (array $rows): array => array_values($rows),
     );
     $c = array_merge($defaults, $overrides);
 
+    $metadataBuilder = new FormControlMetadataBuilder($c['islandSelector']);
+    $pseudoFormAnalyzer = new PseudoFormAnalyzer($metadataBuilder, $c['islandSelector']);
     return new RuntimeIslandAnalyzer(new RuntimeIslandContext(
         $c['fallbackEmitter'],
         $c['runtimeDom'],
@@ -97,11 +100,10 @@ $makeAnalyzer = static function (array $domSelectors = array(), array $presentat
         $c['requiredScripts'],
         $c['preservedRoot'],
         $c['hasWorkspace'],
-        $c['isPseudoForm'],
         $c['isInline'],
         $c['isPresentational'],
         $c['dedupe']
-    ));
+    ), $pseudoFormAnalyzer);
 };
 
 // An id or class named by a runtime selector is a DOM target.


### PR DESCRIPTION
## Summary

- move bounded pseudo-form detection, standalone-search signaling, and form-boundary diagnostics into a stateless `PseudoFormAnalyzer`
- inject the analyzer directly into search conversion and runtime-island analysis instead of routing those decisions through transformer context closures
- add a standalone analyzer contract covering control pairing, submit ownership, search exclusion, landmark rejection, tightest-container selection, and real-form ownership

Part of #242.

## Verification

- `composer test`
- pseudo-form analyzer contract: 12 assertions passed
- PHP transformer parity: 289 fixtures passed
- fresh CSS-attached corpus comparison against the exact current-trunk base: 383 documents, 87 fixtures, 82 fixtures with CSS, 0 throws, byte-identical records

## AI assistance

OpenAI GPT-5.6 Sol was used through OpenCode to identify the pseudo-form boundary, extract and rewire the collaborator, add its direct unit contract, and run the focused, contract, package-install, and corpus verification workflows. The implementation and evidence were reviewed and orchestrated by Chris Huber.