### PR TITLE
Match generated selectors in static parity

### DIFF
--- a/php-transformer/dev/VisualParity/StaticCssCascade.php
+++ b/php-transformer/dev/VisualParity/StaticCssCascade.php
@@ -375,6 +375,7 @@ final class StaticCssCascade
     private function specificity(string $selector): int
     {
         $selector = trim(preg_replace('/::?(hover|focus|active|visited|before|after)\b[^ ]*/', '', $selector) ?? $selector);
+        $selector = $this->normalizeGeneratedFunctionalGuard($selector, true);
         if ( preg_match('/:(?:is|where|not)\s*\(/i', $selector) ) {
             $parsed = CssSelectorMatcher::parse($selector);
             if ( $parsed['supported'] ) {
@@ -463,6 +464,8 @@ final class StaticCssCascade
             return null !== $element->ownerDocument && $element === $element->ownerDocument->documentElement;
         }
 
+        $selector = $this->normalizeGeneratedFunctionalGuard($selector, false);
+
         // `:is()`, `:where()` and `:not()` are the grammar the transformer's own
         // author-stylesheet projection emits to preserve author specificity, e.g.
         // `.footer-col ul :where(.be-source-li-…):not(be-specificity-…) a`. Without
@@ -519,6 +522,30 @@ final class StaticCssCascade
         }
 
         return strtolower($selector) === strtolower($element->tagName);
+    }
+
+    /**
+     * Normalize the zero-specificity exclusion guard emitted by author-selector
+     * projection into the conservative production matcher's supported grammar.
+     *
+     * `:not(:where(.a,.b))` is equivalent for matching to
+     * `:not(.a):not(.b)`, but its specificity remains zero because every class
+     * is inside :where(). For specificity calculation the whole guard therefore
+     * disappears; for matching it expands to the equivalent conjunction.
+     */
+    private function normalizeGeneratedFunctionalGuard(string $selector, bool $forSpecificity): string
+    {
+        return preg_replace_callback(
+            '/:not\(\s*:where\(\s*((?:\.[A-Za-z0-9_-]+\s*,\s*)*\.[A-Za-z0-9_-]+)\s*\)\s*\)/i',
+            static function (array $match) use ($forSpecificity): string {
+                if ( $forSpecificity ) {
+                    return '';
+                }
+                $classes = array_values(array_filter(array_map('trim', explode(',', $match[1]))));
+                return implode('', array_map(static fn (string $class): string => ':not(' . $class . ')', $classes));
+            },
+            $selector
+        ) ?? $selector;
     }
 
     /**

--- a/php-transformer/dev/VisualParity/StaticCssCascade.php
+++ b/php-transformer/dev/VisualParity/StaticCssCascade.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\VisualParity;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssSelectorMatcher;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssStylesheetTransformer;
 use DOMDocument;
 use DOMElement;
 
@@ -210,7 +212,9 @@ final class StaticCssCascade
                 if ( array() === $declarations ) {
                     continue;
                 }
-                foreach ( explode(',', (string) $match[1]) as $selector ) {
+                // Parenthesis-aware: a comma inside functional notation is not
+                // a selector-list separator.
+                foreach ( CssStylesheetTransformer::splitSelectorList((string) $match[1]) ?? array() as $selector ) {
                     $selector = trim($selector);
                     if ( '' === $selector ) {
                         continue;
@@ -371,12 +375,49 @@ final class StaticCssCascade
     private function specificity(string $selector): int
     {
         $selector = trim(preg_replace('/::?(hover|focus|active|visited|before|after)\b[^ ]*/', '', $selector) ?? $selector);
+        if ( preg_match('/:(?:is|where|not)\s*\(/i', $selector) ) {
+            $parsed = CssSelectorMatcher::parse($selector);
+            if ( $parsed['supported'] ) {
+                return $this->parsedSpecificity($parsed['compounds']);
+            }
+        }
         $ids = preg_match_all('/#[A-Za-z0-9_-]+/', $selector);
         $classes = preg_match_all('/\.[A-Za-z0-9_-]+|\[[^\]]+\]/', $selector);
         $bare = preg_replace('/[#.][A-Za-z0-9_-]+|\[[^\]]+\]|[>+~]/', ' ', $selector) ?? $selector;
         $elements = preg_match_all('/[A-Za-z][A-Za-z0-9_-]*/', $bare);
 
         return ( (int) $ids * 100 ) + ( (int) $classes * 10 ) + (int) $elements;
+    }
+
+    /**
+     * Specificity for selectors parsed by the production matcher.
+     *
+     * CssSelectorMatcher records which simple selectors came from :where() so
+     * rewriting can preserve their zero specificity. Account for that metadata
+     * here rather than maintaining a second functional-selector parser.
+     *
+     * @param list<array<string, mixed>> $compounds
+     */
+    private function parsedSpecificity(array $compounds): int
+    {
+        $specificity = 0;
+        foreach ( $compounds as $compound ) {
+            $zero = $compound['zero_specificity'] ?? array();
+            $specificity += 100 * (count($compound['ids']) - (int) ($zero['ids'] ?? 0));
+            $specificity += 10 * (
+                count($compound['classes']) - (int) ($zero['classes'] ?? 0)
+                + count($compound['attributes']) - (int) ($zero['attributes'] ?? 0)
+                + (int) (null !== $compound['nth_child'])
+                + (int) $compound['first_child']
+                + (int) $compound['last_child']
+            );
+            $specificity += (int) (null !== $compound['type']) - (int) ($zero['types'] ?? 0);
+            foreach ( $compound['not'] as $negated ) {
+                $specificity += $this->parsedSpecificity(array( $negated ));
+            }
+        }
+
+        return $specificity;
     }
 
     /**
@@ -420,6 +461,17 @@ final class StaticCssCascade
         // carries values the transformer already resolved.
         if ( ':root' === strtolower($selector) ) {
             return null !== $element->ownerDocument && $element === $element->ownerDocument->documentElement;
+        }
+
+        // `:is()`, `:where()` and `:not()` are the grammar the transformer's own
+        // author-stylesheet projection emits to preserve author specificity, e.g.
+        // `.footer-col ul :where(.be-source-li-…):not(be-specificity-…) a`. Without
+        // support here the probe cannot match the candidate's own generated rules,
+        // so it reports the inherited value and blames the transformer for a
+        // declaration it carried correctly.
+        if ( preg_match('/:(?:is|where|not)\s*\(/i', $selector) ) {
+            $match = CssSelectorMatcher::matches($element, CssSelectorMatcher::parse($selector));
+            return $match['supported'] && $match['matches'];
         }
 
         if ( '' === $selector || str_contains($selector, '+') || str_contains($selector, '~') || str_contains($selector, '[') ) {

--- a/php-transformer/tests/unit/static-css-cascade.php
+++ b/php-transformer/tests/unit/static-css-cascade.php
@@ -151,6 +151,22 @@ $notSpecificity = 'a:not(.x) { font-size: 3rem; } a { font-size: 4rem; }';
 $result = $resolve($marked, $notSpecificity, '//a', array( 'font-size' ));
 $assert('3rem' === ( $result['font-size'] ?? '' ), ':not() contributes its argument to specificity');
 
+// Broad type selectors that also match promoted controls are emitted with a
+// zero-specificity exclusion guard. The ordinary anchor must match it; a control
+// marker named in the guard must not.
+$guarded = 'a:not(:where(.control-a,.control-b)) { text-decoration: none; }';
+$result = $resolve($marked, $guarded, '//a', array( 'text-decoration' ));
+$assert('none' === ( $result['text-decoration'] ?? '' ), 'a generated nested :not(:where()) guard admits ordinary anchors');
+
+$controlled = '<html><body><a class="control-a" href="#">Control</a></body></html>';
+$result = $resolve($controlled, $guarded, '//a', array( 'text-decoration' ));
+$assert(! isset($result['text-decoration']), 'a generated nested :not(:where()) guard excludes projected controls');
+
+$guardSpecificity = '.ordinary { font-size: 1rem; } a:not(:where(.control-a,.control-b)) { font-size: 2rem; }';
+$ordinary = '<html><body><a class="ordinary" href="#">Ordinary</a></body></html>';
+$result = $resolve($ordinary, $guardSpecificity, '//a', array( 'font-size' ));
+$assert('1rem' === ( $result['font-size'] ?? '' ), ':not(:where()) adds zero specificity');
+
 if ( $failures > 0 ) {
     fwrite(STDERR, "StaticCssCascade unit tests: {$failures} failed, {$passes} passed\n");
     exit(1);

--- a/php-transformer/tests/unit/static-css-cascade.php
+++ b/php-transformer/tests/unit/static-css-cascade.php
@@ -122,6 +122,35 @@ $assert('0.92rem' === ( $result['font-size'] ?? '' ), 'a list item inherits font
 $result = $resolve($page, $inherited, '//footer//a', array( 'font-size' ), array( 'font-size' ));
 $assert('0.9rem' === ( $result['font-size'] ?? '' ), 'a more specific descendant rule still wins over inheritance');
 
+// :is()/:where()/:not() are the grammar the transformer's own author-stylesheet
+// projection emits to preserve author specificity. Without support the probe
+// cannot match the candidate's generated rules and blames the transformer for a
+// declaration it carried correctly.
+$marked = '<html><body><div class="footer-col"><ul><li class="src-li"><a href="#">Link</a></li></ul></div></body></html>';
+
+$projected = '.footer-col ul :where(.src-li):not(be-specificity-0) a { font-size: 0.9rem; }';
+$result = $resolve($marked, $projected, '//a', array( 'font-size' ));
+$assert('0.9rem' === ( $result['font-size'] ?? '' ), 'a projected :where()/:not() rule matches');
+
+$result = $resolve($marked, '.footer-col :is(ul) li a { font-size: 0.8rem; }', '//a', array( 'font-size' ));
+$assert('0.8rem' === ( $result['font-size'] ?? '' ), ':is() matches its argument');
+
+$result = $resolve($marked, 'li:not(.src-li) a { font-size: 0.7rem; }', '//a', array( 'font-size' ));
+$assert(! isset($result['font-size']), ':not() excludes a matching element');
+
+$result = $resolve($marked, 'li:not(.other) a { font-size: 0.6rem; }', '//a', array( 'font-size' ));
+$assert('0.6rem' === ( $result['font-size'] ?? '' ), ':not() admits a non-matching element');
+
+// :where() contributes no specificity, which is the whole reason the projection
+// uses it: the author's own rule must still win.
+$specificity = '.footer-col a { font-size: 1rem; } :where(.footer-col) a { font-size: 2rem; }';
+$result = $resolve($marked, $specificity, '//a', array( 'font-size' ));
+$assert('1rem' === ( $result['font-size'] ?? '' ), ':where() adds no specificity');
+
+$notSpecificity = 'a:not(.x) { font-size: 3rem; } a { font-size: 4rem; }';
+$result = $resolve($marked, $notSpecificity, '//a', array( 'font-size' ));
+$assert('3rem' === ( $result['font-size'] ?? '' ), ':not() contributes its argument to specificity');
+
 if ( $failures > 0 ) {
     fwrite(STDERR, "StaticCssCascade unit tests: {$failures} failed, {$passes} passed\n");
     exit(1);


### PR DESCRIPTION
Fixes #1376.

After #1372 corrected the source-side cascade, the remaining footer style drift on `28-enterprise-b2b` looked like transformer bugs. It was another measurement gap: the transformer carried the declarations, but the parity harness could not read the selectors the transformer generated.

```css
/* projected descendant rule */
.footer-col ul :where(.blocks-engine-source-li-…):not(blocks-engine-specificity-…) a {
  font-size: 0.9rem;
}

/* projected broad anchor rule, excluding promoted controls */
a:not(:where(.blocks-engine-control-1,.blocks-engine-control-2,…)) {
  text-decoration: none;
}
```

`StaticCssCascade` treated both generated shapes as unsupported, ignored the candidate rules, and reported inherited/undeclared values.

## Approach

This reuses the production selector primitives rather than adding another parser to the harness:

- `CssSelectorMatcher` parses and matches its supported `:is()`/`:where()`/`:not()` subset.
- `CssStylesheetTransformer::splitSelectorList()` prevents functional notation from being split at an internal comma.
- The cascade accounts for the matcher's existing `zero_specificity` metadata so `:where()` remains specificity-neutral while `:not()` contributes its ordinary argument.
- The generated `:not(:where(.a,.b))` exclusion guard normalizes to `:not(.a):not(.b)` for matching and disappears for specificity, preserving its CSS semantics without broadening the production parser.
- Unsupported grammar still fails closed.

An initial local implementation duplicated functional-selector parsing. Its unit tests passed, but the fixture did not complete in 15 minutes. Replacing it with the cached production matcher reduced the implementation substantially and completes the fixture in about 90 seconds.

## Result

| `28-enterprise-b2b` | original | after #1372 | this PR |
|---|---:|---:|---:|
| score | 0.5022 | 0.5767 | **0.7126** |
| property parity | 0.7825 | 0.8841 | **0.9492** |
| coverage | 0.6418 | 0.6522 | **0.7507** |
| findings | 683 | 484 | **277** |
| footer findings | 227 | 88 | **4** |

All footer color, font-size, and text-decoration findings are now gone. The four remaining footer findings are missing social SVG icons, which is a real transformer loss rather than cascade noise.

## Verification

```
StaticCssCascade unit tests: 34 passed
composer test:canonical     passed
composer test:parity        289 fixtures passed
composer test:packaging     passed
28-enterprise-b2b           90.80s, score 0.7126, 277 findings
```

This remains dev-only code and does not affect the released package.

---

*AI assistance disclosure: OpenAI GPT-5.6 Sol via OpenCode identified the generated selector mismatches, replaced a duplicate experimental parser with existing production selector primitives, implemented the tests, and produced the fixture and timing evidence above. Chris Huber directed the work and remains responsible for the change.*
