### PR TITLE
Extract authored form control block converter

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -153,6 +153,7 @@
             "php tests/unit/rich-text-element-converter.php",
             "php tests/unit/table-element-converter.php",
             "php tests/unit/unsupported-element-recorder.php",
+            "php tests/unit/authored-form-control-block-converter.php",
             "php tests/unit/form-runtime-requirement-analyzer.php",
             "php tests/unit/form-success-panel-metadata-builder.php",
             "php tests/unit/pseudo-form-analyzer.php",

--- a/php-transformer/src/HtmlToBlocks/Elements/AuthoredFormControlBlockConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/AuthoredFormControlBlockConverter.php
@@ -1,0 +1,158 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredInputBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredSelectBlockGenerator;
+use Closure;
+use DOMElement;
+
+/** Converts native input and select controls into editable block representations. */
+final class AuthoredFormControlBlockConverter
+{
+    /**
+     * @param Closure(DOMElement): array<string, mixed>                                                     $structuralPresentationDeclarations
+     * @param Closure(DOMElement): array<string, mixed>                                                     $presentationAttributes
+     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
+     * @param Closure(class-string, array<string, mixed>): void                                             $registerGeneratedBlock
+     * @param Closure(string): void                                                                         $registerEcho
+     * @param Closure(string): string                                                                       $escapeHtml
+     * @param Closure(string): string                                                                       $safeAnchor
+     */
+    public function __construct(
+        private readonly FormControlMetadataBuilder $metadataBuilder,
+        private readonly Closure $structuralPresentationDeclarations,
+        private readonly Closure $presentationAttributes,
+        private readonly Closure $createBlock,
+        private readonly Closure $registerGeneratedBlock,
+        private readonly Closure $registerEcho,
+        private readonly Closure $escapeHtml,
+        private readonly Closure $safeAnchor
+    ) {
+    }
+
+    /** @return array<string, mixed>|null */
+    public function select(DOMElement $select): ?array
+    {
+        $label = $this->metadataBuilder->readableLabel($select);
+        ($this->registerEcho)($label);
+        $options = $this->metadataBuilder->options($select);
+        if ( array() === $options ) {
+            return null;
+        }
+
+        // Class/id presence alone does not justify a generated native block;
+        // require authored presentation proven by the resolved cascade.
+        if ( array() === ($this->structuralPresentationDeclarations)($select) ) {
+            $optionBlocks = array();
+            foreach ( $options as $option ) {
+                $optionLabel = trim((string) ($option['label'] ?? ''));
+                if ( '' === $optionLabel ) {
+                    continue;
+                }
+                if ( true === ($option['selected'] ?? false) ) {
+                    $optionLabel .= ' (selected)';
+                }
+                ($this->registerEcho)($optionLabel);
+                $optionBlocks[] = ($this->createBlock)('core/list-item', array( 'content' => ($this->escapeHtml)($optionLabel) ), array(), null);
+            }
+
+            return ($this->createBlock)('core/group', ($this->presentationAttributes)($select), array(
+                ($this->createBlock)('core/paragraph', array( 'content' => ($this->escapeHtml)($label) ), array(), $select),
+                ($this->createBlock)('core/list', array(), $optionBlocks, $select),
+            ), $select);
+        }
+
+        $generator = new AuthoredSelectBlockGenerator();
+        ($this->registerGeneratedBlock)(AuthoredSelectBlockGenerator::class, $generator->definition());
+        $attrs = array_filter(array(
+            'id' => $this->attr($select, 'id'),
+            'name' => $this->attr($select, 'name'),
+            'ariaLabel' => $this->attr($select, 'aria-label'),
+            'placeholder' => $this->attr($select, 'placeholder'),
+            'className' => $this->attr($select, 'class'),
+            'style' => $this->attr($select, 'style'),
+            'options' => $options,
+            'selectedSummary' => $this->selectedOptionSummary($options),
+        ), static fn (mixed $value): bool => is_array($value) ? array() !== $value : '' !== $value);
+        $markup = $generator->markup($attrs);
+        $controlBlock = array(
+            'blockName' => AuthoredSelectBlockGenerator::NAME,
+            'attrs' => $attrs,
+            'innerBlocks' => array(),
+            'innerHTML' => $markup,
+            'innerContent' => array( $markup ),
+        );
+
+        // Preserve the established structural address while source identity and
+        // authored selectors remain on the native control inside this shell.
+        return ($this->createBlock)('core/group', array_filter(array(
+            'anchor' => ($this->safeAnchor)($this->attr($select, 'id')),
+            'className' => 'blocks-engine-authored-select-wrapper',
+        )), array( $controlBlock ), null);
+    }
+
+    /**
+     * Return a compact native input only when the resolved cascade proves
+     * authored presentation that a readable paragraph cannot retain.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function input(DOMElement $input): ?array
+    {
+        if ( array() === ($this->structuralPresentationDeclarations)($input) ) {
+            return null;
+        }
+
+        $generator = new AuthoredInputBlockGenerator();
+        ($this->registerGeneratedBlock)(AuthoredInputBlockGenerator::class, $generator->definition());
+        $attrs = array_filter(array(
+            'type' => FormControlClassifier::controlType($input),
+            'id' => $this->attr($input, 'id'),
+            'name' => $this->attr($input, 'name'),
+            'value' => $this->attr($input, 'value'),
+            'placeholder' => $this->attr($input, 'placeholder'),
+            'ariaLabel' => $this->attr($input, 'aria-label'),
+            'className' => $this->attr($input, 'class'),
+            'style' => $this->attr($input, 'style'),
+            'min' => $this->attr($input, 'min'),
+            'max' => $this->attr($input, 'max'),
+            'step' => $this->attr($input, 'step'),
+            'required' => $input->hasAttribute('required'),
+            'disabled' => $input->hasAttribute('disabled'),
+            'readOnly' => $input->hasAttribute('readonly'),
+            'checked' => $input->hasAttribute('checked'),
+        ), static fn (mixed $value): bool => is_bool($value) ? $value : '' !== $value);
+        $markup = $generator->markup($attrs);
+
+        return array(
+            'blockName' => AuthoredInputBlockGenerator::NAME,
+            'attrs' => $attrs,
+            'innerBlocks' => array(),
+            'innerHTML' => $markup,
+            'innerContent' => array( $markup ),
+        );
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $options
+     */
+    private function selectedOptionSummary(array $options): string
+    {
+        $selected = array();
+        foreach ( $options as $option ) {
+            if ( ! empty($option['selected']) && '' !== trim((string) ($option['label'] ?? '')) ) {
+                $selected[] = (string) $option['label'];
+            }
+        }
+
+        return array() === $selected ? '' : implode(', ', $selected) . ' (selected)';
+    }
+
+    private function attr(DOMElement $element, string $name): string
+    {
+        return $element->hasAttribute($name) ? $element->getAttribute($name) : '';
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -33,6 +33,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolutionCon
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolver;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispatchContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispatcher;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\AuthoredFormControlBlockConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormControlMetadataBuilder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormRuntimeRequirementAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormSuccessPanelMetadataBuilder;
@@ -267,6 +268,8 @@ final class HtmlTransformer
 
     private readonly FormControlMetadataBuilder $formControlMetadataBuilder;
 
+    private readonly AuthoredFormControlBlockConverter $authoredFormControlBlockConverter;
+
     private readonly PseudoFormAnalyzer $pseudoFormAnalyzer;
 
     private readonly FormRuntimeRequirementAnalyzer $formRuntimeRequirementAnalyzer;
@@ -412,6 +415,20 @@ final class HtmlTransformer
             $this->runtime
         );
         $this->formControlMetadataBuilder = new FormControlMetadataBuilder(fn (DOMElement $element): string => $this->elementSelector($element));
+        $this->authoredFormControlBlockConverter = new AuthoredFormControlBlockConverter(
+            $this->formControlMetadataBuilder,
+            fn (DOMElement $element): array => $this->styleResolver->structuralPresentationDeclarations($element),
+            fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
+            fn (string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
+            function (string $identity, array $definition): void {
+                $this->generatedBlocks()->register($identity, $definition);
+            },
+            function (string $text): void {
+                $this->registerFormControlEcho($text);
+            },
+            fn (string $text): string => $this->runtime->escapeHtml($text),
+            fn (string $id): string => $this->safeAnchor($id)
+        );
         $this->pseudoFormAnalyzer = new PseudoFormAnalyzer($this->formControlMetadataBuilder, fn (DOMElement $element): string => $this->elementSelector($element));
         $this->runtimeIslands = new RuntimeIslandAnalyzer($this->createRuntimeIslandContext(), $this->pseudoFormAnalyzer);
         $this->formRuntimeRequirementAnalyzer = new FormRuntimeRequirementAnalyzer(

--- a/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredInputBlockGenerator;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredSelectBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackDiagnostic;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\FormControlTopologyBuilder;
@@ -270,14 +269,14 @@ trait FormDispatchTrait
         }
 
         if ( 'select' === $tagName ) {
-            $selectBlock = $this->readableSelectBlockFromElement($element);
+            $selectBlock = $this->authoredFormControlBlockConverter->select($element);
             if ( null !== $selectBlock ) {
                 return $selectBlock;
             }
         }
 
         if ( 'input' === $tagName ) {
-            $inputBlock = $this->readableInputBlockFromElement($element);
+            $inputBlock = $this->authoredFormControlBlockConverter->input($element);
             if ( null !== $inputBlock ) {
                 return $inputBlock;
             }
@@ -328,124 +327,6 @@ trait FormDispatchTrait
         ));
 
         return true;
-    }
-
-    /**
-     * @return array<string, mixed>|null
-     */
-    private function readableSelectBlockFromElement(DOMElement $select): ?array
-    {
-        $label = $this->formControlMetadataBuilder->readableLabel($select);
-        $this->registerFormControlEcho($label);
-        $options = $this->formControlMetadataBuilder->options($select);
-        if ( array() === $options ) {
-            return null;
-        }
-        // Form controls are below the general high-value style boundary, so use
-        // the selector-resolved author cascade directly as the representation
-        // gate. Class/id presence alone is never sufficient.
-        if ( array() === $this->styleResolver->structuralPresentationDeclarations($select) ) {
-            $optionBlocks = array();
-            foreach ( $options as $option ) {
-                $optionLabel = trim((string) ($option['label'] ?? ''));
-                if ( '' === $optionLabel ) {
-                    continue;
-                }
-                if ( true === ($option['selected'] ?? false) ) {
-                    $optionLabel .= ' (selected)';
-                }
-                $this->registerFormControlEcho($optionLabel);
-                $optionBlocks[] = $this->createBlock('core/list-item', array( 'content' => $this->runtime->escapeHtml($optionLabel) ));
-            }
-
-            return $this->createBlock('core/group', $this->styleResolver->presentationAttributes($select), array(
-                $this->createBlock('core/paragraph', array( 'content' => $this->runtime->escapeHtml($label) ), array(), $select),
-                $this->createBlock('core/list', array(), $optionBlocks, $select),
-            ), $select);
-        }
-        $this->generatedBlocks()->register(AuthoredSelectBlockGenerator::class, ( new AuthoredSelectBlockGenerator() )->definition());
-        $attrs = array_filter(array(
-            'id' => $this->attr($select, 'id'),
-            'name' => $this->attr($select, 'name'),
-            'ariaLabel' => $this->attr($select, 'aria-label'),
-            'placeholder' => $this->attr($select, 'placeholder'),
-            'className' => $this->attr($select, 'class'),
-            'style' => $this->attr($select, 'style'),
-            'options' => $options,
-            'selectedSummary' => $this->selectedOptionSummary($options),
-        ), static fn (mixed $value): bool => is_array($value) ? array() !== $value : '' !== $value);
-        $markup = ( new AuthoredSelectBlockGenerator() )->markup($attrs);
-        $controlBlock = array(
-            'blockName' => AuthoredSelectBlockGenerator::NAME,
-            'attrs' => $attrs,
-            'innerBlocks' => array(),
-            'innerHTML' => $markup,
-            'innerContent' => array( $markup ),
-        );
-
-        // Keep the long-standing group/anchor contract for callers that address
-        // the converted field structurally. Source identity lives on the native
-        // control, so authored select selectors never style this transparent shell.
-        return $this->createBlock('core/group', array_filter(array(
-            'anchor' => $this->safeAnchor($this->attr($select, 'id')),
-            'className' => 'blocks-engine-authored-select-wrapper',
-        )), array( $controlBlock ));
-    }
-
-    /**
-     * Return a compact native input only when authored presentation is proven by
-     * the resolved CSS cascade. The direct save shape preserves flex-child and
-     * selector semantics that a readable paragraph cannot represent.
-     *
-     * @return array<string, mixed>|null
-     */
-    private function readableInputBlockFromElement(DOMElement $input): ?array
-    {
-        if ( array() === $this->styleResolver->structuralPresentationDeclarations($input) ) {
-            return null;
-        }
-        $this->generatedBlocks()->register(AuthoredInputBlockGenerator::class, ( new AuthoredInputBlockGenerator() )->definition());
-        $attrs = array_filter(array(
-            'type' => FormControlClassifier::controlType($input),
-            'id' => $this->attr($input, 'id'),
-            'name' => $this->attr($input, 'name'),
-            'value' => $this->attr($input, 'value'),
-            'placeholder' => $this->attr($input, 'placeholder'),
-            'ariaLabel' => $this->attr($input, 'aria-label'),
-            'className' => $this->attr($input, 'class'),
-            'style' => $this->attr($input, 'style'),
-            'min' => $this->attr($input, 'min'),
-            'max' => $this->attr($input, 'max'),
-            'step' => $this->attr($input, 'step'),
-            'required' => $input->hasAttribute('required'),
-            'disabled' => $input->hasAttribute('disabled'),
-            'readOnly' => $input->hasAttribute('readonly'),
-            'checked' => $input->hasAttribute('checked'),
-        ), static fn (mixed $value): bool => is_bool($value) ? $value : '' !== $value);
-        $markup = ( new AuthoredInputBlockGenerator() )->markup($attrs);
-
-        return array(
-            'blockName' => AuthoredInputBlockGenerator::NAME,
-            'attrs' => $attrs,
-            'innerBlocks' => array(),
-            'innerHTML' => $markup,
-            'innerContent' => array( $markup ),
-        );
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $options
-     */
-    private function selectedOptionSummary(array $options): string
-    {
-        $selected = array();
-        foreach ( $options as $option ) {
-            if ( ! empty($option['selected']) && '' !== trim((string) ($option['label'] ?? '')) ) {
-                $selected[] = (string) $option['label'];
-            }
-        }
-
-        return array() === $selected ? '' : implode(', ', $selected) . ' (selected)';
     }
 
     /**

--- a/php-transformer/tests/unit/authored-form-control-block-converter.php
+++ b/php-transformer/tests/unit/authored-form-control-block-converter.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\AuthoredFormControlBlockConverter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormControlMetadataBuilder;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredInputBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredSelectBlockGenerator;
+
+$assertions = 0;
+$failures = array();
+$assert = static function (bool $condition, string $label) use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']';
+    }
+};
+
+$elementFrom = static function (string $html, string $tagName): DOMElement {
+    $document = new DOMDocument();
+    $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+    $element = $document->getElementsByTagName($tagName)->item(0);
+    if ( $element instanceof DOMElement ) {
+        return $element;
+    }
+    throw new RuntimeException('No ' . $tagName . ' parsed');
+};
+
+$registered = array();
+$echoes = array();
+$metadataBuilder = new FormControlMetadataBuilder(static fn (DOMElement $element): string => strtolower($element->tagName));
+$converter = new AuthoredFormControlBlockConverter(
+    $metadataBuilder,
+    static fn (DOMElement $element): array => $element->hasAttribute('data-styled') ? array( 'display' => 'block' ) : array(),
+    static fn (DOMElement $element): array => array( 'className' => 'presented' ),
+    static fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => array(
+        'blockName' => $name,
+        'attrs' => $attrs,
+        'innerBlocks' => $innerBlocks,
+    ),
+    static function (string $identity, array $definition) use (&$registered): void {
+        $registered[$identity] = $definition;
+    },
+    static function (string $text) use (&$echoes): void {
+        $echoes[] = $text;
+    },
+    static fn (string $text): string => htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+    static fn (string $id): string => 'safe-' . $id
+);
+
+$plainInput = $elementFrom('<input name="email">', 'input');
+$assert(null === $converter->input($plainInput), 'unstyled-input-declines-authored-block');
+$assert(array() === $registered, 'unstyled-input-registers-no-generated-block');
+
+$styledInput = $elementFrom('<input data-styled type="range" id="volume" value="4" min="1" max="9" step="2" required>', 'input');
+$inputBlock = $converter->input($styledInput);
+$assert(AuthoredInputBlockGenerator::NAME === ($inputBlock['blockName'] ?? ''), 'styled-input-uses-authored-input-block');
+$assert('range' === ($inputBlock['attrs']['type'] ?? '') && true === ($inputBlock['attrs']['required'] ?? false), 'styled-input-retains-type-and-boolean-attributes');
+$assert('<input type="range" id="volume" value="4" min="1" max="9" step="2" required>' === ($inputBlock['innerHTML'] ?? ''), 'styled-input-emits-native-markup');
+$assert(isset($registered[AuthoredInputBlockGenerator::class]), 'styled-input-registers-generated-definition');
+
+$echoes = array();
+$plainSelect = $elementFrom('<select aria-label="Plan"><option value="basic">Basic</option><option selected>Pro &amp; Plus</option></select>', 'select');
+$selectFallback = $converter->select($plainSelect);
+$assert('core/group' === ($selectFallback['blockName'] ?? ''), 'unstyled-select-uses-readable-group');
+$assert('presented' === ($selectFallback['attrs']['className'] ?? ''), 'unstyled-select-retains-presentation-attributes');
+$assert('Plan' === ($selectFallback['innerBlocks'][0]['attrs']['content'] ?? ''), 'unstyled-select-emits-readable-label');
+$assert('Pro &amp; Plus (selected)' === ($selectFallback['innerBlocks'][1]['innerBlocks'][1]['attrs']['content'] ?? ''), 'unstyled-select-marks-and-escapes-selected-option');
+$assert(array( 'Plan', 'Basic', 'Pro & Plus (selected)' ) === $echoes, 'unstyled-select-registers-round-trip-echoes');
+
+$echoes = array();
+$styledSelect = $elementFrom('<select data-styled id="plan" name="plan"><option value="basic">Basic</option><option value="pro" selected>Pro</option></select>', 'select');
+$selectBlock = $converter->select($styledSelect);
+$authoredSelect = $selectBlock['innerBlocks'][0] ?? array();
+$assert('safe-plan' === ($selectBlock['attrs']['anchor'] ?? ''), 'styled-select-retains-wrapper-anchor-contract');
+$assert(AuthoredSelectBlockGenerator::NAME === ($authoredSelect['blockName'] ?? ''), 'styled-select-uses-authored-select-block');
+$assert('Pro (selected)' === ($authoredSelect['attrs']['selectedSummary'] ?? ''), 'styled-select-retains-selected-summary');
+$assert(str_contains((string) ($authoredSelect['innerHTML'] ?? ''), '<option value="pro" selected>Pro</option>'), 'styled-select-emits-native-option-markup');
+$assert(isset($registered[AuthoredSelectBlockGenerator::class]), 'styled-select-registers-generated-definition');
+$assert(array( 'plan' ) === $echoes, 'styled-select-registers-only-label-echo');
+
+$echoes = array();
+$emptySelect = $elementFrom('<select></select>', 'select');
+$assert(null === $converter->select($emptySelect), 'select-without-options-declines-block');
+$assert(array( 'Select option' ) === $echoes, 'select-without-options-still-registers-label-echo');
+
+if ( $failures ) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Authored form control block converter tests: ' . $assertions . " passed\n";


### PR DESCRIPTION
## Summary
- extract input/select representation policy into `AuthoredFormControlBlockConverter`
- keep runtime-target, label association, and readable-form orchestration in `FormDispatchTrait`
- preserve resolved-cascade gating, readable select fallbacks, generated native blocks, selected summaries, wrapper anchors, and round-trip echoes through explicit callbacks
- reduce `FormDispatchTrait` from 607 to 488 lines
- add a 19-assertion direct converter contract

## Verification
- `composer test`
- PHP transformer parity: 289 fixtures
- distribution shape: 200 files, 10 monorepo-only trees excluded
- exact-base CSS-attached corpus comparison: byte-identical records for 383 documents / 87 fixtures / 82 fixtures with CSS / 0 throws

Part of #242.

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to inspect the existing form-control conversion policy, implement the collaborator extraction and direct contract, and run the package suite and exact-base corpus comparison.