### PR TITLE
Extract readable form control block converter

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -156,6 +156,7 @@
             "php tests/unit/unsupported-element-recorder.php",
             "php tests/unit/authored-form-control-block-converter.php",
             "php tests/unit/form-runtime-island-recorder.php",
+            "php tests/unit/readable-form-control-block-converter.php",
             "php tests/unit/form-runtime-requirement-analyzer.php",
             "php tests/unit/form-success-panel-metadata-builder.php",
             "php tests/unit/pseudo-form-analyzer.php",

--- a/php-transformer/src/HtmlToBlocks/Elements/ReadableFormControlBlockConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/ReadableFormControlBlockConverter.php
@@ -1,0 +1,201 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
+use Closure;
+use DOMElement;
+
+/** Converts labels and native controls into readable editable blocks. */
+final class ReadableFormControlBlockConverter
+{
+    /**
+     * @param Closure(DOMElement): array<string, mixed>                                                     $eventMetadata
+     * @param Closure(DOMElement): bool                                                                     $isRuntimeDomTarget
+     * @param Closure(DOMElement): array<string, mixed>                                                     $htmlPreservationBlock
+     * @param Closure(DOMElement): array<string, mixed>                                                     $presentationAttributes
+     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
+     * @param Closure(string): void                                                                         $registerEcho
+     */
+    public function __construct(
+        private readonly FormControlMetadataBuilder $metadataBuilder,
+        private readonly AuthoredFormControlBlockConverter $authoredBlockConverter,
+        private readonly FormRuntimeIslandRecorder $runtimeIslandRecorder,
+        private readonly Runtime $runtime,
+        private readonly Closure $eventMetadata,
+        private readonly Closure $isRuntimeDomTarget,
+        private readonly Closure $htmlPreservationBlock,
+        private readonly Closure $presentationAttributes,
+        private readonly Closure $createBlock,
+        private readonly Closure $registerEcho
+    ) {
+    }
+
+    /** @return array<string, mixed>|null */
+    public function convert(DOMElement $element): ?array
+    {
+        $tagName = strtolower($element->tagName);
+        if ( 'label' === $tagName ) {
+            return $this->convertLabel($element);
+        }
+
+        if ( ! FormControlClassifier::isControlElement($element)
+            || ! FormControlClassifier::isReadableControl($element)
+            || array() !== ($this->eventMetadata)($element)
+        ) {
+            return null;
+        }
+
+        if ( 'input' === $tagName && 'search' === FormControlClassifier::controlType($element) ) {
+            $label = $this->metadataBuilder->label($element);
+            if ( '' === $label ) {
+                $label = $this->attr($element, 'aria-label');
+            }
+            if ( '' === $label ) {
+                $label = 'Search';
+            }
+
+            return ($this->htmlPreservationBlock)($element);
+        }
+
+        if ( ($this->isRuntimeDomTarget)($element) ) {
+            $this->runtimeIslandRecorder->recordControl($element);
+            return ($this->htmlPreservationBlock)($element);
+        }
+
+        if ( 'select' === $tagName ) {
+            $selectBlock = $this->authoredBlockConverter->select($element);
+            if ( null !== $selectBlock ) {
+                return $selectBlock;
+            }
+        }
+
+        if ( 'input' === $tagName ) {
+            $inputBlock = $this->authoredBlockConverter->input($element);
+            if ( null !== $inputBlock ) {
+                return $inputBlock;
+            }
+        }
+
+        $summary = $this->controlText($element);
+        if ( '' === $summary ) {
+            return null;
+        }
+
+        return ($this->createBlock)('core/paragraph', array_merge(($this->presentationAttributes)($element), array( 'content' => $summary )), array(), $element);
+    }
+
+    /** @return array<string, mixed>|null */
+    private function convertLabel(DOMElement $element): ?array
+    {
+        $controls = FormControlClassifier::controlElements($element);
+        if ( array() !== $controls ) {
+            $blocks = array();
+            foreach ( $controls as $control ) {
+                if ( ! FormControlClassifier::isReadableControl($control) || array() !== ($this->eventMetadata)($control) ) {
+                    return null;
+                }
+
+                if ( ($this->isRuntimeDomTarget)($control) ) {
+                    $this->runtimeIslandRecorder->recordControl($control);
+                    return ($this->htmlPreservationBlock)($element);
+                }
+
+                $summary = $this->controlText($control);
+                if ( '' !== $summary ) {
+                    $blocks[] = ($this->createBlock)('core/paragraph', array( 'content' => $summary ), array(), $control);
+                }
+            }
+
+            if ( 1 === count($blocks) ) {
+                return $blocks[0];
+            }
+
+            return array() !== $blocks
+                ? ($this->createBlock)('core/group', ($this->presentationAttributes)($element), $blocks, $element)
+                : null;
+        }
+
+        $label = $this->metadataBuilder->labelText($element);
+        if ( '' === $label ) {
+            $label = trim(preg_replace('/\s+/', ' ', $element->textContent ?? '') ?? '');
+        }
+
+        return '' !== $label
+            ? ($this->createBlock)('core/paragraph', array( 'content' => $this->runtime->escapeHtml($label) ), array(), $element)
+            : null;
+    }
+
+    private function controlText(DOMElement $control): string
+    {
+        $label = $this->metadataBuilder->readableLabel($control);
+        $type = FormControlClassifier::controlType($control);
+        if ( '' === $label ) {
+            $label = 'select' === $type ? 'Select option' : ucfirst($type);
+        }
+
+        $details = array();
+        if ( 'select' === strtolower($control->tagName) ) {
+            $options = array();
+            $selected = array();
+            foreach ( $this->metadataBuilder->options($control) as $option ) {
+                $optionLabel = (string) ($option['label'] ?? '');
+                if ( '' === $optionLabel ) {
+                    continue;
+                }
+                $options[] = $optionLabel;
+                if ( true === ($option['selected'] ?? false) ) {
+                    $selected[] = $optionLabel;
+                }
+            }
+            if ( array() !== $options ) {
+                $details[] = implode(', ', $options);
+            }
+            if ( array() !== $selected ) {
+                $details[] = 'selected: ' . implode(', ', $selected);
+            }
+        } elseif ( 'range' === $type ) {
+            $value = trim($this->attr($control, 'value'));
+            if ( '' !== $value ) {
+                $details[] = $value;
+            }
+
+            $bounds = array();
+            foreach ( array( 'min', 'max', 'step' ) as $attribute ) {
+                $value = trim($this->attr($control, $attribute));
+                if ( '' !== $value ) {
+                    $bounds[] = $attribute . ' ' . $value;
+                }
+            }
+            if ( array() !== $bounds ) {
+                $details[] = implode(', ', $bounds);
+            }
+        } else {
+            foreach ( array( 'value', 'placeholder' ) as $attribute ) {
+                $value = trim($this->attr($control, $attribute));
+                if ( '' !== $value ) {
+                    $details[] = $value;
+                    break;
+                }
+            }
+        }
+
+        $text = $label;
+        if ( array() !== $details ) {
+            $text .= ': ' . implode(' (', $details) . ( count($details) > 1 ? ')' : '' );
+        }
+        if ( $control->hasAttribute('required') ) {
+            $text .= ' (required)';
+        }
+
+        ($this->registerEcho)($text);
+        return $this->runtime->escapeHtml($text);
+    }
+
+    private function attr(DOMElement $element, string $name): string
+    {
+        return $element->hasAttribute($name) ? $element->getAttribute($name) : '';
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -38,6 +38,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormControlMeta
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormRuntimeRequirementAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormRuntimeIslandRecorder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormSuccessPanelMetadataBuilder;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ReadableFormControlBlockConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\PseudoFormAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandContext;
@@ -273,6 +274,8 @@ final class HtmlTransformer
 
     private readonly AuthoredFormControlBlockConverter $authoredFormControlBlockConverter;
 
+    private readonly ReadableFormControlBlockConverter $readableFormControlBlockConverter;
+
     private readonly PseudoFormAnalyzer $pseudoFormAnalyzer;
 
     private readonly FormRuntimeRequirementAnalyzer $formRuntimeRequirementAnalyzer;
@@ -441,6 +444,20 @@ final class HtmlTransformer
             },
             fn (DOMElement $element): array => $this->eventMetadata($element),
             fn (DOMElement $element): array => $this->requiredScriptsForElement($element)
+        );
+        $this->readableFormControlBlockConverter = new ReadableFormControlBlockConverter(
+            $this->formControlMetadataBuilder,
+            $this->authoredFormControlBlockConverter,
+            $this->formRuntimeIslandRecorder,
+            $this->runtime,
+            fn (DOMElement $element): array => $this->eventMetadata($element),
+            fn (DOMElement $element): bool => $this->runtimeIslands->isRuntimeDomTarget($element),
+            fn (DOMElement $element): array => $this->htmlPreservationBlock($element),
+            fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
+            fn (string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
+            function (string $text): void {
+                $this->registerFormControlEcho($text);
+            }
         );
         $this->formRuntimeRequirementAnalyzer = new FormRuntimeRequirementAnalyzer(
             fn (DOMElement $element): array => $this->eventMetadata($element),
@@ -3914,7 +3931,7 @@ if ( $this->isInlineContentElement($tagName) ) {
         }
 
         if ( 'label' === $tagName ) {
-            return $this->readableFormControlBlockFromElement($element);
+            return $this->readableFormControlBlockConverter->convert($element);
         }
 
         if ( 'pre' === $tagName || 'plaintext' === $tagName ) {
@@ -4024,7 +4041,7 @@ if ( 'svg' === $tagName ) {
             }
         }
 
-        $readableControlBlock = $this->readableFormControlBlockFromElement($element);
+        $readableControlBlock = $this->readableFormControlBlockConverter->convert($element);
         if ( null !== $readableControlBlock ) {
             return $readableControlBlock;
         }

--- a/php-transformer/src/HtmlToBlocks/Support/ElementConversionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/ElementConversionTrait.php
@@ -548,7 +548,7 @@ trait ElementConversionTrait
         // A select's option text is not prose. Route it before generic text
         // flow can flatten the control into a paragraph.
         if ( 'select' === $tagName ) {
-            $selectBlock = $this->readableFormControlBlockFromElement($element);
+            $selectBlock = $this->readableFormControlBlockConverter->convert($element);
             if ( null !== $selectBlock ) {
                 return $selectBlock;
             }

--- a/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
@@ -101,7 +101,7 @@ trait FormDispatchTrait
                 $this->formRuntimeIslandRecorder->recordControl($control);
             }
 
-            $readableControlBlock = $this->readableFormControlBlockFromElement($control);
+            $readableControlBlock = $this->readableFormControlBlockConverter->convert($control);
             if ( null === $readableControlBlock ) {
                 continue;
             }
@@ -109,7 +109,7 @@ trait FormDispatchTrait
             $fieldBlocks = array();
             $associatedLabel = $this->formControlMetadataBuilder->associatedLabel($control);
             if ( $associatedLabel instanceof DOMElement && AuthoredInputBlockGenerator::NAME === ($readableControlBlock['blockName'] ?? '') ) {
-                $labelBlock = $this->readableFormControlBlockFromElement($associatedLabel);
+                $labelBlock = $this->readableFormControlBlockConverter->convert($associatedLabel);
                 if ( null !== $labelBlock ) {
                     $fieldBlocks[] = $labelBlock;
                 }
@@ -194,90 +194,6 @@ trait FormDispatchTrait
     }
 
     /**
-     * @return array<string, mixed>|null
-     */
-    private function readableFormControlBlockFromElement(DOMElement $element): ?array
-    {
-        $tagName = strtolower($element->tagName);
-        if ( 'label' === $tagName ) {
-            $controls = FormControlClassifier::controlElements($element);
-            if ( array() !== $controls ) {
-                $blocks = array();
-                foreach ( $controls as $control ) {
-                    if ( ! FormControlClassifier::isReadableControl($control) || array() !== $this->eventMetadata($control) ) {
-                        return null;
-                    }
-
-                    if ( $this->runtimeIslands->isRuntimeDomTarget($control) ) {
-                        $this->formRuntimeIslandRecorder->recordControl($control);
-                        return $this->htmlPreservationBlock($element);
-                    }
-
-                    $summary = $this->readableFormControlText($control);
-                    if ( '' !== $summary ) {
-                        $blocks[] = $this->createBlock('core/paragraph', array( 'content' => $summary ), array(), $control);
-                    }
-                }
-
-                if ( 1 === count($blocks) ) {
-                    return $blocks[0];
-                }
-
-                return array() !== $blocks ? $this->createBlock('core/group', $this->styleResolver->presentationAttributes($element), $blocks, $element) : null;
-            }
-
-            $label = $this->formControlMetadataBuilder->labelText($element);
-            if ( '' === $label ) {
-                $label = trim(preg_replace('/\s+/', ' ', $element->textContent ?? '') ?? '');
-            }
-
-            return '' !== $label ? $this->createBlock('core/paragraph', array( 'content' => $this->runtime->escapeHtml($label) ), array(), $element) : null;
-        }
-
-        if ( ! FormControlClassifier::isControlElement($element) || ! FormControlClassifier::isReadableControl($element) || array() !== $this->eventMetadata($element) ) {
-            return null;
-        }
-
-        if ( 'input' === $tagName && 'search' === FormControlClassifier::controlType($element) ) {
-            $label = $this->formControlMetadataBuilder->label($element);
-            if ( '' === $label ) {
-                $label = $this->attr($element, 'aria-label');
-            }
-            if ( '' === $label ) {
-                $label = 'Search';
-            }
-
-            return $this->htmlPreservationBlock($element);
-        }
-
-        if ( $this->runtimeIslands->isRuntimeDomTarget($element) ) {
-            $this->formRuntimeIslandRecorder->recordControl($element);
-            return $this->htmlPreservationBlock($element);
-        }
-
-        if ( 'select' === $tagName ) {
-            $selectBlock = $this->authoredFormControlBlockConverter->select($element);
-            if ( null !== $selectBlock ) {
-                return $selectBlock;
-            }
-        }
-
-        if ( 'input' === $tagName ) {
-            $inputBlock = $this->authoredFormControlBlockConverter->input($element);
-            if ( null !== $inputBlock ) {
-                return $inputBlock;
-            }
-        }
-
-        $summary = $this->readableFormControlText($element);
-        if ( '' === $summary ) {
-            return null;
-        }
-
-        return $this->createBlock('core/paragraph', array_merge($this->styleResolver->presentationAttributes($element), array( 'content' => $summary )), array(), $element);
-    }
-
-    /**
      * Build the shared html_form_fallback finding (issue #315) for an element that
      * behaves as a form. Both the real <form> path and the div-based pseudo-form
      * path emit through here so the downstream materializer receives an identical
@@ -329,74 +245,6 @@ trait FormDispatchTrait
         }
 
         return FallbackDiagnostic::build($finding, $this->transformationProvenance()->fallback());
-    }
-
-    private function readableFormControlText(DOMElement $control): string
-    {
-        $label = $this->formControlMetadataBuilder->readableLabel($control);
-
-        $type = FormControlClassifier::controlType($control);
-        if ( '' === $label ) {
-            $label = 'select' === $type ? 'Select option' : ucfirst($type);
-        }
-
-        $details = array();
-        if ( 'select' === strtolower($control->tagName) ) {
-            $options = array();
-            $selected = array();
-            foreach ( $this->formControlMetadataBuilder->options($control) as $option ) {
-                $optionLabel = (string) ($option['label'] ?? '');
-                if ( '' === $optionLabel ) {
-                    continue;
-                }
-                $options[] = $optionLabel;
-                if ( true === ($option['selected'] ?? false) ) {
-                    $selected[] = $optionLabel;
-                }
-            }
-            if ( array() !== $options ) {
-                $details[] = implode(', ', $options);
-            }
-            if ( array() !== $selected ) {
-                $details[] = 'selected: ' . implode(', ', $selected);
-            }
-        } elseif ( 'range' === $type ) {
-            $value = trim($this->attr($control, 'value'));
-            if ( '' !== $value ) {
-                $details[] = $value;
-            }
-
-            $bounds = array();
-            foreach ( array( 'min', 'max', 'step' ) as $attribute ) {
-                $value = trim($this->attr($control, $attribute));
-                if ( '' !== $value ) {
-                    $bounds[] = $attribute . ' ' . $value;
-                }
-            }
-            if ( array() !== $bounds ) {
-                $details[] = implode(', ', $bounds);
-            }
-        } else {
-            foreach ( array( 'value', 'placeholder' ) as $attribute ) {
-                $value = trim($this->attr($control, $attribute));
-                if ( '' !== $value ) {
-                    $details[] = $value;
-                    break;
-                }
-            }
-        }
-
-        $text = $label;
-        if ( array() !== $details ) {
-            $text .= ': ' . implode(' (', $details) . ( count($details) > 1 ? ')' : '' );
-        }
-        if ( $control->hasAttribute('required') ) {
-            $text .= ' (required)';
-        }
-
-        $this->registerFormControlEcho($text);
-
-        return $this->runtime->escapeHtml($text);
     }
 
     /**

--- a/php-transformer/tests/unit/readable-form-control-block-converter.php
+++ b/php-transformer/tests/unit/readable-form-control-block-converter.php
@@ -1,0 +1,130 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\AuthoredFormControlBlockConverter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormControlMetadataBuilder;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormRuntimeIslandRecorder;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ReadableFormControlBlockConverter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredInputBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
+
+$assertions = 0;
+$failures = array();
+$assert = static function (bool $condition, string $label) use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']';
+    }
+};
+
+$elementFrom = static function (string $html, string $tagName): DOMElement {
+    $document = new DOMDocument();
+    $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+    $element = $document->getElementsByTagName($tagName)->item(0);
+    if ( $element instanceof DOMElement ) {
+        return $element;
+    }
+    throw new RuntimeException('No ' . $tagName . ' parsed');
+};
+
+$createBlock = static fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => array(
+    'blockName' => $name,
+    'attrs' => $attrs,
+    'innerBlocks' => $innerBlocks,
+);
+$presentationAttributes = static fn (DOMElement $element): array => array( 'className' => 'presented' );
+$echoes = array();
+$recorded = array();
+$metadataBuilder = new FormControlMetadataBuilder(static fn (DOMElement $element): string => strtolower($element->tagName));
+$runtimeRecorder = new FormRuntimeIslandRecorder(
+    $metadataBuilder,
+    static function (DOMElement $element, string $kind, string $reason, string $capability, array $metadata) use (&$recorded): void {
+        $recorded[] = compact('kind', 'reason', 'capability', 'metadata');
+    },
+    static fn (DOMElement $element): array => array(),
+    static fn (DOMElement $element): array => array()
+);
+$authoredConverter = new AuthoredFormControlBlockConverter(
+    $metadataBuilder,
+    static fn (DOMElement $element): array => $element->hasAttribute('data-styled') ? array( 'display' => 'block' ) : array(),
+    $presentationAttributes,
+    $createBlock,
+    static function (string $identity, array $definition): void {
+    },
+    static function (string $text) use (&$echoes): void {
+        $echoes[] = $text;
+    },
+    static fn (string $text): string => htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+    static fn (string $id): string => $id
+);
+$converter = new ReadableFormControlBlockConverter(
+    $metadataBuilder,
+    $authoredConverter,
+    $runtimeRecorder,
+    new Runtime(),
+    static fn (DOMElement $element): array => $element->hasAttribute('data-event') ? array( 'change' => true ) : array(),
+    static fn (DOMElement $element): bool => $element->hasAttribute('data-runtime'),
+    static fn (DOMElement $element): array => array( 'blockName' => 'core/html', 'attrs' => array( 'content' => 'preserved-' . strtolower($element->tagName) ) ),
+    $presentationAttributes,
+    $createBlock,
+    static function (string $text) use (&$echoes): void {
+        $echoes[] = $text;
+    }
+);
+
+$plainLabel = $converter->convert($elementFrom('<label>Terms &amp; Conditions</label>', 'label'));
+$assert('core/paragraph' === ($plainLabel['blockName'] ?? ''), 'plain-label-becomes-paragraph');
+$assert('Terms &amp; Conditions' === ($plainLabel['attrs']['content'] ?? ''), 'plain-label-is-escaped');
+
+$echoes = array();
+$wrappedInput = $converter->convert($elementFrom('<label>Email<input value="a&amp;b" required></label>', 'label'));
+$assert('Email: a&amp;b (required)' === ($wrappedInput['attrs']['content'] ?? ''), 'wrapped-input-becomes-readable-summary');
+$assert(array( 'Email: a&b (required)' ) === $echoes, 'wrapped-input-registers-raw-echo');
+
+$multiControl = $converter->convert($elementFrom('<label>Choices<input type="checkbox" value="A"><input type="checkbox" value="B"></label>', 'label'));
+$assert('core/group' === ($multiControl['blockName'] ?? ''), 'multi-control-label-becomes-group');
+$assert(2 === count($multiControl['innerBlocks'] ?? array()), 'multi-control-label-retains-each-summary');
+$assert('presented' === ($multiControl['attrs']['className'] ?? ''), 'multi-control-label-retains-presentation');
+
+$eventLabel = $converter->convert($elementFrom('<label>Email<input data-event></label>', 'label'));
+$assert(null === $eventLabel, 'eventful-wrapped-control-declines-readable-block');
+
+$recorded = array();
+$runtimeLabel = $converter->convert($elementFrom('<label>Email<input data-runtime name="email"></label>', 'label'));
+$assert('core/html' === ($runtimeLabel['blockName'] ?? ''), 'runtime-wrapped-control-preserves-label-markup');
+$assert('runtime_dom_target' === ($recorded[0]['reason'] ?? ''), 'runtime-wrapped-control-records-island');
+
+$recorded = array();
+$search = $converter->convert($elementFrom('<input type="search" aria-label="Find">', 'input'));
+$assert('core/html' === ($search['blockName'] ?? ''), 'search-input-is-preserved');
+$assert(array() === $recorded, 'search-input-does-not-record-runtime-target');
+
+$runtimeInput = $converter->convert($elementFrom('<input data-runtime name="email">', 'input'));
+$assert('core/html' === ($runtimeInput['blockName'] ?? ''), 'runtime-input-is-preserved');
+$assert('runtime_dom_target' === ($recorded[0]['reason'] ?? ''), 'runtime-input-records-island');
+
+$styledInput = $converter->convert($elementFrom('<input data-styled type="range" value="5">', 'input'));
+$assert(AuthoredInputBlockGenerator::NAME === ($styledInput['blockName'] ?? ''), 'styled-input-delegates-to-authored-converter');
+
+$echoes = array();
+$range = $converter->convert($elementFrom('<input type="range" aria-label="Volume" value="5" min="0" max="10" step="1" required>', 'input'));
+$assert('core/paragraph' === ($range['blockName'] ?? ''), 'unstyled-range-becomes-readable-paragraph');
+$assert('Volume: 5 (min 0, max 10, step 1) (required)' === ($range['attrs']['content'] ?? ''), 'range-summary-retains-value-and-bounds');
+$assert(array( 'Volume: 5 (min 0, max 10, step 1) (required)' ) === $echoes, 'range-summary-registers-echo');
+
+$echoes = array();
+$wrappedSelect = $converter->convert($elementFrom('<label>Plan<select><option>Free</option><option selected>Pro</option></select></label>', 'label'));
+$assert('Plan: Free, Pro (selected: Pro)' === ($wrappedSelect['attrs']['content'] ?? ''), 'wrapped-select-summary-retains-options-and-selection');
+$assert(array( 'Plan: Free, Pro (selected: Pro)' ) === $echoes, 'wrapped-select-registers-echo');
+
+$assert(null === $converter->convert($elementFrom('<div>Not a control</div>', 'div')), 'non-control-is-declined');
+$assert(null === $converter->convert($elementFrom('<input data-event name="email">', 'input')), 'eventful-control-is-declined');
+
+if ( $failures ) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Readable form control block converter tests: ' . $assertions . " passed\n";


### PR DESCRIPTION
## Summary
- extract label and native-control readable lowering into `ReadableFormControlBlockConverter`
- centralize runtime-target preservation, search preservation, authored input/select delegation, range/select summaries, and round-trip echoes
- route five call sites across `HtmlTransformer`, `FormDispatchTrait`, and `ElementConversionTrait` through the typed collaborator
- reduce `FormDispatchTrait` from 436 to 284 lines
- add a 22-assertion direct converter contract

## Verification
- `composer test`
- PHP transformer parity: 289 fixtures
- distribution shape: 202 files, 10 monorepo-only trees excluded
- exact-base CSS-attached corpus comparison: byte-identical records for 383 documents / 87 fixtures / 82 fixtures with CSS / 0 throws

Part of #242.

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to identify the readable control ownership boundary, implement the collaborator and direct contract, and run the package suite and exact-base corpus comparison.