### PR TITLE
Extract form runtime island recorder

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -155,6 +155,7 @@
             "php tests/unit/table-element-converter.php",
             "php tests/unit/unsupported-element-recorder.php",
             "php tests/unit/authored-form-control-block-converter.php",
+            "php tests/unit/form-runtime-island-recorder.php",
             "php tests/unit/form-runtime-requirement-analyzer.php",
             "php tests/unit/form-success-panel-metadata-builder.php",
             "php tests/unit/pseudo-form-analyzer.php",

--- a/php-transformer/src/HtmlToBlocks/Elements/FormRuntimeIslandRecorder.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FormRuntimeIslandRecorder.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Closure;
+use DOMElement;
+
+/** Records the runtime contracts required by forms and standalone controls. */
+final class FormRuntimeIslandRecorder
+{
+    /**
+     * @param Closure(DOMElement, string, string, string, array<string, mixed>): void $recordRuntimeIsland
+     * @param Closure(DOMElement): array<string, mixed>                                $eventMetadata
+     * @param Closure(DOMElement): array<int, array<string, mixed>>                    $requiredScriptsForElement
+     */
+    public function __construct(
+        private readonly FormControlMetadataBuilder $metadataBuilder,
+        private readonly Closure $recordRuntimeIsland,
+        private readonly Closure $eventMetadata,
+        private readonly Closure $requiredScriptsForElement
+    ) {
+    }
+
+    /** @param array<string, mixed>|null $readableFormBlock */
+    public function recordForm(DOMElement $element, ?array $readableFormBlock): void
+    {
+        $controls = $this->metadataBuilder->controls($element);
+        ($this->recordRuntimeIsland)($element, 'form', 'form_requires_runtime', 'server_or_client_form_handler', array(
+            'form'             => $this->metadataBuilder->form($element),
+            'controls'         => $controls,
+            'control_count'    => count($controls),
+            'events'           => ($this->eventMetadata)($element),
+            'readable_blocks'  => null !== $readableFormBlock ? array( $readableFormBlock ) : array(),
+            'required_scripts' => ($this->requiredScriptsForElement)($element),
+        ));
+    }
+
+    public function recordControl(DOMElement $element): void
+    {
+        ($this->recordRuntimeIsland)($element, 'control', 'runtime_dom_target', 'client_script_execution', $this->controlMetadata($element));
+    }
+
+    /**
+     * Preserve a standalone control whose behavior depends on a client runtime
+     * rather than emitting an unsupported-element loss.
+     */
+    public function preserveStandaloneControl(DOMElement $element): bool
+    {
+        if ( ! in_array(strtolower($element->tagName), array( 'input', 'select', 'textarea' ), true) ) {
+            return false;
+        }
+
+        ($this->recordRuntimeIsland)($element, 'control', 'form_control_requires_runtime', 'client_form_control_runtime', $this->controlMetadata($element));
+        return true;
+    }
+
+    /** @return array<string, mixed> */
+    private function controlMetadata(DOMElement $element): array
+    {
+        return array(
+            'control'          => $this->metadataBuilder->control($element),
+            'events'           => ($this->eventMetadata)($element),
+            'required_scripts' => ($this->requiredScriptsForElement)($element),
+        );
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -36,6 +36,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispa
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\AuthoredFormControlBlockConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormControlMetadataBuilder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormRuntimeRequirementAnalyzer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormRuntimeIslandRecorder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormSuccessPanelMetadataBuilder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\PseudoFormAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandAnalyzer;
@@ -266,6 +267,8 @@ final class HtmlTransformer
 
     private readonly RuntimeIslandAnalyzer $runtimeIslands;
 
+    private readonly FormRuntimeIslandRecorder $formRuntimeIslandRecorder;
+
     private readonly FormControlMetadataBuilder $formControlMetadataBuilder;
 
     private readonly AuthoredFormControlBlockConverter $authoredFormControlBlockConverter;
@@ -431,6 +434,14 @@ final class HtmlTransformer
         );
         $this->pseudoFormAnalyzer = new PseudoFormAnalyzer($this->formControlMetadataBuilder, fn (DOMElement $element): string => $this->elementSelector($element));
         $this->runtimeIslands = new RuntimeIslandAnalyzer($this->createRuntimeIslandContext(), $this->pseudoFormAnalyzer);
+        $this->formRuntimeIslandRecorder = new FormRuntimeIslandRecorder(
+            $this->formControlMetadataBuilder,
+            function (DOMElement $element, string $kind, string $reason, string $capability, array $metadata): void {
+                $this->runtimeIslands->recordRuntimeIsland($element, $kind, $reason, $capability, $metadata);
+            },
+            fn (DOMElement $element): array => $this->eventMetadata($element),
+            fn (DOMElement $element): array => $this->requiredScriptsForElement($element)
+        );
         $this->formRuntimeRequirementAnalyzer = new FormRuntimeRequirementAnalyzer(
             fn (DOMElement $element): array => $this->eventMetadata($element),
             fn (DOMElement $element): bool => $this->runtimeIslands->isRuntimeDomTarget($element)
@@ -617,7 +628,7 @@ final class HtmlTransformer
         return new ButtonLinkDispatchContext(
             fn (DOMElement $element): bool => $this->runtimeIslands->isRuntimeDomTarget($element),
             function (DOMElement $element): void {
-                $this->recordRuntimeControlIsland($element);
+                $this->formRuntimeIslandRecorder->recordControl($element);
             },
             fn (DOMElement $element): array => $this->htmlPreservationBlock($element),
             function (DOMElement $element, array &$fallbacks, array $patterns): ?array {
@@ -4018,7 +4029,7 @@ if ( 'svg' === $tagName ) {
             return $readableControlBlock;
         }
 
-        if ( $this->preserveStandaloneFormControlAsRuntimeIsland($element) ) {
+        if ( $this->formRuntimeIslandRecorder->preserveStandaloneControl($element) ) {
             return null;
         }
 

--- a/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
@@ -28,7 +28,7 @@ trait FormDispatchTrait
             $composition = $this->compositionalFormBlock($element, $fallbacks);
             if ( null !== $composition ) {
                 $fallbacks[] = $this->formFallbackFinding($element, $composition['block'], $composition['slot']);
-                $this->recordFormRuntimeIsland($element, $composition['block']);
+                $this->formRuntimeIslandRecorder->recordForm($element, $composition['block']);
                 return $composition['block'];
             }
         }
@@ -45,13 +45,13 @@ trait FormDispatchTrait
         if ( FormControlClassifier::hasDataEntryControls($element) ) {
             $preservationBlock = $this->htmlPreservationBlock($element);
             $fallbacks[] = $this->formFallbackFinding($element, $readableFormBlock, $preservationBlock);
-            $this->recordFormRuntimeIsland($element, $readableFormBlock);
+            $this->formRuntimeIslandRecorder->recordForm($element, $readableFormBlock);
 
             return $preservationBlock;
         }
 
         $readableFormBlock = $this->readableFormBlockFromForm($element, true);
-        $this->recordFormRuntimeIsland($element, $readableFormBlock);
+        $this->formRuntimeIslandRecorder->recordForm($element, $readableFormBlock);
 
         // Surface a form fallback finding so a downstream consumer can map the
         // preserved control structure onto a working form provider.
@@ -72,22 +72,6 @@ trait FormDispatchTrait
         if ( $this->pseudoFormAnalyzer->isPseudoForm($element) ) {
             $fallbacks[] = $this->formFallbackFinding($element, $this->readableFormBlockFromForm($element, true));
         }
-    }
-
-    /**
-     * @param array<string, mixed>|null $readableFormBlock
-     */
-    private function recordFormRuntimeIsland(DOMElement $element, ?array $readableFormBlock): void
-    {
-        $controls = $this->formControlMetadataBuilder->controls($element);
-        $this->runtimeIslands->recordRuntimeIsland($element, 'form', 'form_requires_runtime', 'server_or_client_form_handler', array(
-            'form'             => $this->formControlMetadataBuilder->form($element),
-            'controls'         => $controls,
-            'control_count'    => count($controls),
-            'events'           => $this->eventMetadata($element),
-            'readable_blocks'  => null !== $readableFormBlock ? array( $readableFormBlock ) : array(),
-            'required_scripts' => $this->requiredScriptsForElement($element),
-        ));
     }
 
     /**
@@ -114,11 +98,7 @@ trait FormDispatchTrait
             }
 
             if ( $this->runtimeIslands->isRuntimeDomTarget($control) ) {
-                $this->runtimeIslands->recordRuntimeIsland($control, 'control', 'runtime_dom_target', 'client_script_execution', array(
-                    'control'          => $this->formControlMetadataBuilder->control($control),
-                    'events'           => $this->eventMetadata($control),
-                    'required_scripts' => $this->requiredScriptsForElement($control),
-                ));
+                $this->formRuntimeIslandRecorder->recordControl($control);
             }
 
             $readableControlBlock = $this->readableFormControlBlockFromElement($control);
@@ -229,7 +209,7 @@ trait FormDispatchTrait
                     }
 
                     if ( $this->runtimeIslands->isRuntimeDomTarget($control) ) {
-                        $this->recordRuntimeControlIsland($control);
+                        $this->formRuntimeIslandRecorder->recordControl($control);
                         return $this->htmlPreservationBlock($element);
                     }
 
@@ -271,7 +251,7 @@ trait FormDispatchTrait
         }
 
         if ( $this->runtimeIslands->isRuntimeDomTarget($element) ) {
-            $this->recordRuntimeControlIsland($element);
+            $this->formRuntimeIslandRecorder->recordControl($element);
             return $this->htmlPreservationBlock($element);
         }
 
@@ -295,45 +275,6 @@ trait FormDispatchTrait
         }
 
         return $this->createBlock('core/paragraph', array_merge($this->styleResolver->presentationAttributes($element), array( 'content' => $summary )), array(), $element);
-    }
-
-    private function recordRuntimeControlIsland(DOMElement $element): void
-    {
-        $this->runtimeIslands->recordRuntimeIsland($element, 'control', 'runtime_dom_target', 'client_script_execution', array(
-            'control'          => $this->formControlMetadataBuilder->control($element),
-            'events'           => $this->eventMetadata($element),
-            'required_scripts' => $this->requiredScriptsForElement($element),
-        ));
-    }
-
-    /**
-     * Preserve a standalone form control that has no faithful native block or
-     * readable static approximation as a bounded runtime island instead of an
-     * unsupported-element loss.
-     *
-     * Reached only after the readable-control and search paths decline, so the
-     * control is one whose behavior depends on a client runtime: file/hidden/
-     * color/date-style inputs core blocks cannot represent, or any control
-     * carrying inline event handlers. The source markup is carried in the
-     * island snippet so the behavior can be re-attached, and no misleading
-     * static text is emitted for controls (often hidden) that have no visual
-     * representation. This yields a `preserved_runtime_island` outcome rather
-     * than an `unsupported_element_loss`.
-     */
-    private function preserveStandaloneFormControlAsRuntimeIsland(DOMElement $element): bool
-    {
-        $tagName = strtolower($element->tagName);
-        if ( ! in_array($tagName, array( 'input', 'select', 'textarea' ), true) ) {
-            return false;
-        }
-
-        $this->runtimeIslands->recordRuntimeIsland($element, 'control', 'form_control_requires_runtime', 'client_form_control_runtime', array(
-            'control'          => $this->formControlMetadataBuilder->control($element),
-            'events'           => $this->eventMetadata($element),
-            'required_scripts' => $this->requiredScriptsForElement($element),
-        ));
-
-        return true;
     }
 
     /**

--- a/php-transformer/tests/unit/form-runtime-island-recorder.php
+++ b/php-transformer/tests/unit/form-runtime-island-recorder.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormControlMetadataBuilder;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormRuntimeIslandRecorder;
+
+$assertions = 0;
+$failures = array();
+$assert = static function (bool $condition, string $label) use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']';
+    }
+};
+
+$elementFrom = static function (string $html, string $tagName): DOMElement {
+    $document = new DOMDocument();
+    $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+    $element = $document->getElementsByTagName($tagName)->item(0);
+    if ( $element instanceof DOMElement ) {
+        return $element;
+    }
+    throw new RuntimeException('No ' . $tagName . ' parsed');
+};
+
+$recorded = array();
+$metadataBuilder = new FormControlMetadataBuilder(static function (DOMElement $element): string {
+    $id = $element->getAttribute('id');
+    return '' !== $id ? '#' . $id : strtolower($element->tagName);
+});
+$recorder = new FormRuntimeIslandRecorder(
+    $metadataBuilder,
+    static function (DOMElement $element, string $kind, string $reason, string $capability, array $metadata) use (&$recorded): void {
+        $recorded[] = compact('element', 'kind', 'reason', 'capability', 'metadata');
+    },
+    static fn (DOMElement $element): array => $element->hasAttribute('data-event') ? array( 'submit' => 'handle' ) : array(),
+    static fn (DOMElement $element): array => $element->hasAttribute('data-script') ? array( array( 'src' => '/form.js' ) ) : array()
+);
+
+$form = $elementFrom('<form id="signup" action="/join" data-event data-script><input name="email" required><select name="plan"><option>Free</option></select></form>', 'form');
+$readableBlock = array( 'blockName' => 'core/group' );
+$recorder->recordForm($form, $readableBlock);
+$formRecord = $recorded[0] ?? array();
+$formMetadata = $formRecord['metadata'] ?? array();
+$assert('form' === ($formRecord['kind'] ?? ''), 'form-kind');
+$assert('form_requires_runtime' === ($formRecord['reason'] ?? ''), 'form-reason');
+$assert('server_or_client_form_handler' === ($formRecord['capability'] ?? ''), 'form-capability');
+$assert('signup' === ($formMetadata['form']['id'] ?? '') && '/join' === ($formMetadata['form']['action'] ?? ''), 'form-metadata');
+$assert(2 === ($formMetadata['control_count'] ?? 0) && 2 === count($formMetadata['controls'] ?? array()), 'form-control-count');
+$assert('email' === ($formMetadata['controls'][0]['name'] ?? '') && true === ($formMetadata['controls'][0]['required'] ?? false), 'form-control-metadata');
+$assert(array( 'submit' => 'handle' ) === ($formMetadata['events'] ?? array()), 'form-events');
+$assert(array( $readableBlock ) === ($formMetadata['readable_blocks'] ?? array()), 'form-readable-block');
+$assert(array( array( 'src' => '/form.js' ) ) === ($formMetadata['required_scripts'] ?? array()), 'form-required-scripts');
+
+$recorder->recordForm($form, null);
+$assert(array() === ($recorded[1]['metadata']['readable_blocks'] ?? null), 'form-without-readable-block');
+
+$control = $elementFrom('<input id="runtime-email" name="email" data-event data-script>', 'input');
+$recorder->recordControl($control);
+$controlRecord = $recorded[2] ?? array();
+$controlMetadata = $controlRecord['metadata'] ?? array();
+$assert('control' === ($controlRecord['kind'] ?? '') && 'runtime_dom_target' === ($controlRecord['reason'] ?? ''), 'runtime-control-classification');
+$assert('client_script_execution' === ($controlRecord['capability'] ?? ''), 'runtime-control-capability');
+$assert('#runtime-email' === ($controlMetadata['control']['selector'] ?? '') && 'email' === ($controlMetadata['control']['name'] ?? ''), 'runtime-control-metadata');
+$assert(array( 'submit' => 'handle' ) === ($controlMetadata['events'] ?? array()), 'runtime-control-events');
+$assert(array( array( 'src' => '/form.js' ) ) === ($controlMetadata['required_scripts'] ?? array()), 'runtime-control-scripts');
+
+$nonControl = $elementFrom('<div data-event></div>', 'div');
+$assert(! $recorder->preserveStandaloneControl($nonControl) && 3 === count($recorded), 'non-control-is-not-preserved');
+
+$standalone = $elementFrom('<textarea name="message" data-event></textarea>', 'textarea');
+$assert($recorder->preserveStandaloneControl($standalone), 'standalone-control-is-preserved');
+$standaloneRecord = $recorded[3] ?? array();
+$assert('form_control_requires_runtime' === ($standaloneRecord['reason'] ?? ''), 'standalone-control-reason');
+$assert('client_form_control_runtime' === ($standaloneRecord['capability'] ?? ''), 'standalone-control-capability');
+
+if ( $failures ) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Form runtime island recorder tests: ' . $assertions . " passed\n";


### PR DESCRIPTION
## Summary
- extract form, runtime-target control, and standalone-control island recording into `FormRuntimeIslandRecorder`
- centralize control metadata, event metadata, required scripts, and runtime capability classification behind three explicit operations
- route form dispatch, readable controls, button dispatch, and standalone-control preservation through the typed collaborator
- reduce `FormDispatchTrait` from 495 to 436 lines
- add a 19-assertion direct recorder contract

## Verification
- `composer test`
- PHP transformer parity: 289 fixtures
- distribution shape: 201 files, 10 monorepo-only trees excluded
- exact-base CSS-attached corpus comparison: byte-identical records for 383 documents / 87 fixtures / 82 fixtures with CSS / 0 throws

Part of #242.

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to identify the runtime-island ownership boundary, implement the recorder and direct contract, and run the package suite and exact-base corpus comparison.