### PR TITLE
Extract form runtime requirement analyzer

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -153,6 +153,7 @@
             "php tests/unit/rich-text-element-converter.php",
             "php tests/unit/table-element-converter.php",
             "php tests/unit/unsupported-element-recorder.php",
+            "php tests/unit/form-runtime-requirement-analyzer.php",
             "php tests/unit/pseudo-form-analyzer.php",
             "php tests/unit/runtime-island-analyzer.php",
             "php tests/unit/button-link-dispatcher.php"

--- a/php-transformer/src/HtmlToBlocks/Elements/FormRuntimeRequirementAnalyzer.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FormRuntimeRequirementAnalyzer.php
@@ -1,0 +1,107 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
+use Closure;
+use DOMElement;
+
+/** Determines whether a form depends on behavior that native blocks cannot retain. */
+final class FormRuntimeRequirementAnalyzer
+{
+    /**
+     * @param Closure(DOMElement): array<string, mixed> $eventMetadata
+     * @param Closure(DOMElement): bool                 $isRuntimeDomTarget
+     */
+    public function __construct(
+        private readonly Closure $eventMetadata,
+        private readonly Closure $isRuntimeDomTarget
+    ) {
+    }
+
+    public function requiresPreservation(DOMElement $form): bool
+    {
+        return 0 < $form->getElementsByTagName('script')->length
+            || array() !== ($this->eventMetadata)($form)
+            || $this->hasSubmissionMetadata($form)
+            || $this->hasCommerceSubmissionSignal($form)
+            || $this->hasRuntimeDomTargets($form);
+    }
+
+    private function hasSubmissionMetadata(DOMElement $form): bool
+    {
+        $action = trim($this->attr($form, 'action'));
+        if ( '' !== $action && '#' !== $action ) {
+            return true;
+        }
+
+        if ( '' === $action && '' !== trim($this->attr($form, 'method')) ) {
+            return true;
+        }
+
+        foreach ( array( 'enctype', 'target' ) as $attribute ) {
+            if ( '' !== trim($this->attr($form, $attribute)) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasCommerceSubmissionSignal(DOMElement $form): bool
+    {
+        foreach ( FormControlClassifier::controlElements($form) as $control ) {
+            if ( ! FormControlClassifier::isSubmitLikeControl($control) ) {
+                continue;
+            }
+
+            $haystack = strtolower(implode(' ', array(
+                $control->textContent ?? '',
+                $this->attr($control, 'value'),
+                $this->attr($control, 'class'),
+                $this->attr($control, 'id'),
+                $this->attr($control, 'name'),
+                $this->attr($control, 'aria-label'),
+                $this->attr($control, 'title'),
+            )));
+
+            if ( preg_match('/(?:^|[^a-z0-9])(?:add to cart|cart|checkout|payment|purchase|buy|order|register|registration|ticket)(?:[^a-z0-9]|$)/', $haystack) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasRuntimeDomTargets(DOMElement $form): bool
+    {
+        if ( ($this->isRuntimeDomTarget)($form) || $this->hasRuntimeClassSignal($form) ) {
+            return true;
+        }
+
+        foreach ( FormControlClassifier::controlElements($form) as $control ) {
+            if ( ($this->isRuntimeDomTarget)($control) || $this->hasRuntimeClassSignal($control) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasRuntimeClassSignal(DOMElement $element): bool
+    {
+        foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) {
+            if ( preg_match('/^js-[A-Za-z0-9_-]+$/', $class) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function attr(DOMElement $element, string $name): string
+    {
+        return $element->hasAttribute($name) ? $element->getAttribute($name) : '';
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -34,6 +34,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolver;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispatchContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispatcher;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormControlMetadataBuilder;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormRuntimeRequirementAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\PseudoFormAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandContext;
@@ -267,6 +268,8 @@ final class HtmlTransformer
 
     private readonly PseudoFormAnalyzer $pseudoFormAnalyzer;
 
+    private readonly FormRuntimeRequirementAnalyzer $formRuntimeRequirementAnalyzer;
+
     private readonly SearchBlockConverter $searchBlockConverter;
 
     private readonly ButtonLinkDispatcher $buttonLinkDispatcher;
@@ -408,6 +411,10 @@ final class HtmlTransformer
         $this->formControlMetadataBuilder = new FormControlMetadataBuilder(fn (DOMElement $element): string => $this->elementSelector($element));
         $this->pseudoFormAnalyzer = new PseudoFormAnalyzer($this->formControlMetadataBuilder, fn (DOMElement $element): string => $this->elementSelector($element));
         $this->runtimeIslands = new RuntimeIslandAnalyzer($this->createRuntimeIslandContext(), $this->pseudoFormAnalyzer);
+        $this->formRuntimeRequirementAnalyzer = new FormRuntimeRequirementAnalyzer(
+            fn (DOMElement $element): array => $this->eventMetadata($element),
+            fn (DOMElement $element): bool => $this->runtimeIslands->isRuntimeDomTarget($element)
+        );
         $this->searchBlockConverter = new SearchBlockConverter($this->createSearchBlockConversionContext(), $this->formControlMetadataBuilder, $this->pseudoFormAnalyzer);
         $this->buttonLinkDispatcher = new ButtonLinkDispatcher($this->createButtonLinkDispatchContext());
         $this->tableConverter = new TableElementConverter($this->createTableElementContext());

--- a/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
@@ -27,7 +27,7 @@ trait FormDispatchTrait
         }
 
         $readableFormBlock = $this->readableFormBlockFromForm($element);
-        if ( null !== $readableFormBlock && ! $this->formRequiresRuntimePreservation($element) ) {
+        if ( null !== $readableFormBlock && ! $this->formRuntimeRequirementAnalyzer->requiresPreservation($element) ) {
             if ( FormControlClassifier::hasDataEntryControls($element) ) {
                 $fallbacks[] = $this->formFallbackFinding($element, $readableFormBlock);
             }
@@ -447,86 +447,6 @@ trait FormDispatchTrait
         }
 
         return array() === $selected ? '' : implode(', ', $selected) . ' (selected)';
-    }
-
-    private function formRequiresRuntimePreservation(DOMElement $form): bool
-    {
-        return 0 < $form->getElementsByTagName('script')->length
-            || array() !== $this->eventMetadata($form)
-            || $this->formHasRuntimeSubmissionMetadata($form)
-            || $this->formHasCommerceSubmissionSignal($form)
-            || $this->formHasRuntimeDomTargets($form);
-    }
-
-    private function formHasRuntimeSubmissionMetadata(DOMElement $form): bool
-    {
-        $action = trim($this->attr($form, 'action'));
-        if ( '' !== $action && '#' !== $action ) {
-            return true;
-        }
-
-        if ( '' === $action && '' !== trim($this->attr($form, 'method')) ) {
-            return true;
-        }
-
-        foreach ( array( 'enctype', 'target' ) as $attribute ) {
-            if ( '' !== trim($this->attr($form, $attribute)) ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function formHasCommerceSubmissionSignal(DOMElement $form): bool
-    {
-        foreach ( FormControlClassifier::controlElements($form) as $control ) {
-            if ( ! FormControlClassifier::isSubmitLikeControl($control) ) {
-                continue;
-            }
-
-            $haystack = strtolower(implode(' ', array(
-                $control->textContent ?? '',
-                $this->attr($control, 'value'),
-                $this->attr($control, 'class'),
-                $this->attr($control, 'id'),
-                $this->attr($control, 'name'),
-                $this->attr($control, 'aria-label'),
-                $this->attr($control, 'title'),
-            )));
-
-            if ( preg_match('/(?:^|[^a-z0-9])(?:add to cart|cart|checkout|payment|purchase|buy|order|register|registration|ticket)(?:[^a-z0-9]|$)/', $haystack) ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function formHasRuntimeDomTargets(DOMElement $form): bool
-    {
-        if ( $this->runtimeIslands->isRuntimeDomTarget($form) || $this->hasRuntimeClassSignal($form) ) {
-            return true;
-        }
-
-        foreach ( FormControlClassifier::controlElements($form) as $control ) {
-            if ( $this->runtimeIslands->isRuntimeDomTarget($control) || $this->hasRuntimeClassSignal($control) ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function hasRuntimeClassSignal(DOMElement $element): bool
-    {
-        foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) {
-            if ( preg_match('/^js-[A-Za-z0-9_-]+$/', $class) ) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**

--- a/php-transformer/tests/unit/form-runtime-requirement-analyzer.php
+++ b/php-transformer/tests/unit/form-runtime-requirement-analyzer.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormRuntimeRequirementAnalyzer;
+
+$assertions = 0;
+$failures = array();
+$assert = static function (bool $condition, string $label) use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']';
+    }
+};
+
+$elementFrom = static function (string $html): DOMElement {
+    $document = new DOMDocument();
+    $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+    $element = $document->getElementsByTagName('form')->item(0);
+    if ( $element instanceof DOMElement ) {
+        return $element;
+    }
+    throw new RuntimeException('No form parsed');
+};
+
+$analyzer = new FormRuntimeRequirementAnalyzer(
+    static fn (DOMElement $element): array => $element->hasAttribute('data-event') ? array( 'click' => true ) : array(),
+    static fn (DOMElement $element): bool => $element->hasAttribute('data-runtime')
+);
+
+$assert(! $analyzer->requiresPreservation($elementFrom('<form><input name="email"></form>')), 'plain-form-needs-no-runtime');
+$assert($analyzer->requiresPreservation($elementFrom('<form><script>submit()</script></form>')), 'script-requires-runtime');
+$assert($analyzer->requiresPreservation($elementFrom('<form data-event="1"></form>')), 'form-event-requires-runtime');
+$assert($analyzer->requiresPreservation($elementFrom('<form action="/subscribe"></form>')), 'action-requires-runtime');
+$assert(! $analyzer->requiresPreservation($elementFrom('<form action="#"></form>')), 'hash-action-is-inert');
+$assert($analyzer->requiresPreservation($elementFrom('<form method="post"></form>')), 'method-without-action-requires-runtime');
+$assert($analyzer->requiresPreservation($elementFrom('<form target="_blank"></form>')), 'target-requires-runtime');
+$assert($analyzer->requiresPreservation($elementFrom('<form><button type="submit">Checkout</button></form>')), 'commerce-submit-requires-runtime');
+$assert(! $analyzer->requiresPreservation($elementFrom('<form><button type="submit">Send</button></form>')), 'generic-submit-needs-no-runtime');
+$assert($analyzer->requiresPreservation($elementFrom('<form data-runtime="1"></form>')), 'form-runtime-target-requires-preservation');
+$assert($analyzer->requiresPreservation($elementFrom('<form><input data-runtime="1"></form>')), 'control-runtime-target-requires-preservation');
+$assert($analyzer->requiresPreservation($elementFrom('<form class="signup js-form"></form>')), 'form-js-class-requires-runtime');
+$assert($analyzer->requiresPreservation($elementFrom('<form><input class="field js-validate"></form>')), 'control-js-class-requires-runtime');
+
+if ( $failures ) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Form runtime requirement analyzer tests: ' . $assertions . " passed\n";


### PR DESCRIPTION
## Summary

- move form runtime-preservation policy into a stateless `FormRuntimeRequirementAnalyzer`
- make event metadata and runtime-target detection its only explicit transformer operations
- add a standalone analyzer contract covering scripts, events, submission metadata, commerce submits, runtime targets, and `js-*` class signals

Part of #242.

## Verification

- `composer test`
- form runtime requirement analyzer contract: 13 assertions passed
- PHP transformer parity: 289 fixtures passed
- distribution-shape packaging contract passed
- fresh CSS-attached corpus comparison against exact current trunk: 383 documents, 87 fixtures, 82 fixtures with CSS, 0 throws, byte-identical records

## AI assistance

OpenAI GPT-5.6 Sol was used through OpenCode to identify the runtime-policy boundary, extract and rewire the collaborator, preserve concurrent trunk packaging changes during rebase, add its direct unit contract, and run the focused, contract, package-install, and corpus verification workflows. The implementation and evidence were reviewed and orchestrated by Chris Huber.