### PR TITLE
Resolve static-parity base state the way a browser would

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -95,6 +95,7 @@
       "php tests/unit/admin-bar-accommodation.php",
       "php tests/unit/css-rule-analyzer.php",
       "php tests/unit/css-selector-matcher.php",
+      "php tests/unit/static-css-cascade.php",
       "php tests/unit/author-selector-semantics.php",
       "php tests/unit/engine-support-css-asset.php",
       "php tests/unit/engine-support-css-specificity.php",

--- a/php-transformer/dev/VisualParity/StaticCssCascade.php
+++ b/php-transformer/dev/VisualParity/StaticCssCascade.php
@@ -29,6 +29,15 @@ use DOMElement;
 final class StaticCssCascade
 {
     /**
+     * Viewport width @media conditions are resolved against, matching the
+     * desktop reference the transformer itself uses for responsive decisions.
+     */
+    private const REFERENCE_VIEWPORT_WIDTH_PX = 1440;
+
+    /** Root font size used to convert rem/em media-query widths to pixels. */
+    private const ROOT_FONT_SIZE_PX = 16;
+
+    /**
      * @var array<int, array{selector: string, declarations: array<string, string>, specificity: int, order: int}>
      */
     private array $rules;
@@ -183,6 +192,15 @@ final class StaticCssCascade
         }
 
         foreach ( $cssBlocks as $css ) {
+            // Comments must go before anything reads the rule grammar. The flat
+            // `selector { declarations }` scan treats everything between the
+            // previous `}` and the next `{` as the selector, so a section header
+            // comment is glued onto the selector of the rule that follows it and
+            // that rule then matches nothing. It is silent, and it lands on the
+            // first rule after every comment — which in a hand-authored
+            // stylesheet is typically the structural one (`:root`, `*`, `body`,
+            // a layout container, a landmark).
+            $css = $this->stripComments($css);
             $css = $this->stripAtRuleBlocks($css);
             if ( ! preg_match_all('/([^{}]+)\{([^{}]+)\}/', $css, $matches, PREG_SET_ORDER) ) {
                 continue;
@@ -210,12 +228,24 @@ final class StaticCssCascade
         return $rules;
     }
 
+    /** Remove `/* … *&#47;` comments so they cannot be absorbed into a selector. */
+    private function stripComments(string $css): string
+    {
+        return preg_replace('#/\*.*?\*/#s', '', $css) ?? $css;
+    }
+
     /**
      * Remove at-rule prelude tokens (@media/@supports/@font-face headers and
      * @keyframes blocks) that would otherwise corrupt the flat rule grammar.
-     * The nested rules inside @media/@supports are intentionally kept (flattened)
-     * because they still declare effective style; @keyframes interiors are dropped
-     * because their "selectors" (0%, to, from) are not element selectors.
+     *
+     * @media blocks are resolved against {@see REFERENCE_VIEWPORT_WIDTH_PX}
+     * rather than flattened unconditionally. Flattening every block makes a
+     * `@media (max-width: 1080px) { .main-nav { display: none } }` rule declare
+     * `display: none` on the desktop nav in base state, which is the opposite of
+     * what the stylesheet says at the reference width. @supports and @layer are
+     * still unwrapped: they carry no viewport condition, so their rules do
+     * declare effective style. @keyframes interiors are dropped because their
+     * "selectors" (0%, to, from) are not element selectors.
      */
     private function stripAtRuleBlocks(string $css): string
     {
@@ -224,10 +254,113 @@ final class StaticCssCascade
         // Drop @font-face / @import / @charset prelude+block which carry no element rules.
         $css = preg_replace('/@font-face\b[^{]*\{[^{}]*\}/i', '', $css) ?? $css;
         $css = preg_replace('/@(?:import|charset)\b[^;]*;/i', '', $css) ?? $css;
-        // Unwrap @media/@supports/@layer wrappers, keeping their inner rules.
-        $css = preg_replace('/@(?:media|supports|layer)\b[^{]*\{/i', '', $css) ?? $css;
+        // Resolve @media against the reference viewport, keeping only the blocks
+        // that apply there.
+        $css = $this->resolveMediaBlocks($css);
+        // Unwrap @supports/@layer wrappers, keeping their inner rules.
+        $css = preg_replace('/@(?:supports|layer)\b[^{]*\{/i', '', $css) ?? $css;
 
         return $css;
+    }
+
+    /**
+     * Inline the contents of every @media block that applies at the reference
+     * viewport and drop the rest, brace-balanced so nested rules survive intact.
+     */
+    private function resolveMediaBlocks(string $css): string
+    {
+        $out = '';
+        $offset = 0;
+        $length = strlen($css);
+
+        while ( $offset < $length ) {
+            if ( ! preg_match('/@media\b/i', $css, $match, PREG_OFFSET_CAPTURE, $offset) ) {
+                $out .= substr($css, $offset);
+                break;
+            }
+
+            $start = (int) $match[0][1];
+            $out  .= substr($css, $offset, $start - $offset);
+
+            $bracePos = strpos($css, '{', $start);
+            if ( false === $bracePos ) {
+                // Truncated at-rule with no block: nothing further to resolve.
+                break;
+            }
+
+            $condition = trim(substr($css, $start + strlen('@media'), $bracePos - $start - strlen('@media')));
+
+            $depth = 0;
+            $end   = $bracePos;
+            for ( $index = $bracePos; $index < $length; $index++ ) {
+                if ( '{' === $css[$index] ) {
+                    $depth++;
+                    continue;
+                }
+                if ( '}' === $css[$index] ) {
+                    $depth--;
+                    if ( 0 === $depth ) {
+                        $end = $index;
+                        break;
+                    }
+                }
+            }
+
+            if ( 0 !== $depth ) {
+                // Unbalanced block: keep the remainder verbatim rather than guessing.
+                $out .= substr($css, $bracePos + 1);
+                break;
+            }
+
+            if ( $this->mediaConditionApplies($condition) ) {
+                $out .= "\n" . substr($css, $bracePos + 1, $end - $bracePos - 1) . "\n";
+            }
+
+            $offset = $end + 1;
+        }
+
+        return $out;
+    }
+
+    /**
+     * Does a media condition hold at the reference viewport?
+     *
+     * Width features are evaluated numerically. Non-visual media types are
+     * rejected. Anything else this resolver does not model (orientation,
+     * prefers-*, hover) is kept, so an unmodelled condition degrades to the
+     * previous flattening behaviour rather than silently deleting author style.
+     */
+    private function mediaConditionApplies(string $condition): bool
+    {
+        $condition = strtolower(trim($condition));
+
+        if ( '' === $condition ) {
+            return true;
+        }
+
+        if ( preg_match('/\b(?:print|speech|aural|braille|embossed|tty)\b/', $condition) ) {
+            return false;
+        }
+
+        foreach ( array( 'min' => '>=', 'max' => '<=' ) as $bound => $comparison ) {
+            if ( ! preg_match_all('/\(\s*' . $bound . '-width\s*:\s*([0-9.]+)\s*(px|rem|em)?\s*\)/', $condition, $matches, PREG_SET_ORDER) ) {
+                continue;
+            }
+            foreach ( $matches as $widthMatch ) {
+                $value = (float) $widthMatch[1];
+                if ( in_array($widthMatch[2] ?? 'px', array( 'rem', 'em' ), true) ) {
+                    $value *= self::ROOT_FONT_SIZE_PX;
+                }
+                $holds = '>=' === $comparison
+                    ? self::REFERENCE_VIEWPORT_WIDTH_PX >= $value
+                    : self::REFERENCE_VIEWPORT_WIDTH_PX <= $value;
+                if ( ! $holds ) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -268,7 +401,27 @@ final class StaticCssCascade
 
     private function matchesSimpleSelector(DOMElement $element, string $selector): bool
     {
-        $selector = trim(preg_replace('/:(hover|focus|active|visited|before|after)\b.*/', '', $selector) ?? $selector);
+        $selector = trim($selector);
+
+        // A rule gated on interaction state, or one targeting a pseudo-element,
+        // does not style the element in its resting state. Rewriting it into a
+        // base-state rule (by deleting the pseudo-class and matching what is
+        // left) lets `a:hover { color: red }` outrank the real `a { color: blue }`
+        // on source order, so the probe reports the hover colour as the base
+        // colour and every such link becomes a false parity finding.
+        if ( $this->isNonBaseStateSelector($selector) ) {
+            return false;
+        }
+
+        // `:root` is the document element. Without this it falls through every
+        // branch below and returns false, so `:root { --token: … }` never matches
+        // and no custom property is ever collected — leaving every `var(--token)`
+        // reference unresolved on the source side while the candidate side
+        // carries values the transformer already resolved.
+        if ( ':root' === strtolower($selector) ) {
+            return null !== $element->ownerDocument && $element === $element->ownerDocument->documentElement;
+        }
+
         if ( '' === $selector || str_contains($selector, '+') || str_contains($selector, '~') || str_contains($selector, '[') ) {
             return false;
         }
@@ -314,6 +467,29 @@ final class StaticCssCascade
         }
 
         return strtolower($selector) === strtolower($element->tagName);
+    }
+
+    /**
+     * Does this selector depend on interaction state or target a pseudo-element?
+     *
+     * Structural pseudo-classes (`:first-child`, `:nth-of-type()`, `:not()`) are
+     * deliberately absent: they describe the resting document, so they belong in
+     * base state. They are unsupported by the matcher for other reasons and fail
+     * closed further down rather than being silently rewritten.
+     */
+    private function isNonBaseStateSelector(string $selector): bool
+    {
+        return 1 === preg_match(
+            '/::?(?:hover|focus|focus-within|focus-visible|focus-visible-within|active|visited|target|any-link|checked|indeterminate|placeholder-shown|user-invalid)\b/i',
+            $selector
+        ) || 1 === preg_match(
+            '/::(?:before|after|placeholder|selection|marker|backdrop|first-line|first-letter)\b/i',
+            $selector
+        ) || 1 === preg_match(
+            // Single-colon legacy pseudo-element syntax (`:before`, `:after`).
+            '/:(?:before|after|first-line|first-letter)\b/i',
+            $selector
+        );
     }
 
     private function matchesChildSelector(DOMElement $element, string $selector): bool

--- a/php-transformer/tests/unit/static-css-cascade.php
+++ b/php-transformer/tests/unit/static-css-cascade.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * StaticCssCascade base-state resolution.
+ *
+ * This resolver decides the SOURCE side of every static-parity comparison, so a
+ * value it reports that the browser would never compute becomes a parity finding
+ * against a transformer that was correct. Each case below is a way that used to
+ * happen.
+ */
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\VisualParity\StaticCssCascade;
+
+$failures = 0;
+$passes = 0;
+$assert = static function (bool $condition, string $message) use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+    ++$failures;
+    fwrite(STDERR, "FAIL: {$message}\n");
+};
+
+/** Resolve one property for the first element matching an XPath query. */
+$resolve = static function (string $html, string $css, string $xpath, array $properties, array $inheritable = array()): array {
+    $dom = new DOMDocument();
+    $previous = libxml_use_internal_errors(true);
+    $dom->loadHTML('<?xml encoding="utf-8" ?>' . $html);
+    libxml_clear_errors();
+    libxml_use_internal_errors($previous);
+
+    $element = ( new DOMXPath($dom) )->query($xpath)->item(0);
+    if ( ! $element instanceof DOMElement ) {
+        throw new RuntimeException("No element for {$xpath}");
+    }
+
+    return ( new StaticCssCascade($dom, $css) )->resolve($element, $properties, $inheritable);
+};
+
+$page = '<html><body><footer class="site-footer"><div class="col"><ul><li><a href="#">Link</a></li></ul></div></footer><nav class="main-nav">nav</nav></body></html>';
+
+// A comment before a rule used to be absorbed into that rule's selector, so the
+// rule matched nothing. It lands on the first rule after every comment, which in
+// hand-authored CSS is usually the structural one.
+$commented = "/* ─── Footer ─── */\n.site-footer { color: rgb(1, 2, 3); font-size: 0.92rem; }";
+$result = $resolve($page, $commented, '//footer', array( 'color', 'font-size' ));
+$assert('rgb(1, 2, 3)' === ( $result['color'] ?? '' ), 'a rule preceded by a comment still matches');
+$assert('0.92rem' === ( $result['font-size'] ?? '' ), 'a commented rule keeps every declaration');
+
+$result = $resolve($page, "/* a */ .site-footer /* b */ { color: rgb(4, 5, 6); }", '//footer', array( 'color' ));
+$assert('rgb(4, 5, 6)' === ( $result['color'] ?? '' ), 'comments inside a selector are removed');
+
+// :root is the document element. Without it no custom property is ever collected
+// and every var() reference stays literal on the source side.
+$result = $resolve($page, ':root { --brand: #123456; } .site-footer { color: var(--brand); }', '//footer', array( 'color' ));
+$assert('#123456' === ( $result['color'] ?? '' ), ':root custom properties resolve var() references');
+
+$result = $resolve(
+    $page,
+    ':root { --a: #aabbcc; } .site-footer { color: var(--missing, var(--a)); }',
+    '//footer',
+    array( 'color' )
+);
+$assert('#aabbcc' === ( $result['color'] ?? '' ), 'var() fallback chains resolve through :root');
+
+// A rule gated on interaction state must not become a base-state rule. Source
+// order would otherwise let the hover declaration outrank the real base one.
+$hover = '.site-footer a { color: rgb(1, 1, 1); } .site-footer a:hover { color: rgb(9, 9, 9); }';
+$result = $resolve($page, $hover, '//footer//a', array( 'color' ));
+$assert('rgb(1, 1, 1)' === ( $result['color'] ?? '' ), ':hover does not override the base colour');
+
+foreach ( array( ':focus', ':focus-within', ':active', ':visited', ':target' ) as $state ) {
+    $css = ".site-footer a { color: rgb(1, 1, 1); } .site-footer a{$state} { color: rgb(9, 9, 9); }";
+    $result = $resolve($page, $css, '//footer//a', array( 'color' ));
+    $assert('rgb(1, 1, 1)' === ( $result['color'] ?? '' ), "{$state} does not override the base colour");
+}
+
+foreach ( array( '::before', ':before', '::after', '::placeholder', '::marker' ) as $pseudoElement ) {
+    $css = ".site-footer a { color: rgb(1, 1, 1); } .site-footer a{$pseudoElement} { color: rgb(9, 9, 9); }";
+    $result = $resolve($page, $css, '//footer//a', array( 'color' ));
+    $assert('rgb(1, 1, 1)' === ( $result['color'] ?? '' ), "{$pseudoElement} does not style the element itself");
+}
+
+// An ancestor gated on state must not reveal a descendant either: this is the
+// CSS-only mega-menu shape, where the panel is hidden until the item is hovered.
+$menu = '<html><body><div class="item"><div class="panel">p</div></div></body></html>';
+$menuCss = '.panel { visibility: hidden; } .item:hover .panel { visibility: visible; }';
+$result = $resolve($menu, $menuCss, '//div[@class="panel"]', array( 'visibility' ));
+$assert('hidden' === ( $result['visibility'] ?? '' ), 'a hover-gated ancestor does not reveal a hidden descendant');
+
+// @media is resolved against the desktop reference width rather than flattened.
+$narrow = '@media (max-width: 1080px) { .main-nav { display: none; } }';
+$result = $resolve($page, $narrow, '//nav', array( 'display' ));
+$assert(! isset($result['display']), 'a max-width block below the reference width does not apply');
+
+$wide = '@media (min-width: 768px) { .main-nav { display: flex; } }';
+$result = $resolve($page, $wide, '//nav', array( 'display' ));
+$assert('flex' === ( $result['display'] ?? '' ), 'a min-width block satisfied at the reference width applies');
+
+$result = $resolve($page, '@media print { .main-nav { display: none; } }', '//nav', array( 'display' ));
+$assert(! isset($result['display']), 'a non-visual media type does not apply');
+
+// Rules after a dropped block must survive: the block is brace-balanced, not
+// regex-unwrapped, so the rule following it is still parsed.
+$following = '@media (max-width: 600px) { .main-nav { display: none; } } .site-footer { color: rgb(7, 7, 7); }';
+$result = $resolve($page, $following, '//footer', array( 'color' ));
+$assert('rgb(7, 7, 7)' === ( $result['color'] ?? '' ), 'a rule following a dropped @media block still parses');
+
+$result = $resolve($page, '@supports (display: grid) { .site-footer { color: rgb(8, 8, 8); } }', '//footer', array( 'color' ));
+$assert('rgb(8, 8, 8)' === ( $result['color'] ?? '' ), '@supports rules still declare effective style');
+
+// Inheritance still comes from the nearest declaring ancestor, and only once the
+// ancestor's own rule is actually matched.
+$inherited = "/* ─── Footer ─── */\n.site-footer { color: rgb(2, 4, 6); font-size: 0.92rem; }\n.col ul li a { font-size: 0.9rem; }";
+$result = $resolve($page, $inherited, '//footer//li', array( 'color', 'font-size' ), array( 'color', 'font-size' ));
+$assert('rgb(2, 4, 6)' === ( $result['color'] ?? '' ), 'a list item inherits colour from the footer, not the body default');
+$assert('0.92rem' === ( $result['font-size'] ?? '' ), 'a list item inherits font-size from the footer');
+
+$result = $resolve($page, $inherited, '//footer//a', array( 'font-size' ), array( 'font-size' ));
+$assert('0.9rem' === ( $result['font-size'] ?? '' ), 'a more specific descendant rule still wins over inheritance');
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, "StaticCssCascade unit tests: {$failures} failed, {$passes} passed\n");
+    exit(1);
+}
+fwrite(STDOUT, "StaticCssCascade unit tests: {$passes} passed\n");


### PR DESCRIPTION
Fixes #1369.

`StaticCssCascade` decides the **source** side of every static-parity comparison. A value it reports that a browser would never compute becomes a parity finding against a transformer that was correct — so the gate has been aiming fixture work at phantom targets.

Four defects, each reproducible in isolation and each covered by a new unit test.

## 1. Comments were never stripped

The flat `selector { declarations }` scan treats everything between the previous `}` and the next `{` as the selector, so this:

```css
/* ─── Footer ─── */
.site-footer { color: rgba(255,255,255,0.74); font-size: 0.92rem; }
```

parsed as a selector of `/* ─── Footer ─── */\n.site-footer`, which matches nothing. In `28-enterprise-b2b` that silently dropped **44 of 567 selectors**, and because it lands on the first rule after every comment it took the structural ones: `:root`, `*`, `h1`, `.container`, `.site-footer`.

This was the root cause of the footer drift. `.footer-col ul li a` parsed fine because no comment precedes it — which is exactly why footer *links* resolved correctly while the footer *itself* fell back to `body`.

## 2. `:root` matched no element

`:root` fell through every branch of `matchesSimpleSelector` and hit the `^[A-Za-z]` guard, so no custom property was ever collected. Every `var()` stayed literal on the source side while the candidate carried values the transformer had already resolved — literal-vs-resolved then reads as a mismatch.

## 3. Interaction state was rewritten into base state

`preg_replace('/:(hover|focus|active|visited|before|after)\b.*/', '', $selector)` deleted the pseudo-class and matched what was left, so `a:hover` became `a` and, being later in source order, outranked the real base declaration. The probe reported the hover colour as the base colour.

The same rewrite meant a hover-gated *ancestor* revealed hidden descendants — precisely the CSS-only mega-menu shape (`.item:hover .panel`), so panels the browser keeps hidden were resolved as visible.

Structural pseudo-classes (`:first-child`, `:nth-of-type()`, `:not()`) are deliberately **not** in the new list: they describe the resting document. They remain unsupported for other reasons and fail closed rather than being silently rewritten.

## 4. `@media` was flattened unconditionally

A `@media (max-width: 1080px) { .main-nav { display: none } }` rule declared `display: none` on the desktop nav in base state. Blocks are now resolved against the same **1440px** desktop reference the transformer uses, brace-balanced so a rule following a dropped block still parses. Conditions this resolver does not model (orientation, `prefers-*`, hover) are kept, degrading to the previous flattening rather than deleting author style. `@supports`/`@layer` still unwrap — they carry no viewport condition.

## Result on `28-enterprise-b2b`

The corpus's highest finding count:

| | before | after |
|---|---|---|
| score | 0.5022 | **0.5767** |
| property parity | 0.7825 | **0.8841** |
| coverage | 0.6418 | 0.6522 |
| findings | 683 | **484** |

By region: footer 227 → **88**, `main#main` 141 → **87**, header 172 → 165, mobile nav 124 → 125.

Footer `color` findings went **84 → 2**. Element coverage is essentially unchanged, which is the expected shape for a change that only corrects *declared values* and not element matching.

What remains in the footer now looks like genuine transformer loss rather than probe noise — 24 findings of `font-size 0.9rem → 0.92rem`, i.e. `.footer-col ul li a { font-size: 0.9rem }` not carried onto the candidate anchor. That is a real target, and it was invisible underneath the false positives.

## Verification

```
composer test:canonical   green (StaticCssCascade unit tests: 25 passed)
composer test:parity      289 fixtures passed
composer test:packaging   dist shape + install proof passed
```

The new `tests/unit/static-css-cascade.php` asserts each defect directly against `StaticCssCascade` rather than through a corpus score, including that a rule following a dropped `@media` block still parses and that a more specific descendant rule still beats inheritance.

This is dev-only code — it moved to `dev/` in #1366 and is export-ignored, so the released package is untouched.

---

*AI assistance disclosure: implemented by Claude Sonnet 4.6 running in Claude Code, operated by @chubes4. The AI traced the four defects from a per-region finding aggregation on `28-enterprise-b2b`, confirmed each with isolated cascade probes, made the change, wrote the unit tests, and ran the suites and re-baseline quoted above. Reviewed by a human before opening.*
