### PR TITLE
Extract form success panel metadata builder

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -154,6 +154,7 @@
             "php tests/unit/table-element-converter.php",
             "php tests/unit/unsupported-element-recorder.php",
             "php tests/unit/form-runtime-requirement-analyzer.php",
+            "php tests/unit/form-success-panel-metadata-builder.php",
             "php tests/unit/pseudo-form-analyzer.php",
             "php tests/unit/runtime-island-analyzer.php",
             "php tests/unit/button-link-dispatcher.php"

--- a/php-transformer/src/HtmlToBlocks/Elements/FormSuccessPanelMetadataBuilder.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FormSuccessPanelMetadataBuilder.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Closure;
+use DOMElement;
+use DOMNode;
+
+/** Discovers form success panels and builds provider-neutral metadata. */
+final class FormSuccessPanelMetadataBuilder
+{
+    /**
+     * @param Closure(DOMElement): string                                          $elementSelector
+     * @param Closure(DOMElement): array{html: string, bytes: int, truncated: bool} $fallbackHtmlMetadata
+     * @param Closure(DOMElement): string                                          $innerHtml
+     */
+    public function __construct(
+        private readonly Closure $elementSelector,
+        private readonly Closure $fallbackHtmlMetadata,
+        private readonly Closure $innerHtml
+    ) {
+    }
+
+    /** @return array<string, mixed> */
+    public function build(DOMElement $form): array
+    {
+        if ( 'form' !== strtolower($form->tagName) ) {
+            foreach ( $form->getElementsByTagName('*') as $descendant ) {
+                if ( $descendant instanceof DOMElement && $this->hasSignal($descendant) ) {
+                    return $this->metadata($descendant);
+                }
+            }
+
+            return array();
+        }
+
+        for ( $sibling = $form->nextSibling; $sibling instanceof DOMNode; $sibling = $sibling->nextSibling ) {
+            if ( XML_TEXT_NODE === $sibling->nodeType && '' === trim($sibling->textContent ?? '') ) {
+                continue;
+            }
+
+            if ( ! $sibling instanceof DOMElement || ! $this->hasSignal($sibling) ) {
+                return array();
+            }
+
+            return $this->metadata($sibling);
+        }
+
+        return array();
+    }
+
+    /** @return array<string, mixed> */
+    private function metadata(DOMElement $element): array
+    {
+        $boundedHtml = ($this->fallbackHtmlMetadata)($element);
+        return array_filter(array(
+            'selector'       => ($this->elementSelector)($element),
+            'id'             => $this->attr($element, 'id'),
+            'class'          => $this->attr($element, 'class'),
+            'role'           => $this->attr($element, 'role'),
+            'aria_live'      => $this->attr($element, 'aria-live'),
+            'text'           => $this->normalizedText($element),
+            'html'           => $boundedHtml['html'],
+            'html_bytes'     => $boundedHtml['bytes'],
+            'html_truncated' => $boundedHtml['truncated'],
+        ), static fn (mixed $value): bool => is_bool($value) || is_int($value) || '' !== trim((string) $value));
+    }
+
+    private function normalizedText(DOMElement $element): string
+    {
+        $html = preg_replace('/<\/?[a-z][a-z0-9]*\b[^>]*>/i', ' ', ($this->innerHtml)($element)) ?? $element->textContent ?? '';
+        return trim(preg_replace('/\s+/', ' ', html_entity_decode(strip_tags($html), ENT_QUOTES | ENT_HTML5, 'UTF-8')) ?? '');
+    }
+
+    private function hasSignal(DOMElement $element): bool
+    {
+        $role = strtolower($this->attr($element, 'role'));
+        if ( in_array($role, array( 'status', 'alert' ), true) ) {
+            return true;
+        }
+
+        $tokens = strtolower(trim($this->attr($element, 'id') . ' ' . $this->attr($element, 'class') . ' ' . $this->attr($element, 'aria-live')));
+        return (bool) preg_match('/(?:^|[^a-z0-9])(?:success|sent|submitted|thank|thanks|confirmation|confirmed)(?:[^a-z0-9]|$)/', $tokens);
+    }
+
+    private function attr(DOMElement $element, string $name): string
+    {
+        return $element->hasAttribute($name) ? $element->getAttribute($name) : '';
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -35,6 +35,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispa
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispatcher;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormControlMetadataBuilder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormRuntimeRequirementAnalyzer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormSuccessPanelMetadataBuilder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\PseudoFormAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandContext;
@@ -270,6 +271,8 @@ final class HtmlTransformer
 
     private readonly FormRuntimeRequirementAnalyzer $formRuntimeRequirementAnalyzer;
 
+    private readonly FormSuccessPanelMetadataBuilder $formSuccessPanelMetadataBuilder;
+
     private readonly SearchBlockConverter $searchBlockConverter;
 
     private readonly ButtonLinkDispatcher $buttonLinkDispatcher;
@@ -414,6 +417,11 @@ final class HtmlTransformer
         $this->formRuntimeRequirementAnalyzer = new FormRuntimeRequirementAnalyzer(
             fn (DOMElement $element): array => $this->eventMetadata($element),
             fn (DOMElement $element): bool => $this->runtimeIslands->isRuntimeDomTarget($element)
+        );
+        $this->formSuccessPanelMetadataBuilder = new FormSuccessPanelMetadataBuilder(
+            fn (DOMElement $element): string => $this->elementSelector($element),
+            fn (DOMElement $element): array => $this->boundedFallbackHtml($this->safeFallbackHtml($element)),
+            fn (DOMElement $element): string => $this->innerHtml($element)
         );
         $this->searchBlockConverter = new SearchBlockConverter($this->createSearchBlockConversionContext(), $this->formControlMetadataBuilder, $this->pseudoFormAnalyzer);
         $this->buttonLinkDispatcher = new ButtonLinkDispatcher($this->createButtonLinkDispatchContext());

--- a/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
@@ -11,7 +11,6 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\FormControlTopolog
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\FormLayoutGraphBuilder;
 use DOMDocument;
 use DOMElement;
-use DOMNode;
 
 trait FormDispatchTrait
 {
@@ -480,7 +479,7 @@ trait FormDispatchTrait
             'selector'        => $this->elementSelector($element),
             'attributes'      => $this->htmlAttributes($element),
             'form'            => $this->formControlMetadataBuilder->form($element),
-            'success_panel'   => $this->formSuccessPanelMetadata($element),
+            'success_panel'   => $this->formSuccessPanelMetadataBuilder->build($element),
             'context'         => $this->sourceContext($element),
             'classification'  => $this->fallbackEmitter()->classifyFallbackSubtree($element),
             'events'          => $this->eventMetadata($element),
@@ -501,74 +500,6 @@ trait FormDispatchTrait
         }
 
         return FallbackDiagnostic::build($finding, $this->transformationProvenance()->fallback());
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function formSuccessPanelMetadata(DOMElement $form): array
-    {
-        if ( 'form' !== strtolower($form->tagName) ) {
-            foreach ( $this->descendantElements($form) as $descendant ) {
-                if ( $this->hasSuccessPanelSignal($descendant) ) {
-                    return $this->successPanelMetadata($descendant);
-                }
-            }
-
-            return array();
-        }
-
-        for ( $sibling = $form->nextSibling; $sibling instanceof DOMNode; $sibling = $sibling->nextSibling ) {
-            if ( XML_TEXT_NODE === $sibling->nodeType && '' === trim($sibling->textContent ?? '') ) {
-                continue;
-            }
-
-            if ( ! $sibling instanceof DOMElement ) {
-                return array();
-            }
-
-            if ( ! $this->hasSuccessPanelSignal($sibling) ) {
-                return array();
-            }
-
-            return $this->successPanelMetadata($sibling);
-        }
-
-        return array();
-    }
-
-    /** @return array<string, mixed> */
-    private function successPanelMetadata(DOMElement $element): array
-    {
-        $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($element));
-        return array_filter(array(
-            'selector'       => $this->elementSelector($element),
-            'id'             => $this->attr($element, 'id'),
-            'class'          => $this->attr($element, 'class'),
-            'role'           => $this->attr($element, 'role'),
-            'aria_live'      => $this->attr($element, 'aria-live'),
-            'text'           => $this->normalizedSuccessPanelText($element),
-            'html'           => $boundedHtml['html'],
-            'html_bytes'     => $boundedHtml['bytes'],
-            'html_truncated' => $boundedHtml['truncated'],
-        ), static fn (mixed $value): bool => is_bool($value) || is_int($value) || '' !== trim((string) $value));
-    }
-
-    private function normalizedSuccessPanelText(DOMElement $element): string
-    {
-        $html = preg_replace('/<\/?[a-z][a-z0-9]*\b[^>]*>/i', ' ', $this->innerHtml($element)) ?? $element->textContent ?? '';
-        return trim(preg_replace('/\s+/', ' ', html_entity_decode(strip_tags($html), ENT_QUOTES | ENT_HTML5, 'UTF-8')) ?? '');
-    }
-
-    private function hasSuccessPanelSignal(DOMElement $element): bool
-    {
-        $role = strtolower($this->attr($element, 'role'));
-        if ( in_array($role, array( 'status', 'alert' ), true) ) {
-            return true;
-        }
-
-        $tokens = strtolower(trim($this->attr($element, 'id') . ' ' . $this->attr($element, 'class') . ' ' . $this->attr($element, 'aria-live')));
-        return (bool) preg_match('/(?:^|[^a-z0-9])(?:success|sent|submitted|thank|thanks|confirmation|confirmed)(?:[^a-z0-9]|$)/', $tokens);
     }
 
     private function readableFormControlText(DOMElement $control): string

--- a/php-transformer/tests/unit/form-success-panel-metadata-builder.php
+++ b/php-transformer/tests/unit/form-success-panel-metadata-builder.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormSuccessPanelMetadataBuilder;
+
+$assertions = 0;
+$failures = array();
+$assert = static function (bool $condition, string $label) use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']';
+    }
+};
+
+$elementFrom = static function (string $html): DOMElement {
+    $document = new DOMDocument();
+    $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+    foreach ( $document->getElementsByTagName('body')->item(0)->childNodes as $node ) {
+        if ( $node instanceof DOMElement ) {
+            return $node;
+        }
+    }
+    throw new RuntimeException('No element parsed');
+};
+
+$selector = static function (DOMElement $element): string {
+    $id = $element->getAttribute('id');
+    return '' !== $id ? '#' . $id : strtolower($element->tagName);
+};
+$fallbackHtmlMetadata = static function (DOMElement $element): array {
+    $html = trim($element->ownerDocument->saveHTML($element) ?: '');
+    return array(
+        'html'      => $html,
+        'bytes'     => strlen($html),
+        'truncated' => false,
+    );
+};
+$innerHtml = static function (DOMElement $element): string {
+    $html = '';
+    foreach ( $element->childNodes as $child ) {
+        $html .= $element->ownerDocument->saveHTML($child);
+    }
+    return trim($html);
+};
+$builder = new FormSuccessPanelMetadataBuilder($selector, $fallbackHtmlMetadata, $innerHtml);
+
+$form = $elementFrom('<form></form>   <div id="sent" class="notice success" role="status" aria-live="polite"> Thanks <strong>Chris</strong> &amp; team </div>');
+$metadata = $builder->build($form);
+$assert('#sent' === ($metadata['selector'] ?? ''), 'real-form-finds-adjacent-panel-after-whitespace');
+$assert('notice success' === ($metadata['class'] ?? ''), 'panel-attributes-are-retained');
+$assert('Thanks Chris & team' === ($metadata['text'] ?? ''), 'nested-confirmation-text-is-normalized');
+$assert(false === ($metadata['html_truncated'] ?? null), 'bounded-html-state-is-retained');
+$assert(($metadata['html_bytes'] ?? 0) === strlen((string) ($metadata['html'] ?? '')), 'bounded-html-byte-count-is-retained');
+
+$blocked = $elementFrom('<form></form><p>Other content</p><div role="status">Sent</div>');
+$assert(array() === $builder->build($blocked), 'unrelated-adjacent-element-blocks-panel-discovery');
+
+$commentBlocked = $elementFrom('<form></form><!-- boundary --><div role="status">Sent</div>');
+$assert(array() === $builder->build($commentBlocked), 'non-element-adjacent-node-blocks-panel-discovery');
+
+$pseudoForm = $elementFrom('<div id="signup"><label>Email<input></label><div><p id="confirmation-message">Submitted</p></div></div>');
+$assert('#confirmation-message' === ($builder->build($pseudoForm)['selector'] ?? ''), 'pseudo-form-finds-descendant-token-panel');
+
+$firstPanel = $elementFrom('<div><p role="alert" id="first">Try again</p><p role="status" id="second">Sent</p></div>');
+$assert('#first' === ($builder->build($firstPanel)['selector'] ?? ''), 'pseudo-form-uses-first-signaled-descendant');
+
+$ariaToken = $elementFrom('<div><output aria-live="confirmed">Complete</output></div>');
+$assert('output' === ($builder->build($ariaToken)['selector'] ?? ''), 'confirmation-token-in-aria-live-is-a-signal');
+
+$partialToken = $elementFrom('<div><p class="unsuccessful">No match</p></div>');
+$assert(array() === $builder->build($partialToken), 'partial-success-token-is-not-a-signal');
+
+$boundedBuilder = new FormSuccessPanelMetadataBuilder(
+    $selector,
+    static fn (DOMElement $element): array => array( 'html' => '<p>...', 'bytes' => 2500, 'truncated' => true ),
+    $innerHtml
+);
+$truncated = $boundedBuilder->build($elementFrom('<div><p role="status">Sent</p></div>'));
+$assert(true === ($truncated['html_truncated'] ?? false) && 2500 === ($truncated['html_bytes'] ?? 0), 'truncated-html-metadata-is-propagated');
+
+if ( $failures ) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Form success panel metadata builder tests: ' . $assertions . " passed\n";


### PR DESCRIPTION
## Summary
- extract success-panel discovery, signal classification, normalized text, and metadata assembly into a stateless `FormSuccessPanelMetadataBuilder`
- preserve selector generation, source canonicalization, and bounded safe-HTML policy through explicit transformer callbacks
- reduce `FormDispatchTrait` from 676 to 607 lines while keeping fallback orchestration in the trait
- add a 12-assertion direct contract for real forms, pseudo-forms, adjacency boundaries, signal tokens, normalized text, and bounded HTML metadata

## Verification
- `composer test`
- PHP transformer parity: 289 fixtures
- distribution shape: 199 files, 10 monorepo-only trees excluded
- exact-base CSS-attached corpus comparison: byte-identical records for 383 documents / 87 fixtures / 82 fixtures with CSS / 0 throws

Part of #242.

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to inspect the existing extraction patterns, implement the refactor and direct contract, and run the verification suite and exact-base corpus comparison.