### PR TITLE
Extract readable form block builder

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -157,6 +157,7 @@
             "php tests/unit/authored-form-control-block-converter.php",
             "php tests/unit/form-runtime-island-recorder.php",
             "php tests/unit/readable-form-control-block-converter.php",
+            "php tests/unit/readable-form-block-builder.php",
             "php tests/unit/form-runtime-requirement-analyzer.php",
             "php tests/unit/form-success-panel-metadata-builder.php",
             "php tests/unit/pseudo-form-analyzer.php",

--- a/php-transformer/src/HtmlToBlocks/Elements/ReadableFormBlockBuilder.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/ReadableFormBlockBuilder.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredInputBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
+use Closure;
+use DOMElement;
+
+/** Builds the readable static block representation of a form. */
+final class ReadableFormBlockBuilder
+{
+    /**
+     * @param Closure(DOMElement): array<string, mixed>                                                     $eventMetadata
+     * @param Closure(DOMElement): bool                                                                     $isRuntimeDomTarget
+     * @param Closure(DOMElement): array<string, mixed>                                                     $presentationAttributes
+     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
+     */
+    public function __construct(
+        private readonly FormControlMetadataBuilder $metadataBuilder,
+        private readonly ReadableFormControlBlockConverter $controlBlockConverter,
+        private readonly FormRuntimeIslandRecorder $runtimeIslandRecorder,
+        private readonly Runtime $runtime,
+        private readonly Closure $eventMetadata,
+        private readonly Closure $isRuntimeDomTarget,
+        private readonly Closure $presentationAttributes,
+        private readonly Closure $createBlock
+    ) {
+    }
+
+    /** @return array<string, mixed>|null */
+    public function build(DOMElement $form, bool $allowFormEvents = false): ?array
+    {
+        if ( 0 < $form->getElementsByTagName('script')->length
+            || ( ! $allowFormEvents && array() !== ($this->eventMetadata)($form) )
+        ) {
+            return null;
+        }
+
+        $contentBlocks = array();
+        $buttonBlocks = array();
+        foreach ( FormControlClassifier::controlElements($form) as $control ) {
+            if ( array() !== ($this->eventMetadata)($control) || ! FormControlClassifier::isReadableControl($control) ) {
+                return null;
+            }
+
+            if ( FormControlClassifier::isSubmitLikeControl($control) ) {
+                $buttonBlocks[] = ($this->createBlock)('core/button', array_merge(($this->presentationAttributes)($control), array(
+                    'text' => $this->runtime->escapeHtml($this->metadataBuilder->submitText($control, 'Submit')),
+                )), array(), $control);
+                continue;
+            }
+
+            if ( ($this->isRuntimeDomTarget)($control) ) {
+                $this->runtimeIslandRecorder->recordControl($control);
+            }
+
+            $readableControlBlock = $this->controlBlockConverter->convert($control);
+            if ( null === $readableControlBlock ) {
+                continue;
+            }
+
+            $fieldBlocks = array();
+            $associatedLabel = $this->metadataBuilder->associatedLabel($control);
+            if ( $associatedLabel instanceof DOMElement && AuthoredInputBlockGenerator::NAME === ($readableControlBlock['blockName'] ?? '') ) {
+                $labelBlock = $this->controlBlockConverter->convert($associatedLabel);
+                if ( null !== $labelBlock ) {
+                    $fieldBlocks[] = $labelBlock;
+                }
+            }
+            $fieldBlocks[] = $readableControlBlock;
+            $contentBlocks[] = ( 1 === count($fieldBlocks) && AuthoredInputBlockGenerator::NAME !== ($readableControlBlock['blockName'] ?? '') )
+                ? $fieldBlocks[0]
+                : ($this->createBlock)('core/group', array(), $fieldBlocks, $control);
+        }
+
+        if ( array() !== $buttonBlocks ) {
+            $contentBlocks[] = ($this->createBlock)('core/buttons', array(), $buttonBlocks, $form);
+        }
+
+        if ( array() === $contentBlocks ) {
+            return null;
+        }
+
+        return ($this->createBlock)('core/group', ($this->presentationAttributes)($form), $contentBlocks, $form);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -39,6 +39,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormRuntimeRequ
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormRuntimeIslandRecorder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormSuccessPanelMetadataBuilder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ReadableFormControlBlockConverter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ReadableFormBlockBuilder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\PseudoFormAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandContext;
@@ -276,6 +277,8 @@ final class HtmlTransformer
 
     private readonly ReadableFormControlBlockConverter $readableFormControlBlockConverter;
 
+    private readonly ReadableFormBlockBuilder $readableFormBlockBuilder;
+
     private readonly PseudoFormAnalyzer $pseudoFormAnalyzer;
 
     private readonly FormRuntimeRequirementAnalyzer $formRuntimeRequirementAnalyzer;
@@ -458,6 +461,16 @@ final class HtmlTransformer
             function (string $text): void {
                 $this->registerFormControlEcho($text);
             }
+        );
+        $this->readableFormBlockBuilder = new ReadableFormBlockBuilder(
+            $this->formControlMetadataBuilder,
+            $this->readableFormControlBlockConverter,
+            $this->formRuntimeIslandRecorder,
+            $this->runtime,
+            fn (DOMElement $element): array => $this->eventMetadata($element),
+            fn (DOMElement $element): bool => $this->runtimeIslands->isRuntimeDomTarget($element),
+            fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
+            fn (string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement)
         );
         $this->formRuntimeRequirementAnalyzer = new FormRuntimeRequirementAnalyzer(
             fn (DOMElement $element): array => $this->eventMetadata($element),

--- a/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support;
 
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredInputBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackDiagnostic;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\FormControlTopologyBuilder;
@@ -33,7 +32,7 @@ trait FormDispatchTrait
             }
         }
 
-        $readableFormBlock = $this->readableFormBlockFromForm($element);
+        $readableFormBlock = $this->readableFormBlockBuilder->build($element);
         if ( null !== $readableFormBlock && ! $this->formRuntimeRequirementAnalyzer->requiresPreservation($element) ) {
             if ( FormControlClassifier::hasDataEntryControls($element) ) {
                 $fallbacks[] = $this->formFallbackFinding($element, $readableFormBlock);
@@ -50,7 +49,7 @@ trait FormDispatchTrait
             return $preservationBlock;
         }
 
-        $readableFormBlock = $this->readableFormBlockFromForm($element, true);
+        $readableFormBlock = $this->readableFormBlockBuilder->build($element, true);
         $this->formRuntimeIslandRecorder->recordForm($element, $readableFormBlock);
 
         // Surface a form fallback finding so a downstream consumer can map the
@@ -70,65 +69,8 @@ trait FormDispatchTrait
         // Some signup/contact widgets pair data-entry controls with a submit-like
         // control inside a plain container. Emit the same finding as a real form.
         if ( $this->pseudoFormAnalyzer->isPseudoForm($element) ) {
-            $fallbacks[] = $this->formFallbackFinding($element, $this->readableFormBlockFromForm($element, true));
+            $fallbacks[] = $this->formFallbackFinding($element, $this->readableFormBlockBuilder->build($element, true));
         }
-    }
-
-    /**
-     * @return array<string, mixed>|null
-     */
-    private function readableFormBlockFromForm(DOMElement $form, bool $allowFormEvents = false): ?array
-    {
-        if ( 0 < $form->getElementsByTagName('script')->length || ( ! $allowFormEvents && array() !== $this->eventMetadata($form) ) ) {
-            return null;
-        }
-
-        $contentBlocks = array();
-        $buttonBlocks = array();
-        foreach ( FormControlClassifier::controlElements($form) as $control ) {
-            if ( array() !== $this->eventMetadata($control) || ! FormControlClassifier::isReadableControl($control) ) {
-                return null;
-            }
-
-            if ( FormControlClassifier::isSubmitLikeControl($control) ) {
-                $buttonBlocks[] = $this->createBlock('core/button', array_merge($this->styleResolver->presentationAttributes($control), array(
-                    'text' => $this->runtime->escapeHtml($this->formControlMetadataBuilder->submitText($control, 'Submit')),
-                )), array(), $control);
-                continue;
-            }
-
-            if ( $this->runtimeIslands->isRuntimeDomTarget($control) ) {
-                $this->formRuntimeIslandRecorder->recordControl($control);
-            }
-
-            $readableControlBlock = $this->readableFormControlBlockConverter->convert($control);
-            if ( null === $readableControlBlock ) {
-                continue;
-            }
-
-            $fieldBlocks = array();
-            $associatedLabel = $this->formControlMetadataBuilder->associatedLabel($control);
-            if ( $associatedLabel instanceof DOMElement && AuthoredInputBlockGenerator::NAME === ($readableControlBlock['blockName'] ?? '') ) {
-                $labelBlock = $this->readableFormControlBlockConverter->convert($associatedLabel);
-                if ( null !== $labelBlock ) {
-                    $fieldBlocks[] = $labelBlock;
-                }
-            }
-            $fieldBlocks[] = $readableControlBlock;
-            $contentBlocks[] = ( 1 === count($fieldBlocks) && AuthoredInputBlockGenerator::NAME !== ($readableControlBlock['blockName'] ?? '') )
-                ? $fieldBlocks[0]
-                : $this->createBlock('core/group', array(), $fieldBlocks, $control);
-        }
-
-        if ( array() !== $buttonBlocks ) {
-            $contentBlocks[] = $this->createBlock('core/buttons', array(), $buttonBlocks, $form);
-        }
-
-        if ( array() === $contentBlocks ) {
-            return null;
-        }
-
-        return $this->createBlock('core/group', $this->styleResolver->presentationAttributes($form), $contentBlocks, $form);
     }
 
     /**

--- a/php-transformer/tests/unit/readable-form-block-builder.php
+++ b/php-transformer/tests/unit/readable-form-block-builder.php
@@ -1,0 +1,133 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\AuthoredFormControlBlockConverter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormControlMetadataBuilder;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormRuntimeIslandRecorder;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ReadableFormBlockBuilder;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ReadableFormControlBlockConverter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredInputBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
+
+$assertions = 0;
+$failures = array();
+$assert = static function (bool $condition, string $label) use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']';
+    }
+};
+
+$formFrom = static function (string $html): DOMElement {
+    $document = new DOMDocument();
+    $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+    $form = $document->getElementsByTagName('form')->item(0);
+    if ( $form instanceof DOMElement ) {
+        return $form;
+    }
+    throw new RuntimeException('No form parsed');
+};
+
+$createBlock = static fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => array(
+    'blockName' => $name,
+    'attrs' => $attrs,
+    'innerBlocks' => $innerBlocks,
+);
+$presentationAttributes = static fn (DOMElement $element): array => array( 'className' => 'presented-' . strtolower($element->tagName) );
+$eventMetadata = static fn (DOMElement $element): array => $element->hasAttribute('data-event') ? array( 'submit' => true ) : array();
+$isRuntimeDomTarget = static fn (DOMElement $element): bool => $element->hasAttribute('data-runtime');
+$recorded = array();
+$echoes = array();
+$metadataBuilder = new FormControlMetadataBuilder(static fn (DOMElement $element): string => strtolower($element->tagName));
+$runtimeRecorder = new FormRuntimeIslandRecorder(
+    $metadataBuilder,
+    static function (DOMElement $element, string $kind, string $reason, string $capability, array $metadata) use (&$recorded): void {
+        $recorded[] = compact('kind', 'reason', 'capability', 'metadata');
+    },
+    $eventMetadata,
+    static fn (DOMElement $element): array => array()
+);
+$authoredConverter = new AuthoredFormControlBlockConverter(
+    $metadataBuilder,
+    static fn (DOMElement $element): array => $element->hasAttribute('data-styled') ? array( 'display' => 'block' ) : array(),
+    $presentationAttributes,
+    $createBlock,
+    static function (string $identity, array $definition): void {
+    },
+    static function (string $text) use (&$echoes): void {
+        $echoes[] = $text;
+    },
+    static fn (string $text): string => htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+    static fn (string $id): string => $id
+);
+$controlConverter = new ReadableFormControlBlockConverter(
+    $metadataBuilder,
+    $authoredConverter,
+    $runtimeRecorder,
+    new Runtime(),
+    $eventMetadata,
+    $isRuntimeDomTarget,
+    static fn (DOMElement $element): array => array( 'blockName' => 'core/html', 'attrs' => array( 'content' => 'preserved' ) ),
+    $presentationAttributes,
+    $createBlock,
+    static function (string $text) use (&$echoes): void {
+        $echoes[] = $text;
+    }
+);
+$builder = new ReadableFormBlockBuilder(
+    $metadataBuilder,
+    $controlConverter,
+    $runtimeRecorder,
+    new Runtime(),
+    $eventMetadata,
+    $isRuntimeDomTarget,
+    $presentationAttributes,
+    $createBlock
+);
+
+$assert(null === $builder->build($formFrom('<form></form>')), 'empty-form-declines-block');
+$assert(null === $builder->build($formFrom('<form><script>submit()</script><input></form>')), 'scripted-form-declines-block');
+
+$eventForm = $formFrom('<form data-event><input aria-label="Email"></form>');
+$assert(null === $builder->build($eventForm), 'eventful-form-declines-by-default');
+$assert('core/group' === ($builder->build($eventForm, true)['blockName'] ?? ''), 'eventful-form-builds-when-allowed');
+
+$assert(null === $builder->build($formFrom('<form><input data-event></form>')), 'eventful-control-declines-form');
+$assert(null === $builder->build($formFrom('<form><input type="hidden" value="secret"></form>')), 'unreadable-control-declines-form');
+
+$echoes = array();
+$plain = $builder->build($formFrom('<form><input aria-label="Email" value="a&amp;b" required></form>'));
+$assert('core/group' === ($plain['blockName'] ?? ''), 'plain-form-builds-group');
+$assert('presented-form' === ($plain['attrs']['className'] ?? ''), 'form-presentation-is-retained');
+$assert('core/paragraph' === ($plain['innerBlocks'][0]['blockName'] ?? ''), 'plain-control-remains-direct-child');
+$assert('Email: a&amp;b (required)' === ($plain['innerBlocks'][0]['attrs']['content'] ?? ''), 'plain-control-summary-is-retained');
+$assert(array( 'Email: a&b (required)' ) === $echoes, 'plain-control-registers-echo');
+
+$submit = $builder->build($formFrom('<form><button type="submit">Join &amp; Go</button></form>'));
+$buttons = $submit['innerBlocks'][0] ?? array();
+$assert('core/buttons' === ($buttons['blockName'] ?? ''), 'submit-controls-build-buttons-container');
+$assert('Join &amp; Go' === ($buttons['innerBlocks'][0]['attrs']['text'] ?? ''), 'submit-text-is-escaped');
+$assert('presented-button' === ($buttons['innerBlocks'][0]['attrs']['className'] ?? ''), 'submit-presentation-is-retained');
+
+$combined = $builder->build($formFrom('<form><input aria-label="Email"><button type="submit">Join</button></form>'));
+$assert('core/paragraph' === ($combined['innerBlocks'][0]['blockName'] ?? '') && 'core/buttons' === ($combined['innerBlocks'][1]['blockName'] ?? ''), 'submit-buttons-follow-fields');
+
+$styled = $builder->build($formFrom('<form><label for="email">Email</label><input data-styled id="email" name="email"></form>'));
+$fieldGroup = $styled['innerBlocks'][0] ?? array();
+$assert('core/group' === ($fieldGroup['blockName'] ?? ''), 'authored-input-builds-field-group');
+$assert('core/paragraph' === ($fieldGroup['innerBlocks'][0]['blockName'] ?? ''), 'associated-label-precedes-authored-input');
+$assert(AuthoredInputBlockGenerator::NAME === ($fieldGroup['innerBlocks'][1]['blockName'] ?? ''), 'authored-input-follows-associated-label');
+
+$recorded = array();
+$runtimeForm = $builder->build($formFrom('<form><input data-runtime name="email"></form>'));
+$assert('core/html' === ($runtimeForm['innerBlocks'][0]['blockName'] ?? ''), 'runtime-control-is-preserved');
+$assert(array() !== $recorded && 'runtime_dom_target' === ($recorded[0]['reason'] ?? ''), 'runtime-control-records-island');
+
+if ( $failures ) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Readable form block builder tests: ' . $assertions . " passed\n";


### PR DESCRIPTION
## Summary
- extract readable form assembly into `ReadableFormBlockBuilder`
- centralize form/control rejection, submit-button grouping, associated-label placement, runtime-control recording, and field ordering
- route real and pseudo-form readable representations through the typed builder
- reduce `FormDispatchTrait` from 284 to 226 lines
- add a 20-assertion direct builder contract

## Verification
- `composer test`
- PHP transformer parity: 289 fixtures
- distribution shape: 203 files, 10 monorepo-only trees excluded
- exact-base CSS-attached corpus comparison: byte-identical records for 383 documents / 87 fixtures / 82 fixtures with CSS / 0 throws

Part of #242.

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to extract the readable form assembly boundary, implement the direct contract, and run the package suite and exact-base corpus comparison.