### PR TITLE
Fix nested entrypoint route roots

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -4139,7 +4139,7 @@ final class ArtifactCompiler
                     'source_path'    => $path,
                     'kind'           => 'html',
                     'role'           => $file['role'] ?? 'document',
-                    'entrypoint'     => $path === $entryPath || ! empty($file['entrypoint']),
+                    'entrypoint'     => $path === $entryPath,
                     'slug'           => $slug,
                     'title'          => $title,
                     'metadata'       => array_merge($this->documentMetadata($path, 'html', (string) ($file['role'] ?? 'document'), $slug, $title, $bodyFormat), is_string($file['metadata']['route_path'] ?? null) ? array('route_path' => $file['metadata']['route_path']) : array(), is_string($file['metadata']['post_type'] ?? null) ? array('post_type' => $file['metadata']['post_type'], 'post_type_declaration' => 'metadata:post_type') : array(), is_array($file['metadata']['template_surface'] ?? null) ? array('template_surface' => $file['metadata']['template_surface']) : array()),

--- a/php-transformer/tests/contract/staged-artifact-compilation.php
+++ b/php-transformer/tests/contract/staged-artifact-compilation.php
@@ -187,6 +187,17 @@ foreach ($sourceShared['analysis']['page_ids'] as $pageId) $sourceReceipts[] = $
 $sourceInline = $compiler->compile($sourceArtifact)->toArray();
 $sourceStaged = $compiler->compose($sourceShared, array_reverse($sourceReceipts))->toArray();
 $assert($canonical($sourceInline) === $canonical($sourceStaged), 'Compiled receipts exactly cover HTML, Markdown, and MDX sources and preserve their complete canonical result.');
+$nestedEntryArtifact = array('entrypoint' => 'website/index.html', 'files' => array(
+    array('path' => 'website/about.html', 'content' => '<main>About</main>'),
+    array('path' => 'website/blog/post/index.html', 'content' => '<main>Post</main>', 'entrypoint' => true),
+    array('path' => 'website/index.html', 'content' => '<main>Home</main>'),
+));
+$nestedEntryShared = $compiler->prepareShared($nestedEntryArtifact);
+$nestedEntryReceipts = array();
+foreach ($nestedEntryShared['analysis']['page_ids'] as $pageId) $nestedEntryReceipts[] = $compiler->compilePage($nestedEntryArtifact, $nestedEntryShared, $pageId);
+$nestedEntryStaged = $compiler->compose($nestedEntryShared, array_reverse($nestedEntryReceipts))->toArray();
+$nestedEntryPages = array_column($nestedEntryStaged['source_reports']['compiled_site']['pages'] ?? array(), 'entrypoint', 'source_path');
+$assert(isset($nestedEntryStaged['source_reports']['wordpress_site_plan']) && array('website/about.html' => false, 'website/blog/post/index.html' => false, 'website/index.html' => true) === $nestedEntryPages, 'Nested index candidates remain ordinary routes when the artifact selects a shallower canonical entrypoint.');
 $throws(static fn() => $compiler->compose($manyShared, array_slice($serializedReceipts, 1)), 'Composition rejects a missing compiled page receipt deterministically.');
 $sitePlan = $whole['source_reports']['wordpress_site_plan'] ?? array();
 $siteAssets = array_column($sitePlan['assets'] ?? array(), null, 'source_path');


### PR DESCRIPTION
## Summary
- mark only the artifact-selected entry path as the canonical compiled-site entrypoint
- keep nested index candidates as ordinary routes
- cover arbitrary-order staged receipt composition that previously selected a nested content root

## Root cause
File-level entrypoint candidates were projected as canonical page entrypoints. When a nested `index.html` appeared before the selected root entry in compiled-site order, route planning derived the nested directory as the content root and rejected valid sibling pages.

## Verification
- `composer test`
- `php tests/contract/staged-artifact-compilation.php` after rebasing onto current `origin/trunk`
- `php tests/contract/wordpress-site-plan.php` after rebasing onto current `origin/trunk`

## AI assistance
OpenAI `gpt-5.6-sol` via OpenCode reproduced and traced the staged compilation failure, implemented the minimal fix and regression contract, and ran verification. I reviewed and orchestrated the work.