### PR TITLE
Extract form composition planner

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -158,6 +158,7 @@
             "php tests/unit/form-runtime-island-recorder.php",
             "php tests/unit/readable-form-control-block-converter.php",
             "php tests/unit/readable-form-block-builder.php",
+            "php tests/unit/form-composition-planner.php",
             "php tests/unit/form-runtime-requirement-analyzer.php",
             "php tests/unit/form-success-panel-metadata-builder.php",
             "php tests/unit/pseudo-form-analyzer.php",

--- a/php-transformer/src/HtmlToBlocks/Elements/FormCompositionPlanner.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FormCompositionPlanner.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\TransformationProvenanceState;
+use Closure;
+use DOMElement;
+
+/** Preserves one controls-only subtree as a provider binding slot. */
+final class FormCompositionPlanner
+{
+    /**
+     * @param Closure(): TransformationProvenanceState                                                     $transformationProvenance
+     * @param Closure(DOMElement, array<int, array<string, mixed>>&, bool): array<int, array<string, mixed>> $convertChildren
+     * @param Closure(DOMElement): array<string, mixed>                                                     $presentationAttributes
+     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
+     * @param Closure(DOMElement, DOMElement): bool                                                         $elementContains
+     */
+    public function __construct(
+        private readonly Closure $transformationProvenance,
+        private readonly Closure $convertChildren,
+        private readonly Closure $presentationAttributes,
+        private readonly Closure $createBlock,
+        private readonly Closure $elementContains
+    ) {
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array{block: array<string, mixed>, slot: array<string, mixed>}|null
+     */
+    public function compose(DOMElement $form, array &$fallbacks): ?array
+    {
+        $slot = $this->controlSlotElement($form);
+        if ( null === $slot ) {
+            return null;
+        }
+
+        $path = $slot->getNodePath();
+        $provenance = ($this->transformationProvenance)();
+        $token = $provenance->reserveFormControlSlot($path);
+        try {
+            $children = ($this->convertChildren)($form, $fallbacks, true);
+        } finally {
+            $provenance->releaseFormControlSlot($path);
+        }
+        $slotBlock = $this->blockForBindingToken($children, $token);
+        if ( array() === $children || null === $slotBlock ) {
+            return null;
+        }
+
+        return array(
+            'block' => ($this->createBlock)('core/group', ($this->presentationAttributes)($form), $children, $form),
+            'slot'  => $slotBlock,
+        );
+    }
+
+    /** @param array<int, array<string, mixed>> $blocks @return array<string, mixed>|null */
+    private function blockForBindingToken(array $blocks, string $token): ?array
+    {
+        foreach ( $blocks as $block ) {
+            if ( ! is_array($block) ) {
+                continue;
+            }
+            if ( $token === ($block['_binding_token'] ?? null) ) {
+                return $block;
+            }
+            $nested = $this->blockForBindingToken(is_array($block['innerBlocks'] ?? null) ? $block['innerBlocks'] : array(), $token);
+            if ( null !== $nested ) {
+                return $nested;
+            }
+        }
+
+        return null;
+    }
+
+    private function controlSlotElement(DOMElement $form): ?DOMElement
+    {
+        $controls = array_values(array_filter(
+            FormControlClassifier::controlElements($form),
+            static fn (DOMElement $control): bool => 'hidden' !== FormControlClassifier::controlType($control)
+        ));
+        if ( array() === $controls ) {
+            return null;
+        }
+
+        $formPath = $form->getNodePath();
+        $slot = null;
+        for ( $candidate = $controls[0]->parentNode; $candidate instanceof DOMElement && $candidate->getNodePath() !== $formPath; $candidate = $candidate->parentNode ) {
+            if ( array_filter($controls, fn (DOMElement $control): bool => ! ($this->elementContains)($candidate, $control)) ) {
+                continue;
+            }
+            foreach ( $candidate->childNodes as $child ) {
+                if ( XML_TEXT_NODE === $child->nodeType && '' !== trim($child->textContent ?? '') ) {
+                    continue 2;
+                }
+                if ( ! $child instanceof DOMElement ) {
+                    continue;
+                }
+                if ( ! array_filter($controls, fn (DOMElement $control): bool => ($this->elementContains)($child, $control)) ) {
+                    continue 2;
+                }
+            }
+            $slot = $candidate;
+        }
+
+        return $slot;
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -35,6 +35,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispa
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispatcher;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\AuthoredFormControlBlockConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormControlMetadataBuilder;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormCompositionPlanner;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormRuntimeRequirementAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormRuntimeIslandRecorder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormSuccessPanelMetadataBuilder;
@@ -279,6 +280,8 @@ final class HtmlTransformer
 
     private readonly ReadableFormBlockBuilder $readableFormBlockBuilder;
 
+    private readonly FormCompositionPlanner $formCompositionPlanner;
+
     private readonly PseudoFormAnalyzer $pseudoFormAnalyzer;
 
     private readonly FormRuntimeRequirementAnalyzer $formRuntimeRequirementAnalyzer;
@@ -471,6 +474,15 @@ final class HtmlTransformer
             fn (DOMElement $element): bool => $this->runtimeIslands->isRuntimeDomTarget($element),
             fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
             fn (string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement)
+        );
+        $this->formCompositionPlanner = new FormCompositionPlanner(
+            fn (): TransformationProvenanceState => $this->transformationProvenance(),
+            function (DOMElement $element, array &$fallbacks, bool $captureUnsupported): array {
+                return $this->convertChildren($element, $fallbacks, $captureUnsupported);
+            },
+            fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
+            fn (string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
+            fn (DOMElement $container, DOMElement $element): bool => $this->elementContains($container, $element)
         );
         $this->formRuntimeRequirementAnalyzer = new FormRuntimeRequirementAnalyzer(
             fn (DOMElement $element): array => $this->eventMetadata($element),

--- a/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
@@ -24,7 +24,7 @@ trait FormDispatchTrait
         }
 
         if ( FormControlClassifier::hasDataEntryControls($element) ) {
-            $composition = $this->compositionalFormBlock($element, $fallbacks);
+            $composition = $this->formCompositionPlanner->compose($element, $fallbacks);
             if ( null !== $composition ) {
                 $fallbacks[] = $this->formFallbackFinding($element, $composition['block'], $composition['slot']);
                 $this->formRuntimeIslandRecorder->recordForm($element, $composition['block']);
@@ -71,68 +71,6 @@ trait FormDispatchTrait
         if ( $this->pseudoFormAnalyzer->isPseudoForm($element) ) {
             $fallbacks[] = $this->formFallbackFinding($element, $this->readableFormBlockBuilder->build($element, true));
         }
-    }
-
-    /**
-     * Preserve one unambiguous controls-only subtree as the provider binding
-     * slot while converting the form's surrounding visual content normally.
-     *
-     * @param array<int,array<string,mixed>> $fallbacks
-     * @return array{block:array<string,mixed>,slot:array<string,mixed>}|null
-     */
-    private function compositionalFormBlock(DOMElement $form, array &$fallbacks): ?array
-    {
-        $slot = $this->formControlSlotElement($form);
-        if ( null === $slot ) return null;
-
-        $path = $slot->getNodePath();
-        $token = $this->transformationProvenance()->reserveFormControlSlot($path);
-        try {
-            $children = $this->convertChildren($form, $fallbacks, true);
-        } finally {
-            $this->transformationProvenance()->releaseFormControlSlot($path);
-        }
-        $slotBlock = $this->blockForBindingToken($children, $token);
-        if ( array() === $children || null === $slotBlock ) return null;
-
-        return array(
-            'block' => $this->createBlock('core/group', $this->styleResolver->presentationAttributes($form), $children, $form),
-            'slot'  => $slotBlock,
-        );
-    }
-
-    /** @param array<int,array<string,mixed>> $blocks @return array<string,mixed>|null */
-    private function blockForBindingToken(array $blocks, string $token): ?array
-    {
-        foreach ($blocks as $block) {
-            if (!is_array($block)) continue;
-            if ($token === ($block['_binding_token'] ?? null)) return $block;
-            $nested = $this->blockForBindingToken(is_array($block['innerBlocks'] ?? null) ? $block['innerBlocks'] : array(), $token);
-            if (null !== $nested) return $nested;
-        }
-        return null;
-    }
-
-    private function formControlSlotElement(DOMElement $form): ?DOMElement
-    {
-        $controls = array_values(array_filter(
-            FormControlClassifier::controlElements($form),
-            static fn(DOMElement $control): bool => 'hidden' !== FormControlClassifier::controlType($control)
-        ));
-        if ( array() === $controls ) return null;
-
-        $formPath = $form->getNodePath();
-        $slot = null;
-        for ( $candidate = $controls[0]->parentNode; $candidate instanceof DOMElement && $candidate->getNodePath() !== $formPath; $candidate = $candidate->parentNode ) {
-            if ( array_filter($controls, fn(DOMElement $control): bool => !$this->elementContains($candidate, $control)) ) continue;
-            foreach ( $candidate->childNodes as $child ) {
-                if ( XML_TEXT_NODE === $child->nodeType && '' !== trim($child->textContent ?? '') ) continue 2;
-                if ( !$child instanceof DOMElement ) continue;
-                if ( !array_filter($controls, fn(DOMElement $control): bool => $this->elementContains($child, $control)) ) continue 2;
-            }
-            $slot = $candidate;
-        }
-        return $slot;
     }
 
     /**

--- a/php-transformer/tests/unit/form-composition-planner.php
+++ b/php-transformer/tests/unit/form-composition-planner.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormCompositionPlanner;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\TransformationProvenanceState;
+
+$assertions = 0;
+$failures = array();
+$assert = static function (bool $condition, string $label) use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']';
+    }
+};
+
+$formFrom = static function (string $html): DOMElement {
+    $document = new DOMDocument();
+    $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+    $form = $document->getElementsByTagName('form')->item(0);
+    if ( $form instanceof DOMElement ) {
+        return $form;
+    }
+    throw new RuntimeException('No form parsed');
+};
+
+$provenance = new TransformationProvenanceState();
+$children = array();
+$capturedUnsupported = null;
+$planner = new FormCompositionPlanner(
+    static fn (): TransformationProvenanceState => $provenance,
+    static function (DOMElement $form, array &$fallbacks, bool $captureUnsupported) use (&$children, &$capturedUnsupported, $provenance): array {
+        $capturedUnsupported = $captureUnsupported;
+        $fallbacks[] = array( 'converted' => true );
+        $slot = $form->getElementsByTagName('fieldset')->item(0);
+        $token = $slot instanceof DOMElement ? $provenance->formControlSlotToken($slot->getNodePath()) : null;
+
+        return 'nested' === $children
+            ? array( array( 'blockName' => 'core/group', 'innerBlocks' => array( array( 'blockName' => 'core/html', '_binding_token' => $token ) ) ) )
+            : $children;
+    },
+    static fn (DOMElement $element): array => array( 'className' => 'presented-' . strtolower($element->tagName) ),
+    static fn (string $name, array $attrs, array $innerBlocks, ?DOMElement $sourceElement): array => array(
+        'blockName' => $name,
+        'attrs' => $attrs,
+        'innerBlocks' => $innerBlocks,
+        'sourceTag' => $sourceElement?->tagName,
+    ),
+    static function (DOMElement $container, DOMElement $element): bool {
+        for ( $node = $element; $node instanceof DOMElement; $node = $node->parentNode ) {
+            if ( $node === $container ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+);
+
+$fallbacks = array();
+$assert(null === $planner->compose($formFrom('<form></form>'), $fallbacks), 'empty-form-has-no-composition');
+$assert(null === $planner->compose($formFrom('<form><input type="hidden"></form>'), $fallbacks), 'hidden-control-has-no-composition');
+$assert(null === $planner->compose($formFrom('<form><fieldset>Heading<input></fieldset></form>'), $fallbacks), 'text-bearing-slot-is-rejected');
+$assert(null === $planner->compose($formFrom('<form><div><input></div><div><input></div></form>'), $fallbacks), 'split-controls-have-no-slot');
+
+$children = array();
+$fallbacks = array();
+$assert(null === $planner->compose($formFrom('<form><fieldset><input></fieldset></form>'), $fallbacks), 'empty-conversion-declines-composition');
+$assert(true === $capturedUnsupported, 'composition-captures-unsupported-children');
+$assert(array( array( 'converted' => true ) ) === $fallbacks, 'conversion-can-append-fallbacks');
+
+$children = array( array( 'blockName' => 'core/paragraph', 'innerBlocks' => array() ) );
+$assert(null === $planner->compose($formFrom('<form><fieldset><input></fieldset></form>'), $fallbacks), 'missing-binding-token-declines-composition');
+
+$children = 'nested';
+$form = $formFrom('<form><p>Introduction</p><fieldset><label>Email<input></label></fieldset></form>');
+$composition = $planner->compose($form, $fallbacks);
+$assert('core/group' === ($composition['block']['blockName'] ?? ''), 'composition-builds-group');
+$assert('presented-form' === ($composition['block']['attrs']['className'] ?? ''), 'form-presentation-is-retained');
+$assert('form' === ($composition['block']['sourceTag'] ?? ''), 'form-remains-group-source');
+$assert('core/html' === ($composition['slot']['blockName'] ?? ''), 'nested-binding-block-is-returned');
+$fieldset = $form->getElementsByTagName('fieldset')->item(0);
+$assert($fieldset instanceof DOMElement && null === $provenance->formControlSlotToken($fieldset->getNodePath()), 'binding-slot-token-is-released');
+
+if ( $failures ) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Form composition planner tests: ' . $assertions . " passed\n";


### PR DESCRIPTION
## Summary
- extract controls-only binding slot selection and composition planning into `FormCompositionPlanner`
- keep child conversion, presentation resolution, block creation, provenance, and DOM containment behind explicit collaborator callbacks
- guarantee temporary binding-slot release while returning the nested provider binding block
- reduce `FormDispatchTrait` from 226 to 163 lines
- add a 13-assertion direct planner contract

## Verification
- `composer validate --strict`
- `composer test`
- PHP transformer parity: 289 fixtures
- distribution shape: 204 files, 10 monorepo-only trees excluded
- exact-base CSS-attached corpus comparison: byte-identical records for 383 documents / 87 fixtures / 82 fixtures with CSS / 0 throws

Part of #242.

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to identify and extract the form composition boundary, implement the direct contract, and run the package suite and exact-base corpus comparison.