### PR TITLE
Extract nested responsive shell variants

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -614,6 +614,7 @@ final class ArtifactCompiler
         $this->indexFiles($normalized['files']);
         $entryBlocks = is_array($reduction['entry_blocks'] ?? null) ? $reduction['entry_blocks'] : $this->compileEntryBlocks($html, $entryPath, $normalized['files'], $companionPluginPayloadBuilder->blockNamespace($artifact));
         $compiledHtmlDocuments = is_array($reduction['compiled_documents'] ?? null) ? $reduction['compiled_documents'] : $this->compileHtmlSourceDocuments($normalized['files'], $entryPath, $companionPluginPayloadBuilder->blockNamespace($artifact));
+        $inlineShellCompilation = $this->compileSharedInlineShells($normalized['files'], $entryPath, $companionPluginPayloadBuilder->blockNamespace($artifact));
         $authorStylesheetProjections = $entryBlocks['author_stylesheet_projections'];
         $allDiagnostics = $this->entryTransformDiagnostics($entryBlocks['diagnostics'], $entryPath);
         $allFallbacks = $entryBlocks['fallbacks'];
@@ -637,6 +638,13 @@ final class ArtifactCompiler
         $manifestAssets = $this->assetManifest($normalized['files'], $entryPath, $referenceReports['asset_references'], $html);
         $entryOwnership = is_array($entry) ? $this->fileOwnership($entry) : array('scope' => 'page', 'id' => $entryPath);
         $generatedAssets = $this->generatedAssetsForDocuments($entryBlocks['assets'], $entryOwnership, $compiledHtmlDocuments, $normalized['files']);
+        $generatedAssetIdentities = array();
+        foreach ($generatedAssets as $asset) $generatedAssetIdentities[hash('sha256', (string) ($asset['path'] ?? '') . "\0" . (string) ($asset['content'] ?? ''))] = true;
+        foreach ($inlineShellCompilation['assets'] as $asset) {
+            $identity = hash('sha256', (string) ($asset['path'] ?? '') . "\0" . (string) ($asset['content'] ?? ''));
+            if (isset($generatedAssetIdentities[$identity])) continue;
+            $generatedAssetIdentities[$identity] = true; $generatedAssets[] = $asset;
+        }
         $projectedAdminBarAsset = $this->projectedAdminBarAccommodationAsset($normalized['files']);
         if (null !== $projectedAdminBarAsset) {
             $generatedAssets[] = $projectedAdminBarAsset;
@@ -698,7 +706,7 @@ final class ArtifactCompiler
                 'projected_dialog_count' => $capturedDialogs['projected_count'],
             );
         }
-        $sourceReports['compiled_site'] = $this->compiledSiteReport($normalized, $entryPath, $documents['documents'], $assets, $blockTypes, $serializedBlocks, $entryBlocks['shell_artifacts'], $compiledHtmlDocuments);
+        $sourceReports['compiled_site'] = $this->compiledSiteReport($normalized, $entryPath, $documents['documents'], $assets, $blockTypes, $serializedBlocks, $entryBlocks['shell_artifacts'], $compiledHtmlDocuments, $inlineShellCompilation['artifacts']);
         $identityFailures = WordPressSitePlan::compiledSiteIdentityFailures($sourceReports['compiled_site']);
         foreach ( WordPressSitePlan::documentIdentityDiagnostics($identityFailures) as $identityDiagnostic ) {
             $diagnostics[] = array_merge($identityDiagnostic, array('source' => self::class));
@@ -4087,13 +4095,145 @@ final class ArtifactCompiler
     }
 
     /**
+     * Compile route-shared nested shell landmarks in isolation so generated
+     * support classes and CSS are canonical rather than page-seeded.
+     *
+     * @param array<int,array<string,mixed>> $files
+     * @return array{artifacts:array<int,array<string,mixed>>,assets:array<int,array<string,mixed>>}
+     */
+    private function compileSharedInlineShells(array $files, string $entryPath, string $generatedBlockNamespace): array
+    {
+        $documents = array();
+        foreach ($files as $file) {
+            if ('html' !== ($file['kind'] ?? null) || $this->isTemplatePartFile($file) || !is_string($file['content'] ?? null) || '' === trim($file['content'])) continue;
+            $dom = new \DOMDocument();
+            $previous = libxml_use_internal_errors(true);
+            $loaded = $dom->loadHTML((string) $file['content']);
+            libxml_clear_errors();
+            libxml_use_internal_errors($previous);
+            if (!$loaded) continue;
+            $rows = array('header' => array(), 'footer' => array());
+            $body = $dom->getElementsByTagName('body')->item(0);
+            if (!$body instanceof \DOMElement) continue;
+            $walk = static function (\DOMElement $parent, bool $insideContent = false) use (&$walk, &$rows, $dom): void {
+                foreach ($parent->childNodes as $child) {
+                    if (!$child instanceof \DOMElement) continue;
+                    $tag = strtolower($child->tagName);
+                    $content = $insideContent || in_array($tag, array('main', 'article', 'section', 'aside'), true);
+                    $area = ShellLandmarkPolicy::landmarkKind($tag, trim($child->getAttribute('role')));
+                    if (!$content && isset($rows[$area])) {
+                        $markup = $dom->saveHTML($child);
+                        if (is_string($markup) && '' !== $markup) $rows[$area][] = array('markup' => $markup, 'identity' => self::normalizeSourceShellIdentity($markup));
+                    }
+                    $walk($child, $content);
+                }
+            };
+            $walk($body);
+            $documents[(string) $file['path']] = array('content' => (string) $file['content'], 'rows' => $rows);
+        }
+        if (count($documents) < 2) return array('artifacts' => array(), 'assets' => array());
+
+        $artifacts = array();
+        $assets = array();
+        foreach (array('header', 'footer') as $area) {
+            $variantCount = null; $canonicalMarkups = array();
+            $sourcePath = isset($documents[$entryPath]) ? $entryPath : (string) array_key_first($documents);
+            foreach ($documents as $document) {
+                $count = count($document['rows'][$area]);
+                if (0 === $count || (null !== $variantCount && $variantCount !== $count)) { $variantCount = null; break; }
+                $variantCount = $count;
+            }
+            if (null === $variantCount) continue;
+            for ($variant = 0; $variant < $variantCount; ++$variant) {
+                $identities = self::normalizeSourceShellRootClasses(array_map(static fn(array $document): string => $document['rows'][$area][$variant]['identity'], $documents));
+                if (1 !== count(array_unique($identities))) continue 2;
+                $canonicalMarkups[$variant] = $identities[$sourcePath];
+            }
+            $head = preg_match('/<head\b[^>]*>(.*?)<\/head>/is', $documents[$sourcePath]['content'], $headMatch) ? $headMatch[1] : '';
+            foreach ($documents[$sourcePath]['rows'][$area] as $variant => $row) {
+                $synthetic = '<!doctype html><html><head>' . $head . '</head><body>' . $canonicalMarkups[$variant] . '</body></html>';
+                $compiled = $this->compileHtmlDocumentBlocks($synthetic, $sourcePath, $files, 'artifact-shared-shell', $generatedBlockNamespace, true);
+                $shell = current(array_filter($compiled['shell_artifacts'], static fn(array $candidate): bool => $area === ($candidate['area'] ?? null)));
+                if (!is_array($shell)) { $artifacts = array(); $assets = array(); break 2; }
+                $slug = 1 === $variantCount ? $area : $area . '-' . ($variant + 1);
+                $artifacts[] = array_merge($shell, array(
+                    'slug' => $slug,
+                    'source_path' => $sourcePath . '#' . $slug,
+                    'source_paths' => array_keys($documents),
+                    'source_hash' => hash('sha256', $canonicalMarkups[$variant]),
+                    'variant' => $variant + 1,
+                    'placement' => array('kind' => 'inline_shared_shell', 'source_path' => 'wordpress-site-plan/shared/' . $slug, 'source_paths' => array_keys($documents), 'variant' => $variant + 1),
+                ));
+                foreach ($compiled['assets'] as $asset) {
+                    // Binary assets are already materialized by the full page
+                    // compilation. Only shell-specific support CSS is new here.
+                    if (!is_array($asset) || 'css' !== ($asset['kind'] ?? null)) continue;
+                    $asset['compilation'] = array('scope' => 'shared');
+                    $assets[] = $asset;
+                }
+            }
+        }
+        return array('artifacts' => $artifacts, 'assets' => $assets);
+    }
+
+    private static function normalizeSourceShellIdentity(string $markup): string
+    {
+        $dom = new \DOMDocument();
+        $previous = libxml_use_internal_errors(true);
+        $loaded = $dom->loadHTML('<body>' . $markup . '</body>');
+        libxml_clear_errors(); libxml_use_internal_errors($previous);
+        if (!$loaded) return $markup;
+        $xpath = new \DOMXPath($dom);
+        $currentNodes = array();
+        foreach ($xpath->query('//*[@aria-current] | //*[contains(concat(" ", normalize-space(@data-state), " "), " selected ")]') ?: array() as $node) if ($node instanceof \DOMElement) $currentNodes[] = $node;
+        foreach ($currentNodes as $node) {
+            for ($cursor = $node; $cursor instanceof \DOMElement; $cursor = $cursor->parentNode) {
+                if ($cursor->hasAttribute('data-state')) $cursor->setAttribute('data-state', preg_replace('/\bselected\b/', 'false', $cursor->getAttribute('data-state')) ?? $cursor->getAttribute('data-state'));
+                $classes = preg_split('/\s+/', trim($cursor->getAttribute('class'))) ?: array();
+                if (array() !== $classes && $cursor->parentNode instanceof \DOMElement) {
+                    $siblingClasses = array();
+                    foreach ($cursor->parentNode->childNodes as $sibling) {
+                        if (!$sibling instanceof \DOMElement || $sibling === $cursor || $sibling->tagName !== $cursor->tagName) continue;
+                        foreach (preg_split('/\s+/', trim($sibling->getAttribute('class'))) ?: array() as $class) $siblingClasses[$class] = true;
+                    }
+                    if (array() !== $siblingClasses) $cursor->setAttribute('class', implode(' ', array_values(array_filter($classes, static fn(string $class): bool => isset($siblingClasses[$class])))));
+                }
+                if ('nav' === strtolower($cursor->tagName) || 'navigation' === strtolower($cursor->getAttribute('role'))) break;
+            }
+        }
+        foreach ($xpath->query('//*[@aria-current]') ?: array() as $node) if ($node instanceof \DOMElement) $node->removeAttribute('aria-current');
+        $body = $dom->getElementsByTagName('body')->item(0);
+        $root = $body instanceof \DOMElement ? $body->firstElementChild : null;
+        return $root instanceof \DOMElement ? ($dom->saveHTML($root) ?: $markup) : $markup;
+    }
+
+    /** @param array<int,string> $markups @return array<int,string> */
+    private static function normalizeSourceShellRootClasses(array $markups): array
+    {
+        $classSets = array();
+        foreach ($markups as $markup) {
+            preg_match('/^<[^>]+\sclass="([^"]*)"/i', $markup, $match);
+            $classSets[] = array_values(array_filter(preg_split('/\s+/', trim($match[1] ?? '')) ?: array()));
+        }
+        if (count($markups) < 3 && 1 !== count(array_unique(array_map(static fn(array $classes): string => implode("\0", $classes), $classSets)))) return $markups;
+        $counts = array(); $order = array();
+        foreach ($classSets as $classes) foreach (array_unique($classes) as $class) {
+            if (!isset($counts[$class])) $order[] = $class;
+            $counts[$class] = ($counts[$class] ?? 0) + 1;
+        }
+        $threshold = intdiv(count($markups), 2) + 1;
+        $consensus = array_values(array_filter($order, static fn(string $class): bool => ($counts[$class] ?? 0) >= $threshold));
+        return array_map(static fn(string $markup): string => preg_replace('/^(<[^>]+\sclass=")[^"]*(")/i', '$1' . implode(' ', $consensus) . '$2', $markup, 1) ?? $markup, $markups);
+    }
+
+    /**
      * @param array{files: array<int, array<string, mixed>>, bytes: int, source_hash: string} $artifact
      * @param array<int, array<string, mixed>> $documents
      * @param array<int, array<string, mixed>> $assets
      * @param array<int, array<string, mixed>> $blockTypes
      * @return array<string, mixed>
      */
-    private function compiledSiteReport(array $artifact, string $entryPath, array $documents, array &$assets, array $blockTypes, string $serializedBlocks, array $entryShellArtifacts = array(), array $compiledHtmlDocuments = array()): array
+    private function compiledSiteReport(array $artifact, string $entryPath, array $documents, array &$assets, array $blockTypes, string $serializedBlocks, array $entryShellArtifacts = array(), array $compiledHtmlDocuments = array(), array $inlineShellArtifacts = array()): array
     {
         $pages = array();
         $assetPayloadsByPath = array();
@@ -4214,6 +4354,7 @@ final class ArtifactCompiler
             'pages'       => $pages,
             'assets'      => $this->compiledSiteAssets($assets),
             'template_parts' => $templateParts,
+            'inline_shell_artifacts' => $inlineShellArtifacts,
             'visual_repair' => $this->compiledSiteVisualRepair($assets, $artifact['files']),
             'runtime_declarations' => $artifact['runtime_declarations'],
             'theme'       => array_filter(

--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
@@ -123,9 +123,16 @@ final class WordPressSitePlan
         // canonical plan rebuilds them from full page shell candidates.
         $compiledParts = is_array($compiled['template_parts'] ?? null) ? array_values(array_filter($compiled['template_parts'], static fn(mixed $part): bool => !is_array($part) || 'entry_shell' !== ($part['placement']['kind'] ?? null))) : null;
         $existingParts = $this->documents($compiledParts, true, $tokens, $references, $routeMap);
-        $shells = $this->sharedShells($pages, array_fill_keys(array_column($existingParts, 'slug'), true), $runtimeDeclarations);
+        $reservedPartSlugs = array_fill_keys(array_column($existingParts, 'slug'), true);
+        $canonicalInlineParts = $this->documents(is_array($compiled['inline_shell_artifacts'] ?? null) ? $compiled['inline_shell_artifacts'] : array(), true, $tokens, $references, $routeMap);
+        $inlineShells = $this->inlineSharedShells($pages, $reservedPartSlugs, $runtimeDeclarations, $canonicalInlineParts);
+        $reservedPartSlugs += array_fill_keys(array_column($inlineShells['parts'], 'slug'), true);
+        $shells = $this->sharedShells($inlineShells['pages'], $reservedPartSlugs, $inlineShells['runtime_declarations']);
+        $inlineAreas = array_fill_keys(array_column($inlineShells['parts'], 'area'), true);
+        $shells['diagnostics'] = array_values(array_filter($shells['diagnostics'], static fn(array $diagnostic): bool => !isset($inlineAreas[$diagnostic['area'] ?? '']) || 'wordpress_site_plan_shell_retained_incomplete' !== ($diagnostic['code'] ?? null)));
         $pages = $shells['pages'];
-        $parts = array_merge($existingParts, $shells['parts']);
+        $parts = array_merge($existingParts, $inlineShells['parts'], $shells['parts']);
+        if (array() !== $parts) $themeProjection['theme']['templateParts'] = array_values(array_map(static fn(array $part): array => array('name' => $part['slug'], 'title' => $part['title'], 'area' => $part['area']), $parts));
         $runtimeDeclarations = $shells['runtime_declarations'];
         $runtimeDeclarations = $this->canonicalEntityBindings($runtimeDeclarations, $references, $routeMap, $pages);
         foreach ($pages as &$page) unset($page['_projected_source_block_markup']); unset($page);
@@ -148,12 +155,12 @@ final class WordPressSitePlan
             'routes' => $routes,
             'navigation_links' => $materialization['navigation_links'] ?? null,
             'menus' => $materialization['menus'] ?? null,
-            'theme' => array('stylesheet' => 'style.css', 'theme_json' => 'theme.json', 'bootstrap' => self::needsBootstrap($assets, $scriptLoading['scripts']) ? 'functions.php' : null, 'design_token_provenance' => $themeProjection['provenance']),
+            'theme' => array('stylesheet' => 'style.css', 'theme_json' => 'theme.json', 'bootstrap' => self::needsBootstrap($assets, $scriptLoading['scripts'], $parts) ? 'functions.php' : null, 'design_token_provenance' => $themeProjection['provenance']),
             'visual_repair' => $compiled['visual_repair'] ?? array(),
             'runtime_declarations' => $runtimeDeclarations,
-            'diagnostics' => array_merge($data['diagnostics'], $shells['diagnostics'], $scriptLoading['diagnostics']),
+            'diagnostics' => array_merge($data['diagnostics'], $inlineShells['diagnostics'], $shells['diagnostics'], $scriptLoading['diagnostics']),
             'quality' => array('status' => $data['status'], 'pass' => 'failed' !== $data['status'], 'metrics' => array_diff_key($data['metrics'], array('transform_duration_ms' => true)), 'fallbacks' => $data['fallbacks'], 'core_html_fallback_evidence' => $data['source_reports']['conversion_report']['core_html_fallback_evidence'] ?? array(), 'editability_policy' => $editabilityPolicy ?? array()),
-            'reporting' => $this->reporting($pages, $data, array_merge($shells['diagnostics'], $scriptLoading['diagnostics']), $surfaces),
+            'reporting' => $this->reporting($pages, $data, array_merge($inlineShells['diagnostics'], $shells['diagnostics'], $scriptLoading['diagnostics']), $surfaces),
         );
         $plan['plan_identity'] = self::planIdentity($plan);
         self::assertValid($plan);
@@ -513,6 +520,106 @@ final class WordPressSitePlan
             return array(array('area' => 'header', 'markup' => $chrome, 'inner_markup' => $chrome, 'template_part_markup' => self::withoutCurrentNavigationState($chrome), 'identity_markup' => $identity, 'classes' => array(), 'source_path' => $sourcePath, 'source_hash' => hash('sha256', $chrome), 'legacy_container_opening' => $opening, 'legacy_container_closing' => '<!-- /wp:group -->', 'legacy_content_markup' => $content, 'legacy_content_range' => array('offset' => $contentOffset, 'length' => $contentRange['length']), 'legacy_page_markup' => $markup));
         }
         return array();
+    }
+
+    /** @param array<int,array<string,mixed>> $pages @param array<string,true> $reservedSlugs @param array<int,array<string,mixed>> $runtimeDeclarations @return array{pages:array<int,array<string,mixed>>,parts:array<int,array<string,mixed>>,runtime_declarations:array<int,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>} */
+    private function inlineSharedShells(array $pages, array $reservedSlugs, array $runtimeDeclarations, array $canonicalArtifacts = array()): array
+    {
+        if (count(array_filter($pages, static fn(array $page): bool => empty($page['synthetic']))) < 2) return array('pages' => $pages, 'parts' => array(), 'runtime_declarations' => $runtimeDeclarations, 'diagnostics' => array());
+        $parts = array(); $diagnostics = array();
+        foreach (array('header', 'footer') as $area) {
+            $applicable = array_filter($pages, static fn(array $page): bool => empty($page['synthetic']));
+            $sourcePaths = array_values(array_map(static fn(array $page): string => $page['source_path'], $applicable));
+            $areaArtifacts = array_values(array_filter($canonicalArtifacts, static fn(array $artifact): bool => $area === ($artifact['area'] ?? null)));
+            usort($areaArtifacts, static fn(array $left, array $right): int => ($left['variant'] ?? 0) <=> ($right['variant'] ?? 0));
+            $candidates = array(); $variantCount = null; $rejected = false;
+            foreach ($applicable as $index => $page) {
+                $rows = $this->nestedLandmarkCandidates($page['canonical_block_markup'], $page['source_path'], $area);
+                if (array() === $rows || (null !== $variantCount && $variantCount !== count($rows))) { $rejected = true; break; }
+                $variantCount = count($rows); $candidates[$index] = $rows;
+                foreach ($rows as $candidate) if ($this->shellContainsRuntimeBinding($runtimeDeclarations, $page, $candidate['offset'], $candidate['length'])) { $rejected = true; break 2; }
+            }
+            if ($rejected || null === $variantCount) continue;
+            $expectedSources = $sourcePaths; sort($expectedSources, SORT_STRING);
+            $canonical = count($areaArtifacts) === $variantCount;
+            foreach ($areaArtifacts as $artifact) {
+                $artifactSources = $artifact['placement']['source_paths'] ?? array();
+                if (!is_array($artifactSources)) { $canonical = false; break; }
+                sort($artifactSources, SORT_STRING);
+                if ($artifactSources !== $expectedSources) { $canonical = false; break; }
+            }
+            $variants = array();
+            for ($variant = 0; $variant < $variantCount; ++$variant) {
+                if ($canonical) {
+                    $variants[] = (string) ($areaArtifacts[$variant]['content_hash'] ?? '');
+                    continue;
+                }
+                $identities = array(); foreach ($candidates as $rows) $identities[] = $rows[$variant]['identity_markup'];
+                if (1 !== count(array_unique($identities))) { $rejected = true; break; }
+                $variants[] = $identities[0];
+            }
+            if ($rejected) continue;
+            $slugs = array();
+            for ($variant = 0; $variant < $variantCount; ++$variant) {
+                $slug = 1 === $variantCount ? $area : $area . '-' . ($variant + 1);
+                if (isset($reservedSlugs[$slug])) { $rejected = true; break; }
+                $slugs[] = $slug;
+            }
+            if ($rejected) continue;
+            foreach ($candidates as $index => $rows) foreach ($rows as $candidate) {
+                if ($candidate['markup'] !== substr($pages[$index]['canonical_block_markup'], $candidate['offset'], $candidate['length'])) { $rejected = true; break 2; }
+            }
+            if ($rejected) continue;
+            foreach ($candidates as $index => $rows) {
+                usort($rows, static fn(array $left, array $right): int => $right['offset'] <=> $left['offset']);
+                $markup = $pages[$index]['canonical_block_markup'];
+                foreach ($rows as $candidate) {
+                    $variant = $candidate['variant']; $slug = $slugs[$variant];
+                    $reference = '<!-- wp:template-part {"slug":"' . $slug . '","area":"' . $area . '","tagName":"div"} /-->';
+                    $markup = substr($markup, 0, $candidate['offset']) . $reference . substr($markup, $candidate['offset'] + $candidate['length']);
+                }
+                $pages[$index]['canonical_block_markup'] = $markup;
+                $pages[$index]['content_hash'] = self::contentHash($markup);
+            }
+            foreach ($slugs as $variant => $slug) {
+                $first = $candidates[array_key_first($candidates)][$variant];
+                $artifact = $canonical ? $areaArtifacts[$variant] : array();
+                $sourcePath = 'wordpress-site-plan/shared/' . $slug;
+                $candidateRows = array(); foreach ($candidates as $index => $rows) $candidateRows[$index] = array($rows[$variant]);
+                $title = ucfirst($area) . (1 === $variantCount ? '' : ' Variant ' . ($variant + 1));
+                $partMarkup = $canonical ? (string) ($artifact['canonical_block_markup'] ?? '') : $first['markup'];
+                $partMarkup = self::withoutCurrentNavigationState($partMarkup);
+                $parts[] = array('source_path' => $sourcePath . '#' . $area, 'slug' => $slug, 'title' => $title, 'post_type' => 'wp_template_part', 'parent_source_path' => '', 'entrypoint' => false, 'area' => $area, 'tag_name' => ShellLandmarkPolicy::templatePartAreaTagName($area), 'placement' => array('kind' => 'inline_shared_shell', 'source_path' => $sourcePath, 'source_paths' => $sourcePaths, 'variant' => $variant + 1), 'canonical_block_markup' => $partMarkup, 'metadata' => array(), 'document_metadata' => array('source_context' => array('source_path' => $sourcePath . '#' . $area, 'kind' => 'template_part'), 'title' => $title, 'title_declaration' => array('order' => 0, 'placement' => 'head'), 'meta' => array(), 'links' => array(), 'scripts' => array()), 'provenance' => $this->shellProvenance($area, 'extracted', 'inline_responsive_variant', $candidateRows, hash('sha256', $variants[$variant])), 'reconciliation_identity' => self::identity('template-part', $sourcePath . '#' . $area, 'parts/' . $slug . '.html'), 'content_hash' => self::contentHash($partMarkup));
+            }
+            $diagnostics[] = array('code' => 'wordpress_site_plan_shell_inline_extracted', 'severity' => 'info', 'message' => "Extracted nested responsive {$area} variants at their authored page positions.", 'area' => $area, 'variant_count' => $variantCount, 'page_count' => count($applicable), 'source_paths' => $sourcePaths);
+        }
+        return array('pages' => $pages, 'parts' => $parts, 'runtime_declarations' => $runtimeDeclarations, 'diagnostics' => $diagnostics);
+    }
+
+    /** @return array<int,array<string,mixed>> */
+    private function nestedLandmarkCandidates(string $markup, string $sourcePath, string $area): array
+    {
+        $rows = array(); $stack = array();
+        if (!preg_match_all('/<!--\s*(\/?)wp:([^\s]+)(?:\s+([^>]*?))?\s*(\/?)-->/s', $markup, $matches, PREG_OFFSET_CAPTURE)) return $rows;
+        foreach ($matches[0] as $index => $match) {
+            $token = $match[0]; $offset = $match[1]; $closing = '' !== $matches[1][$index][0]; $selfClosing = '' !== $matches[4][$index][0] || str_ends_with(rtrim($token), '/-->');
+            if ($closing) {
+                $open = array_pop($stack);
+                if (!is_array($open) || empty($open['candidate'])) continue;
+                $length = $offset + strlen($token) - $open['offset']; $candidateMarkup = substr($markup, $open['offset'], $length);
+                $rows[] = array('area' => $area, 'markup' => $candidateMarkup, 'identity_markup' => self::normalizeNestedChromeMarkup($candidateMarkup), 'source_path' => $sourcePath, 'source_hash' => hash('sha256', $candidateMarkup), 'offset' => $open['offset'], 'length' => $length);
+                continue;
+            }
+            $name = $matches[2][$index][0]; $attributes = trim($matches[3][$index][0] ?? ''); $attrs = '' === $attributes ? array() : json_decode($attributes, true);
+            $disallowedAncestor = false;
+            foreach ($stack as $ancestor) if (in_array($ancestor['tag_name'] ?? null, array('main', 'article', 'section', 'aside'), true)) { $disallowedAncestor = true; break; }
+            $tagName = is_array($attrs) ? ($attrs['tagName'] ?? null) : null;
+            $candidate = 0 < count($stack) && !$disallowedAncestor && 'group' === $name && $area === $tagName;
+            if (!$selfClosing) $stack[] = array('offset' => $offset, 'tag_name' => $tagName, 'candidate' => $candidate);
+        }
+        usort($rows, static fn(array $left, array $right): int => $left['offset'] <=> $right['offset']);
+        foreach ($rows as $variant => &$row) $row['variant'] = $variant; unset($row);
+        return $rows;
     }
 
     /** @param array<int,array<string,mixed>> $pages @param array<string,true> $reservedSlugs @param array<int,array<string,mixed>> $runtimeDeclarations @return array{pages:array<int,array<string,mixed>>,parts:array<int,array<string,mixed>>,runtime_declarations:array<int,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>} */
@@ -1348,14 +1455,14 @@ final class WordPressSitePlan
     private function scaffoldWrites(array $assets, array $templates, array $parts, array $scripts, array $theme): array
     {
         $writes = array($this->write('theme_scaffold', 'style.css', "/*\nTheme Name: Blocks Engine Site\nText Domain: blocks-engine-site\n*/\n"), $this->write('theme_scaffold', 'theme.json', json_encode($theme, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n"));
-        if ( self::needsBootstrap($assets, $scripts) ) $writes[] = $this->write('theme_bootstrap', 'functions.php', self::bootstrap($assets, $scripts, $parts));
+        if ( self::needsBootstrap($assets, $scripts, $parts) ) $writes[] = $this->write('theme_bootstrap', 'functions.php', self::bootstrap($assets, $scripts, $parts));
         foreach ( $templates as $template ) $writes[] = $this->write('theme_template', $template['target_path'], $template['canonical_block_markup']);
         foreach ( $parts as $part ) $writes[] = $this->write('theme_template_part', 'parts/' . $part['slug'] . '.html', $part['canonical_block_markup']);
         return $writes;
     }
 
     /** @param array<int,array<string,mixed>> $assets */
-    private static function needsBootstrap(array $assets, array $scripts = array()): bool { foreach ($assets as $asset) if (in_array($asset['kind'], array('css', 'js'), true)) return true; return array() !== $scripts; }
+    private static function needsBootstrap(array $assets, array $scripts = array(), array $parts = array()): bool { foreach ($assets as $asset) if (in_array($asset['kind'], array('css', 'js'), true)) return true; foreach ($parts as $part) if ('inline_shared_shell' === ($part['placement']['kind'] ?? null)) return true; return array() !== $scripts; }
     /** @param array<int,array<string,mixed>> $assets */
     private static function bootstrap(array $assets, array $scripts = array(), array $parts = array()): string
     {
@@ -1383,8 +1490,8 @@ final class WordPressSitePlan
         $editorStyles = array();
         $partSlugsBySource = array();
         foreach ($parts as $part) {
-            $sourcePath = (string) ($part['placement']['source_path'] ?? preg_replace('/#.*$/', '', (string) ($part['source_path'] ?? '')));
-            if ('' !== $sourcePath && '' !== (string) ($part['slug'] ?? '')) $partSlugsBySource[$sourcePath][] = (string) $part['slug'];
+            $sourcePaths = is_array($part['placement']['source_paths'] ?? null) ? $part['placement']['source_paths'] : array((string) ($part['placement']['source_path'] ?? preg_replace('/#.*$/', '', (string) ($part['source_path'] ?? ''))));
+            foreach ($sourcePaths as $sourcePath) if (is_string($sourcePath) && '' !== $sourcePath && '' !== (string) ($part['slug'] ?? '')) $partSlugsBySource[$sourcePath][] = (string) $part['slug'];
         }
         foreach ($assets as $asset) if ('css' === $asset['kind'] && 'frontend' !== ($asset['stylesheet_target'] ?? 'both')) {
             $partSlugs = array();
@@ -1406,6 +1513,14 @@ final class WordPressSitePlan
             $lines[] = "        if ( false !== \$css ) { if ( is_string( \$style['media'] ?? null ) && '' !== trim( \$style['media'] ) ) \$css = '@media ' . \$style['media'] . '{' . \$css . '}'; \$settings['styles'][] = array( 'css' => ':root{--blocks-engine-presentation:' . \$style['content_hash'] . ';}' . \"\\n\" . \$css, '__unstableType' => 'theme' ); }";
             $lines[] = "    }";
             $lines[] = "    return \$settings;";
+            $lines[] = "}, 10, 2 );";
+        }
+        $inlineShellSlugs = array_values(array_map(static fn(array $part): string => (string) $part['slug'], array_filter($parts, static fn(array $part): bool => 'inline_shared_shell' === ($part['placement']['kind'] ?? null))));
+        if (array() !== $inlineShellSlugs) {
+            $lines[] = "add_filter( 'render_block_core/template-part', static function ( string \$content, array \$block ): string {";
+            $lines[] = '    $slugs = ' . var_export($inlineShellSlugs, true) . ';';
+            $lines[] = "    if ( ! in_array( (string) ( \$block['attrs']['slug'] ?? '' ), \$slugs, true ) || ! preg_match( '/^<([a-z][a-z0-9-]*)\\b[^>]*>(.*)<\\/\\1>$/s', \$content, \$match ) ) return \$content;";
+            $lines[] = "    return \$match[2];";
             $lines[] = "}, 10, 2 );";
         }
         $lines[] = "add_filter( 'block_editor_settings_all', static function ( array \$settings ): array { \$settings['styles'][] = array( 'css' => " . var_export(self::EDITOR_CORE_IMAGE_INTERACTION_CSS . self::EDITOR_POST_TITLE_INTERACTION_CSS, true) . ", '__unstableType' => 'theme' ); return \$settings; }, 20 );";
@@ -1655,7 +1770,7 @@ final class WordPressSitePlan
         if (!is_array($theme) || 3 !== ($theme['version'] ?? null) || !is_array($theme['settings'] ?? null) || !is_array($theme['styles'] ?? null)) throw new InvalidArgumentException('WordPress site plan theme.json shape is unsupported.');
         $bootstrap = $writes['functions.php'] ?? null;
         $scriptLoading = (new self())->scriptLoading($plan['pages'], $plan['template_parts'], $plan['assets'], $plan['reference_tokens'], $plan['operations'], $plan['runtime_declarations']);
-        if (self::needsBootstrap($plan['assets'], $scriptLoading['scripts'])) {
+        if (self::needsBootstrap($plan['assets'], $scriptLoading['scripts'], $plan['template_parts'])) {
             if (!is_array($bootstrap) || 'theme_bootstrap' !== ($bootstrap['kind'] ?? null) || 'wordpress-site-plan/functions.php' !== ($bootstrap['source_path'] ?? null) || self::bootstrap($plan['assets'], $scriptLoading['scripts'], $plan['template_parts']) !== ($bootstrap['payload']['data'] ?? null)) throw new InvalidArgumentException('WordPress site plan functions.php bootstrap is invalid.');
         } elseif (null !== ($plan['theme']['bootstrap'] ?? null) || isset($bootstrap)) throw new InvalidArgumentException('WordPress site plan declares an unnecessary bootstrap.');
     }

--- a/php-transformer/tests/contract/shared-shell-plan.php
+++ b/php-transformer/tests/contract/shared-shell-plan.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
+use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlan;
 
 $assert = static function (bool $condition, string $message): void { if (! $condition) throw new RuntimeException($message); };
 $pages = static function (array $plan): array { $rows = array(); foreach ($plan['pages'] as $page) $rows[$page['source_path']] = $page; return $rows; };
@@ -68,6 +69,50 @@ $mixedShells = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.ht
 $mixedWrites = $writes($mixedShells);
 $assert(str_contains($mixedWrites['templates/page-contact.html']['payload']['data'] ?? '', '"slug":"header"') && !str_contains($mixedWrites['templates/page-contact.html']['payload']['data'] ?? '', '"slug":"footer"') && str_contains($mixedWrites['templates/page.html']['payload']['data'] ?? '', '"slug":"header"') && str_contains($mixedWrites['templates/page.html']['payload']['data'] ?? '', '"slug":"footer"'), 'A footer-only exclusion creates a route template that retains the globally shared header and excludes only the divergent footer.');
 $assert(!array_filter($multiple['template_parts'], static fn(array $part): bool => 'header' === ($part['area'] ?? null)) && in_array('wordpress_site_plan_shell_retained_incomplete', array_column($multiple['diagnostics'], 'code'), true), 'Multiple shell candidates remain page-local with bounded incomplete diagnostics.');
+
+$responsiveLandmark = static function (string $area, string $id, string $class, string $content): string {
+    return '<!-- wp:group {"anchor":"' . $id . '","className":"site-' . $area . ' ' . $class . '","tagName":"' . $area . '"} --><' . $area . ' id="' . $id . '" class="wp-block-group site-' . $area . ' ' . $class . '"><!-- wp:paragraph --><p>' . $content . '</p><!-- /wp:paragraph --></' . $area . '><!-- /wp:group -->';
+};
+$responsiveMarkup = static function (string $title, string $mobileHeader = 'Mobile header') use ($responsiveLandmark): string {
+    $document = static function (string $variant, string $title, string $header, string $footer) use ($responsiveLandmark): string {
+        return '<!-- wp:group {"className":"' . $variant . '-document"} --><div class="wp-block-group ' . $variant . '-document">'
+            . $responsiveLandmark('header', $variant . '-header', $variant . '-header', $header)
+            . '<!-- wp:group {"tagName":"main"} --><main class="wp-block-group"><!-- wp:heading --><h2 class="wp-block-heading">' . $title . '</h2><!-- /wp:heading --></main><!-- /wp:group -->'
+            . $responsiveLandmark('footer', $variant . '-footer', $variant . '-footer', $footer)
+            . '</div><!-- /wp:group -->';
+    };
+    return $document('desktop', $title, 'Desktop header', 'Desktop footer') . $document('mobile', $title . ' mobile', $mobileHeader, 'Mobile footer');
+};
+$responsiveResult = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => '<main><h1>Home</h1></main>', 'about.html' => '<main><h1>About</h1></main>')))->toArray();
+foreach ($responsiveResult['source_reports']['compiled_site']['pages'] as &$responsivePage) $responsivePage['block_markup'] = $responsiveMarkup('index.html' === $responsivePage['source_path'] ? 'Home' : 'About'); unset($responsivePage);
+$responsive = (new WordPressSitePlan())->fromResult($responsiveResult);
+$responsivePages = $pages($responsive); $responsiveWrites = $writes($responsive);
+$responsiveParts = array_column($responsive['template_parts'], null, 'slug');
+$assert(array('header-1', 'header-2', 'footer-1', 'footer-2') === array_keys($responsiveParts) && array() === array_filter($responsiveParts, static fn(array $part): bool => 'inline_shared_shell' !== ($part['placement']['kind'] ?? null)), 'Nested desktop and mobile landmarks become distinct inline shared template parts.');
+foreach ($responsivePages as $source => $page) {
+    $markup = $page['canonical_block_markup'] ?? '';
+    $assert(1 === substr_count($markup, '"slug":"header-1"') && 1 === substr_count($markup, '"slug":"header-2"') && 1 === substr_count($markup, '"slug":"footer-1"') && 1 === substr_count($markup, '"slug":"footer-2"') && !str_contains($markup, 'desktop-header') && !str_contains($markup, 'mobile-header') && str_contains($markup, $source === 'index.html' ? '>Home</h2>' : '>About</h2>'), "{$source} retains route content and exact inline shell reference cardinality.");
+}
+$assert(str_contains($responsiveParts['header-1']['canonical_block_markup'] ?? '', 'desktop-header') && str_contains($responsiveParts['header-2']['canonical_block_markup'] ?? '', 'mobile-header') && str_contains($responsiveParts['footer-1']['canonical_block_markup'] ?? '', 'desktop-footer') && str_contains($responsiveParts['footer-2']['canonical_block_markup'] ?? '', 'mobile-footer'), 'Every responsive template part retains its authored landmark wrapper and presentation hooks.');
+$assert(array() === array_filter($responsive['templates'], static fn(array $template): bool => str_contains($template['canonical_block_markup'] ?? '', '"slug":"header-1"')) && str_contains($responsiveWrites['functions.php']['payload']['data'] ?? '', "render_block_core/template-part") && str_contains($responsiveWrites['functions.php']['payload']['data'] ?? '', "'header-1'"), 'Inline shell references remain page-positioned while generated bootstrap removes only the Core transport wrapper.');
+$responsiveTheme = json_decode($responsiveWrites['theme.json']['payload']['data'] ?? '', true);
+$assert(array('header-1', 'header-2', 'footer-1', 'footer-2') === array_column($responsiveTheme['templateParts'] ?? array(), 'name') && array('header', 'header', 'footer', 'footer') === array_column($responsiveTheme['templateParts'] ?? array(), 'area'), 'Generated theme metadata exposes responsive shell parts in their Site Editor header and footer areas.');
+$responsiveDiagnostic = current(array_filter($responsive['diagnostics'], static fn(array $diagnostic): bool => 'wordpress_site_plan_shell_inline_extracted' === ($diagnostic['code'] ?? null) && 'header' === ($diagnostic['area'] ?? null)));
+$assert(2 === ($responsiveDiagnostic['variant_count'] ?? null) && 2 === ($responsiveDiagnostic['page_count'] ?? null) && array('about.html', 'index.html') === array_keys($responsiveParts['header-1']['provenance']['sources'] ?? array()), 'Inline extraction reports bounded variant counts and non-empty source provenance.');
+
+$sourceResponsiveHtml = static fn(string $title): string => '<div class="desktop-document"><header class="desktop-header"><nav><a href="/">Home</a></nav></header><main><h1>' . $title . '</h1></main><footer class="desktop-footer">Desktop footer</footer></div><div class="mobile-document"><header class="mobile-header">Mobile header</header><main><h1>' . $title . ' mobile</h1></main><footer class="mobile-footer">Mobile footer</footer></div>';
+$sourceResponsiveResult = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => $sourceResponsiveHtml('Home'), 'about.html' => $sourceResponsiveHtml('About'))))->toArray();
+$sourceResponsiveArtifacts = $sourceResponsiveResult['source_reports']['compiled_site']['inline_shell_artifacts'] ?? array();
+$assert(array('header-1', 'header-2', 'footer-1', 'footer-2') === array_column($sourceResponsiveArtifacts, 'slug'), 'Source-identical nested shell variants are compiled once before route-specific page projection.');
+$assert(array() === array_filter($sourceResponsiveArtifacts, static fn(array $artifact): bool => array('index.html', 'about.html') !== ($artifact['source_paths'] ?? array())), 'Canonical source-level shell artifacts retain every contributing route.');
+$sourceDivergentResult = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => $sourceResponsiveHtml('Home'), 'about.html' => str_replace('Mobile header', 'Different mobile header', $sourceResponsiveHtml('About')))))->toArray();
+$sourceDivergentArtifacts = $sourceDivergentResult['source_reports']['compiled_site']['inline_shell_artifacts'] ?? array();
+$assert(!array_filter($sourceDivergentArtifacts, static fn(array $artifact): bool => 'header' === ($artifact['area'] ?? null)) && 2 === count(array_filter($sourceDivergentArtifacts, static fn(array $artifact): bool => 'footer' === ($artifact['area'] ?? null))), 'A divergent source variant rejects the complete area bundle while an independently shared area remains canonical.');
+
+$responsiveDivergentResult = $responsiveResult;
+foreach ($responsiveDivergentResult['source_reports']['compiled_site']['pages'] as &$responsivePage) $responsivePage['block_markup'] = $responsiveMarkup('index.html' === $responsivePage['source_path'] ? 'Home' : 'About', 'about.html' === $responsivePage['source_path'] ? 'Different mobile header' : 'Mobile header'); unset($responsivePage);
+$responsiveDivergent = (new WordPressSitePlan())->fromResult($responsiveDivergentResult);
+$assert(!array_filter($responsiveDivergent['template_parts'], static fn(array $part): bool => 'header' === ($part['area'] ?? null)) && str_contains($pages($responsiveDivergent)['index.html']['canonical_block_markup'] ?? '', 'desktop-header') && str_contains($pages($responsiveDivergent)['about.html']['canonical_block_markup'] ?? '', 'Different mobile header'), 'A divergent responsive variant keeps every header variant page-owned instead of partially extracting the bundle.');
 
 $waveShell = static function (string $identity, string $current, string $content): string {
     $sourceClass = 'blocks-engine-source-div-' . $identity . '-4';


### PR DESCRIPTION
## Summary
- identify route-shared nested header/footer variants from source HTML and compile each canonical shell once with shared support CSS
- replace the matching nested block ranges with inline template-part references while retaining authored responsive positions and runtime-binding safety
- expose generated parts in Site Editor header/footer areas and remove only Core template-part transport wrappers on the frontend

Closes #1367.

## Verification
- `composer test`
- 289 PHP transformer parity fixtures
- staged compilation and dist/package-install contracts
- seven-route reproducing artifact emits `header-1`, `header-2`, `footer-1`, and `footer-2`, each with seven-route provenance
- materialized runtime: all seven routes return HTTP 200 with two headers, two footers, one desktop root, one mobile root, and zero template-part transport wrappers
- Site Editor discovers all four parts in their declared header/footer areas

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode traced the source-to-plan shell lifecycle, implemented the canonical extraction and placement changes, ran the deterministic and materialized runtime verification, and prepared this draft PR. Chris Huber directed the work and reviewed the resulting evidence.