### PR TITLE
Preserve labeled social placeholder icons

### DIFF
--- a/php-transformer/dev/VisualParity/StaticStyleParityRunner.php
+++ b/php-transformer/dev/VisualParity/StaticStyleParityRunner.php
@@ -138,6 +138,30 @@ final class StaticStyleParityRunner
      */
     public static function candidateHtmlFromSerializedBlocks(string $serializedBlocks): string
     {
+        // Dynamic social-link children save only block comments. Materialize the
+        // stable server-rendered structure so the render-free proxy can compare
+        // the source controls and icons without embedding WordPress icon data.
+        $serializedBlocks = preg_replace_callback(
+            '/<!--\s+wp:social-link(?:\s+({.*?}))?\s+\/-->/s',
+            static function (array $match): string {
+                $attrs = json_decode((string) ($match[1] ?? ''), true);
+                if (! is_array($attrs) || '' === trim((string) ($attrs['url'] ?? ''))) {
+                    return '';
+                }
+
+                $url = htmlspecialchars((string) $attrs['url'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+                $service = preg_replace('/[^a-z0-9-]+/', '-', strtolower((string) ($attrs['service'] ?? 'share'))) ?? 'share';
+                $label = htmlspecialchars(trim((string) ($attrs['label'] ?? $service)), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+                $className = trim((string) ($attrs['className'] ?? ''));
+                $classes = htmlspecialchars(trim('wp-social-link wp-social-link-' . $service . ' ' . $className), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+                return '<li class="' . $classes . '"><a href="' . $url . '" class="wp-block-social-link-anchor">'
+                    . '<svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false"></svg>'
+                    . '<span class="wp-block-social-link-label screen-reader-text">' . $label . '</span></a></li>';
+            },
+            $serializedBlocks
+        ) ?? $serializedBlocks;
+
         return preg_replace('/<!--\s*\/?wp:[^>]*-->/', '', $serializedBlocks) ?? $serializedBlocks;
     }
 }

--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -385,7 +385,8 @@ final class BlockFactory
             $sizeClass = in_array($size, array( 'small', 'normal', 'large', 'huge' ), true)
                 ? $size . ' has-' . $size . '-icon-size'
                 : '';
-            return array( 'opening' => '<ul' . $this->blockSupportAttrs($attrs, trim('wp-block-social-links ' . $sizeClass)) . '>', 'closing' => '</ul>' );
+            $labelsClass = ! empty($attrs['showLabels']) ? 'has-visible-labels' : '';
+            return array( 'opening' => '<ul' . $this->blockSupportAttrs($attrs, trim('wp-block-social-links ' . $labelsClass . ' ' . $sizeClass)) . '>', 'closing' => '</ul>' );
         }
 
         if ( 'core/social-link' === $name ) {

--- a/php-transformer/src/HtmlToBlocks/Patterns/SocialLinksPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/SocialLinksPattern.php
@@ -24,6 +24,19 @@ final class SocialLinksPattern implements PatternRecognizerInterface
         'x.com' => 'x', 'youtube.com' => 'youtube', 'youtu.be' => 'youtube',
     );
 
+    /** @var array<string,string> */
+    private const LABEL_SERVICES = array(
+        'behance' => 'behance', 'bluesky' => 'bluesky', 'discord' => 'discord',
+        'dribbble' => 'dribbble', 'facebook' => 'facebook', 'github' => 'github',
+        'gitlab' => 'gitlab', 'instagram' => 'instagram', 'linkedin' => 'linkedin',
+        'mastodon' => 'mastodon', 'pinterest' => 'pinterest', 'reddit' => 'reddit',
+        'soundcloud' => 'soundcloud', 'spotify' => 'spotify', 'telegram' => 'telegram',
+        'threads' => 'threads', 'tiktok' => 'tiktok', 'tumblr' => 'tumblr',
+        'twitch' => 'twitch', 'twitter' => 'twitter', 'vimeo' => 'vimeo',
+        'whatsapp' => 'whatsapp', 'x' => 'x', 'x twitter' => 'x',
+        'youtube' => 'youtube', 'email' => 'mail', 'mail' => 'mail',
+    );
+
     public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
         // A source navigation landmark carries menu semantics that core/social-links
@@ -40,12 +53,9 @@ final class SocialLinksPattern implements PatternRecognizerInterface
         $showLabels = false;
         $iconOnly = true;
         $structuralItems = true;
+        $explicit = $this->isExplicitSocialCluster($element);
         foreach ( $anchors as $anchor ) {
             $url = LinkUrlSanitizer::sanitize($this->attr($anchor, 'href'));
-            if ( '' === $url || ! $this->isUsableSocialUrl($url) ) {
-                continue;
-            }
-
             $label = trim($this->attr($anchor, 'aria-label'));
             if ( '' === $label ) {
                 $label = trim($this->attr($anchor, 'title'));
@@ -53,6 +63,13 @@ final class SocialLinksPattern implements PatternRecognizerInterface
             $text = trim((string) $anchor->textContent);
             if ( '' === $label ) {
                 $label = $text;
+            }
+            $service = $this->service($url) ?? $this->serviceFromLabel($label);
+            $labeledPlaceholder = $explicit
+                && $this->isLocalPlaceholderUrl($url)
+                && null !== $service;
+            if ( '' === $url || (! $this->isUsableSocialUrl($url) && ! $labeledPlaceholder) ) {
+                continue;
             }
             $showLabels = $showLabels || '' !== $text;
             $iconOnly = $iconOnly && '' === $text && $this->hasIcon($anchor);
@@ -62,7 +79,7 @@ final class SocialLinksPattern implements PatternRecognizerInterface
                 $context->presentationAttributes($sourceElement),
                 array_filter(array(
                 'url' => $url,
-                'service' => $this->service($url) ?? 'chain',
+                'service' => $service ?? 'chain',
                 'label' => $label,
                 ), static fn(string $value): bool => '' !== $value)
             ), array(), $sourceElement);
@@ -91,9 +108,7 @@ final class SocialLinksPattern implements PatternRecognizerInterface
     /** @param array<int,DOMElement> $anchors */
     private function isSocialCluster(DOMElement $element, array $anchors): bool
     {
-        $identity = strtolower($this->attr($element, 'class') . ' ' . $this->attr($element, 'aria-label') . ' ' . $this->attr($element, 'role'));
-        $explicit = 1 === preg_match('/(?:^|[^a-z])social(?:[^a-z]|$)/', $identity);
-        if ( $explicit ) {
+        if ( $this->isExplicitSocialCluster($element) ) {
             return true;
         }
 
@@ -106,6 +121,12 @@ final class SocialLinksPattern implements PatternRecognizerInterface
             }
         }
         return true;
+    }
+
+    private function isExplicitSocialCluster(DOMElement $element): bool
+    {
+        $identity = strtolower($this->attr($element, 'class') . ' ' . $this->attr($element, 'aria-label') . ' ' . $this->attr($element, 'role'));
+        return 1 === preg_match('/(?:^|[^a-z])social(?:[^a-z]|$)/', $identity);
     }
 
     /** @return array<int,DOMElement> */
@@ -155,6 +176,18 @@ final class SocialLinksPattern implements PatternRecognizerInterface
             }
         }
         return null;
+    }
+
+    private function serviceFromLabel(string $label): ?string
+    {
+        $normalized = strtolower(trim((string) preg_replace('/[^a-z0-9]+/i', ' ', $label)));
+        $normalized = preg_replace('/^(?:follow us on|follow|visit)\s+/', '', $normalized) ?? $normalized;
+        return self::LABEL_SERVICES[$normalized] ?? null;
+    }
+
+    private function isLocalPlaceholderUrl(string $url): bool
+    {
+        return str_starts_with(ltrim(trim($url), '/'), '#');
     }
 
     private function structuralItem(DOMElement $anchor, DOMElement $cluster): DOMElement

--- a/php-transformer/src/HtmlToBlocks/Patterns/SocialLinksPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/SocialLinksPattern.php
@@ -53,7 +53,7 @@ final class SocialLinksPattern implements PatternRecognizerInterface
         $showLabels = false;
         $iconOnly = true;
         $structuralItems = true;
-        $explicit = $this->isExplicitSocialCluster($element);
+        $explicit = self::isExplicitSocialCluster($element);
         foreach ( $anchors as $anchor ) {
             $url = LinkUrlSanitizer::sanitize($this->attr($anchor, 'href'));
             $label = trim($this->attr($anchor, 'aria-label'));
@@ -108,7 +108,7 @@ final class SocialLinksPattern implements PatternRecognizerInterface
     /** @param array<int,DOMElement> $anchors */
     private function isSocialCluster(DOMElement $element, array $anchors): bool
     {
-        if ( $this->isExplicitSocialCluster($element) ) {
+        if ( self::isExplicitSocialCluster($element) ) {
             return true;
         }
 
@@ -123,9 +123,9 @@ final class SocialLinksPattern implements PatternRecognizerInterface
         return true;
     }
 
-    private function isExplicitSocialCluster(DOMElement $element): bool
+    public static function isExplicitSocialCluster(DOMElement $element): bool
     {
-        $identity = strtolower($this->attr($element, 'class') . ' ' . $this->attr($element, 'aria-label') . ' ' . $this->attr($element, 'role'));
+        $identity = strtolower($element->getAttribute('class') . ' ' . $element->getAttribute('aria-label') . ' ' . $element->getAttribute('role'));
         return 1 === preg_match('/(?:^|[^a-z])social(?:[^a-z]|$)/', $identity);
     }
 

--- a/php-transformer/src/HtmlToBlocks/Support/ElementConversionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/ElementConversionTrait.php
@@ -396,6 +396,16 @@ trait ElementConversionTrait
             return $spacer;
         }
 
+        // Explicit social clusters are commonly authored as flex rows. Their
+        // core/social-links representation is more specific than generic
+        // author-owned layout preservation and carries the source presentation
+        // attributes itself, so recognize it before `display:flex` sends the
+        // container down the generic layout path.
+        $socialLinks = $this->recognizePatterns($element, $fallbacks, array(SocialLinksPattern::class));
+        if ( null !== $socialLinks ) {
+            return $socialLinks;
+        }
+
         $flankedSeparator = $this->flankedSeparatorBlockFromElement($element);
         if ( null !== $flankedSeparator ) {
             return $flankedSeparator;

--- a/php-transformer/src/HtmlToBlocks/Support/ElementConversionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/ElementConversionTrait.php
@@ -401,9 +401,11 @@ trait ElementConversionTrait
         // author-owned layout preservation and carries the source presentation
         // attributes itself, so recognize it before `display:flex` sends the
         // container down the generic layout path.
-        $socialLinks = $this->recognizePatterns($element, $fallbacks, array(SocialLinksPattern::class));
-        if ( null !== $socialLinks ) {
-            return $socialLinks;
+        if ( SocialLinksPattern::isExplicitSocialCluster($element) ) {
+            $socialLinks = $this->recognizePatterns($element, $fallbacks, array(SocialLinksPattern::class));
+            if ( null !== $socialLinks ) {
+                return $socialLinks;
+            }
         }
 
         $flankedSeparator = $this->flankedSeparatorBlockFromElement($element);

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -571,6 +571,9 @@ $assert(str_contains($socialLinksCss, '.wp-block-social-links.is-style-logos-onl
 $assert(! str_contains($socialLinksMarkup, 'style="gap:') && ! str_contains($socialLinksMarkup, '<li ') && ! str_contains($socialLinksMarkup, '<a href='), 'social-link children preserve their dynamic empty-save contract inside the canonical social-links wrapper');
 $assert('pass' === ($socialLinksResult['source_reports']['wp_block_validity']['status'] ?? ''), 'dynamic social-link children and their static parent remain WordPress-valid');
 
+$visibleSocialLabels = ( new HtmlTransformer() )->transform('<div class="social-links"><a href="https://github.com/Automattic/blocks-engine">Blocks Engine</a><a href="https://github.com/Automattic/static-site-importer">Static Site Importer</a></div>')->toArray();
+$assert(str_contains((string) ($visibleSocialLabels['serialized_blocks'] ?? ''), 'class="wp-block-social-links has-visible-labels social-links"'), 'social-links save markup carries the canonical has-visible-labels class when labels are shown');
+
 $spanSocialSource = '<span class="wsite-social wsite-social-default"><a class="wsite-social-item wsite-social-facebook" href="https://www.facebook.com/tasteandtravelitaly" aria-label="Facebook"><span class="wsite-social-item-inner"></span></a><a class="wsite-social-item wsite-social-twitter" href="//#" aria-label="Twitter"><span class="wsite-social-item-inner"></span></a><a class="wsite-social-item wsite-social-instagram" href="https://instagram.com/tasteandtravel_italy" aria-label="Instagram"><span class="wsite-social-item-inner"></span></a><a class="wsite-social-item wsite-social-mail" href="mailto:hello@example.com" aria-label="Mail"><span class="wsite-social-item-inner"></span></a></span>';
 $spanSocialResult = ( new HtmlTransformer() )->transform($spanSocialSource)->toArray();
 $spanSocialBlock = $spanSocialResult['blocks'][0] ?? array();

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -576,10 +576,25 @@ $spanSocialResult = ( new HtmlTransformer() )->transform($spanSocialSource)->toA
 $spanSocialBlock = $spanSocialResult['blocks'][0] ?? array();
 $spanSocialServices = array_map(static fn(array $link): string => (string) ($link['attrs']['service'] ?? ''), $spanSocialBlock['innerBlocks'] ?? array());
 $assert('core/social-links' === ($spanSocialBlock['blockName'] ?? null), 'inline social clusters convert to core/social-links instead of empty mark hooks');
-$assert(array( 'facebook', 'instagram', 'mail' ) === $spanSocialServices, 'placeholder social hrefs are skipped and mailto maps to the mail service', json_encode($spanSocialServices));
+$assert(array( 'facebook', 'twitter', 'instagram', 'mail' ) === $spanSocialServices, 'explicit labeled social placeholders infer their service while mailto maps to mail', json_encode($spanSocialServices));
 $assert(str_contains((string) ($spanSocialBlock['attrs']['className'] ?? ''), 'is-style-logos-only'), 'empty generated-content inners count as icon-only social presentation');
 $assert('small' === ($spanSocialBlock['attrs']['size'] ?? null), 'icon-font social clusters default to compact core size when source icons are not measured bitmaps');
 $assert(! str_contains((string) ($spanSocialResult['serialized_blocks'] ?? ''), '<mark'), 'icon-font inner spans are not lowered to mark');
+
+$placeholderSocialSource = '<style>.footer-social{display:flex;gap:14px}.footer-social a{display:inline-flex;width:32px;height:32px}</style><div class="footer-social"><a href="#" aria-label="LinkedIn"><svg width="14" height="14" aria-hidden="true"><path d="M0 0h1v1z"/></svg></a><a href="#" aria-label="X / Twitter"><svg width="14" height="14" aria-hidden="true"><path d="M0 0h1v1z"/></svg></a><a href="#" aria-label="YouTube"><svg width="14" height="14" aria-hidden="true"><path d="M0 0h1v1z"/></svg></a><a href="#" aria-label="GitHub"><svg width="14" height="14" aria-hidden="true"><path d="M0 0h1v1z"/></svg></a></div>';
+$placeholderSocialResult = ( new HtmlTransformer() )->transform($placeholderSocialSource)->toArray();
+$placeholderSocialBlock = $placeholderSocialResult['blocks'][0] ?? array();
+$placeholderSocialServices = array_map(static fn(array $link): string => (string) ($link['attrs']['service'] ?? ''), $placeholderSocialBlock['innerBlocks'] ?? array());
+$placeholderSocialUrls = array_map(static fn(array $link): string => (string) ($link['attrs']['url'] ?? ''), $placeholderSocialBlock['innerBlocks'] ?? array());
+$placeholderSocialLabels = array_map(static fn(array $link): string => (string) ($link['attrs']['label'] ?? ''), $placeholderSocialBlock['innerBlocks'] ?? array());
+$assert('core/social-links' === ($placeholderSocialBlock['blockName'] ?? null), 'explicit labeled social placeholders convert to core/social-links');
+$assert(array( 'linkedin', 'x', 'youtube', 'github' ) === $placeholderSocialServices, 'social placeholder services infer from accessible labels', json_encode($placeholderSocialServices));
+$assert(array( '#', '#', '#', '#' ) === $placeholderSocialUrls, 'social placeholder URLs survive unchanged', json_encode($placeholderSocialUrls));
+$assert(array( 'LinkedIn', 'X / Twitter', 'YouTube', 'GitHub' ) === $placeholderSocialLabels, 'social placeholder accessible labels survive', json_encode($placeholderSocialLabels));
+$assert(str_contains((string) ($placeholderSocialBlock['attrs']['className'] ?? ''), 'is-style-logos-only'), 'labeled SVG placeholders retain logos-only presentation');
+
+$unknownPlaceholderSocial = ( new HtmlTransformer() )->transform('<div class="footer-social"><a href="#" aria-label="Community"><svg aria-hidden="true"></svg></a></div>')->toArray();
+$assert('core/social-links' !== ($unknownPlaceholderSocial['blocks'][0]['blockName'] ?? null), 'unknown placeholder labels do not fabricate social services');
 
 $ordinaryFooterLinks = ( new HtmlTransformer() )->transform('<nav aria-label="Company"><a href="/about">About</a><a href="/contact">Contact</a></nav>')->toArray();
 $assert('core/navigation' === ($ordinaryFooterLinks['blocks'][0]['blockName'] ?? null), 'ordinary navigation does not become social links without profile-host or social-cluster semantics');

--- a/php-transformer/tests/unit/live-wp-parity-runner.php
+++ b/php-transformer/tests/unit/live-wp-parity-runner.php
@@ -110,6 +110,17 @@ $assert(
     '2: external entry reproduces the render-free proxy when fed the proxy candidate + same CSS'
 );
 
+$socialProxy = StaticStyleParityRunner::candidateHtmlFromSerializedBlocks(
+    '<!-- wp:social-links --><ul class="wp-block-social-links"><!-- wp:social-link {"url":"#","service":"github","label":"GitHub","className":"source-item"} /--></ul><!-- /wp:social-links -->'
+);
+$assert(
+    str_contains($socialProxy, '<li class="wp-social-link wp-social-link-github source-item">')
+        && str_contains($socialProxy, '<a href="#" class="wp-block-social-link-anchor">')
+        && str_contains($socialProxy, '<svg width="24" height="24"')
+        && str_contains($socialProxy, '>GitHub</span>'),
+    '2b: render-free proxy materializes the stable structure of dynamic social-link children'
+);
+
 // ---------------------------------------------------------------------------
 // 3. Faithful live render scores perfectly (parity == 1.0, no findings).
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1379.

After #1369/#1376 remove static-parity noise, the `28-enterprise-b2b` footer has four real findings left: its LinkedIn, X/Twitter, YouTube, and GitHub icons disappear.

The source is an explicit social cluster with accessible labels and placeholder URLs:

```html
<div class="footer-social">
  <a href="#" aria-label="LinkedIn"><svg aria-hidden="true">…</svg></a>
  <a href="#" aria-label="X / Twitter"><svg aria-hidden="true">…</svg></a>
  <a href="#" aria-label="YouTube"><svg aria-hidden="true">…</svg></a>
  <a href="#" aria-label="GitHub"><svg aria-hidden="true">…</svg></a>
</div>
```

Two independent gates prevented `SocialLinksPattern` from owning it:

1. `.footer-social { display:flex }` classified the container as generic author-owned layout before the more-specific social recognizer ran.
2. Even in isolation, `isUsableSocialUrl()` rejected every `#` URL before accessible labels could identify the services.

Generic RichText conversion then correctly removed each `aria-hidden` SVG as decorative, but that left four empty labeled controls. The icons are decorative *inside labeled controls*; the controls themselves are not disposable.

## Approach

- Run the conservative `SocialLinksPattern` before generic author-owned layout preservation. It carries source presentation attributes itself, so flex ownership is not lost.
- For an **explicitly identified** social cluster only, accept a local fragment placeholder when `aria-label`/`title` names a known WordPress social service.
- Keep host-based service detection authoritative for real URLs.
- Preserve the original URL and accessible label.
- Unknown labels and arbitrary placeholder-link clusters remain on the conservative fallback path.
- Materialize the stable wrapper/anchor/SVG structure of dynamic `core/social-link` children in the render-free parity proxy. Production serialization remains WordPress-canonical and self-closing; the proxy does not copy or own WordPress icon path data.
- Emit WordPress's required `has-visible-labels` save class when `showLabels` is true. The solved-site gate exposed this pre-existing serializer mismatch on `89-static-site-importer-architecture`; the corrected wrapper now validates as `wp-block-social-links has-visible-labels …`.

The full fixture now emits one valid `core/social-links` block with four `core/social-link` children:

```json
[
  { "url": "#", "service": "linkedin", "label": "LinkedIn" },
  { "url": "#", "service": "x", "label": "X / Twitter" },
  { "url": "#", "service": "youtube", "label": "YouTube" },
  { "url": "#", "service": "github", "label": "GitHub" }
]
```

`wp_block_validity.status` remains `pass`.

## Verification

```
composer test:canonical   passed
composer test:parity      289 fixtures passed
composer test:packaging   passed
solved-site promotion     passed (2 solved fixtures)
```

The contract covers the realistic styled flex row, exact service inference, URL/label retention, logos-only presentation, canonical visible-label save markup, the existing generated-content span cluster, and an unknown-label negative case.

The proxy unit contract also proves that a self-closing `core/social-link` comment becomes the stable server-rendered list item, anchor, SVG, and accessible-label structure needed by static comparison.

Combined with #1377, this takes the business fixture footer from **227 findings to zero**: 227 → 88 after #1372 → 4 after #1377 → 0 here. The full fixture moves from #1377's `277` findings to `273`:

```
28-enterprise-b2b  score=0.7182  property_parity=0.9491  coverage=0.7567  findings=273
```

---

*AI assistance disclosure: OpenAI GPT-5.6 Sol via OpenCode isolated the loss across recognizer ordering and URL validation, implemented the narrow explicit-label fallback, added the contract coverage, and verified the full fixture output. Chris Huber directed the work and remains responsible for the change.*
