### PR TITLE
Extract form fallback finding builder

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -159,6 +159,7 @@
             "php tests/unit/readable-form-control-block-converter.php",
             "php tests/unit/readable-form-block-builder.php",
             "php tests/unit/form-composition-planner.php",
+            "php tests/unit/form-fallback-finding-builder.php",
             "php tests/unit/form-runtime-requirement-analyzer.php",
             "php tests/unit/form-success-panel-metadata-builder.php",
             "php tests/unit/pseudo-form-analyzer.php",

--- a/php-transformer/src/HtmlToBlocks/Elements/FormFallbackFindingBuilder.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FormFallbackFindingBuilder.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\FormControlTopologyBuilder;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\FormLayoutGraphBuilder;
+use DOMElement;
+
+/** Builds the provider-materializable diagnostic for a form-like element. */
+final class FormFallbackFindingBuilder
+{
+    public function __construct(
+        private readonly FormFallbackFindingContext $context,
+        private readonly FormControlMetadataBuilder $metadataBuilder,
+        private readonly FormSuccessPanelMetadataBuilder $successPanelMetadataBuilder,
+        private readonly PseudoFormAnalyzer $pseudoFormAnalyzer
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed>|null $readableFormBlock
+     * @param array<string, mixed>|null $bindingBlock
+     * @return array<string, mixed>
+     */
+    public function build(DOMElement $element, ?array $readableFormBlock, ?array $bindingBlock = null): array
+    {
+        $controls = $this->metadataBuilder->controls($element);
+        $controlTopology = (new FormControlTopologyBuilder())->build($element);
+        $layoutGraph = (new FormLayoutGraphBuilder())->build($element, $this->context->stylesheetAssets(), $this->context->formLayoutCss());
+        $boundedHtml = $this->context->boundedFallbackHtml($element);
+        $replacesRuntimeIsland = null !== $bindingBlock;
+        $bindingBlock ??= $readableFormBlock;
+        $supersededRuntimeSelectors = $this->context->runtimeDomSelectors($element);
+        if ( $replacesRuntimeIsland ) {
+            $supersededRuntimeSelectors[] = $this->context->runtimeIslandSelector($element);
+        }
+
+        $finding = array(
+            'type'             => 'html',
+            'reason'           => 'form_requires_runtime',
+            'diagnostic_code'  => 'html_form_fallback',
+            'message'          => 'Form intent and controls were extracted as provider-materializable metadata; the source form markup is preserved until a form provider materializes it.',
+            'source_format'    => 'html',
+            'tag'              => strtolower($element->tagName),
+            'selector'         => $this->context->elementSelector($element),
+            'attributes'       => $this->context->htmlAttributes($element),
+            'form'             => $this->metadataBuilder->form($element),
+            'success_panel'    => $this->successPanelMetadataBuilder->build($element),
+            'context'          => $this->context->sourceContext($element),
+            'classification'   => $this->context->classifyFallbackSubtree($element),
+            'events'           => $this->context->eventMetadata($element),
+            'readable_blocks'  => null !== $readableFormBlock ? array( $readableFormBlock ) : array(),
+            'binding'          => null !== $bindingBlock ? $this->context->blockBinding($bindingBlock, 'form', $supersededRuntimeSelectors) : array(),
+            'controls'         => $controls,
+            'control_topology' => $controlTopology,
+            'layout_graph'     => $layoutGraph,
+            'control_count'    => count($controls),
+            'text_length'      => strlen(trim($element->textContent ?? '')),
+            'child_count'      => $this->context->childElementCount($element),
+            'html'             => $boundedHtml['html'],
+            'html_bytes'       => $boundedHtml['bytes'],
+            'html_truncated'   => $boundedHtml['truncated'],
+        );
+        if ( 'form' !== strtolower($element->tagName) ) {
+            $finding['form_boundary'] = $this->pseudoFormAnalyzer->boundaryMetadata($element);
+        }
+
+        return $this->context->buildFallbackDiagnostic($finding);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Elements/FormFallbackFindingContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FormFallbackFindingContext.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Closure;
+use DOMElement;
+
+/** Explicit transformer collaborator surface for form fallback findings. */
+final class FormFallbackFindingContext
+{
+    /**
+     * @param Closure(): array<int, array<string, mixed>>                                         $stylesheetAssets
+     * @param Closure(): string                                                                    $formLayoutCss
+     * @param Closure(DOMElement): array{html: string, bytes: int, truncated: bool}                $boundedFallbackHtml
+     * @param Closure(DOMElement): array<int, string>                                               $runtimeDomSelectors
+     * @param Closure(DOMElement): string                                                           $runtimeIslandSelector
+     * @param Closure(DOMElement): string                                                           $elementSelector
+     * @param Closure(DOMElement): array<string, string>                                            $htmlAttributes
+     * @param Closure(DOMElement): array<string, mixed>                                             $sourceContext
+     * @param Closure(DOMElement): array<string, mixed>                                             $classifyFallbackSubtree
+     * @param Closure(DOMElement): array<string, mixed>                                             $eventMetadata
+     * @param Closure(array<string, mixed>, string, array<int, string>): array<string, mixed>       $blockBinding
+     * @param Closure(DOMElement): int                                                              $childElementCount
+     * @param Closure(array<string, mixed>): array<string, mixed>                                   $buildFallbackDiagnostic
+     */
+    public function __construct(
+        private readonly Closure $stylesheetAssets,
+        private readonly Closure $formLayoutCss,
+        private readonly Closure $boundedFallbackHtml,
+        private readonly Closure $runtimeDomSelectors,
+        private readonly Closure $runtimeIslandSelector,
+        private readonly Closure $elementSelector,
+        private readonly Closure $htmlAttributes,
+        private readonly Closure $sourceContext,
+        private readonly Closure $classifyFallbackSubtree,
+        private readonly Closure $eventMetadata,
+        private readonly Closure $blockBinding,
+        private readonly Closure $childElementCount,
+        private readonly Closure $buildFallbackDiagnostic
+    ) {
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function stylesheetAssets(): array
+    {
+        return ($this->stylesheetAssets)();
+    }
+
+    public function formLayoutCss(): string
+    {
+        return ($this->formLayoutCss)();
+    }
+
+    /** @return array{html: string, bytes: int, truncated: bool} */
+    public function boundedFallbackHtml(DOMElement $element): array
+    {
+        return ($this->boundedFallbackHtml)($element);
+    }
+
+    /** @return array<int, string> */
+    public function runtimeDomSelectors(DOMElement $element): array
+    {
+        return ($this->runtimeDomSelectors)($element);
+    }
+
+    public function runtimeIslandSelector(DOMElement $element): string
+    {
+        return ($this->runtimeIslandSelector)($element);
+    }
+
+    public function elementSelector(DOMElement $element): string
+    {
+        return ($this->elementSelector)($element);
+    }
+
+    /** @return array<string, string> */
+    public function htmlAttributes(DOMElement $element): array
+    {
+        return ($this->htmlAttributes)($element);
+    }
+
+    /** @return array<string, mixed> */
+    public function sourceContext(DOMElement $element): array
+    {
+        return ($this->sourceContext)($element);
+    }
+
+    /** @return array<string, mixed> */
+    public function classifyFallbackSubtree(DOMElement $element): array
+    {
+        return ($this->classifyFallbackSubtree)($element);
+    }
+
+    /** @return array<string, mixed> */
+    public function eventMetadata(DOMElement $element): array
+    {
+        return ($this->eventMetadata)($element);
+    }
+
+    /**
+     * @param array<string, mixed> $block
+     * @param array<int, string> $supersededRuntimeSelectors
+     * @return array<string, mixed>
+     */
+    public function blockBinding(array $block, string $role, array $supersededRuntimeSelectors): array
+    {
+        return ($this->blockBinding)($block, $role, $supersededRuntimeSelectors);
+    }
+
+    public function childElementCount(DOMElement $element): int
+    {
+        return ($this->childElementCount)($element);
+    }
+
+    /** @param array<string, mixed> $finding @return array<string, mixed> */
+    public function buildFallbackDiagnostic(array $finding): array
+    {
+        return ($this->buildFallbackDiagnostic)($finding);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -36,6 +36,8 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispa
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\AuthoredFormControlBlockConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormControlMetadataBuilder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormCompositionPlanner;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormFallbackFindingBuilder;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormFallbackFindingContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormRuntimeRequirementAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormRuntimeIslandRecorder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormSuccessPanelMetadataBuilder;
@@ -282,6 +284,8 @@ final class HtmlTransformer
 
     private readonly FormCompositionPlanner $formCompositionPlanner;
 
+    private readonly FormFallbackFindingBuilder $formFallbackFindingBuilder;
+
     private readonly PseudoFormAnalyzer $pseudoFormAnalyzer;
 
     private readonly FormRuntimeRequirementAnalyzer $formRuntimeRequirementAnalyzer;
@@ -492,6 +496,26 @@ final class HtmlTransformer
             fn (DOMElement $element): string => $this->elementSelector($element),
             fn (DOMElement $element): array => $this->boundedFallbackHtml($this->safeFallbackHtml($element)),
             fn (DOMElement $element): string => $this->innerHtml($element)
+        );
+        $this->formFallbackFindingBuilder = new FormFallbackFindingBuilder(
+            new FormFallbackFindingContext(
+                fn (): array => $this->authorStyles()->stylesheetAssets(),
+                fn (): string => $this->sourceStyles()->formLayoutCss(),
+                fn (DOMElement $element): array => $this->boundedFallbackHtml($this->safeFallbackHtml($element)),
+                fn (DOMElement $element): array => $this->runtimeIslands->runtimeDomSelectorsForElement($element),
+                fn (DOMElement $element): string => $this->runtimeIslandSelector($element),
+                fn (DOMElement $element): string => $this->elementSelector($element),
+                fn (DOMElement $element): array => $this->htmlAttributes($element),
+                fn (DOMElement $element): array => $this->sourceContext($element),
+                fn (DOMElement $element): array => $this->fallbackEmitter()->classifyFallbackSubtree($element),
+                fn (DOMElement $element): array => $this->eventMetadata($element),
+                fn (array $block, string $role, array $supersededRuntimeSelectors): array => $this->blockBinding($block, $role, $supersededRuntimeSelectors),
+                fn (DOMElement $element): int => $this->childElementCount($element),
+                fn (array $finding): array => FallbackDiagnostic::build($finding, $this->transformationProvenance()->fallback())
+            ),
+            $this->formControlMetadataBuilder,
+            $this->formSuccessPanelMetadataBuilder,
+            $this->pseudoFormAnalyzer
         );
         $this->searchBlockConverter = new SearchBlockConverter($this->createSearchBlockConversionContext(), $this->formControlMetadataBuilder, $this->pseudoFormAnalyzer);
         $this->buttonLinkDispatcher = new ButtonLinkDispatcher($this->createButtonLinkDispatchContext());

--- a/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/FormDispatchTrait.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackDiagnostic;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\FormControlTopologyBuilder;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\FormLayoutGraphBuilder;
-use DOMDocument;
 use DOMElement;
 
 trait FormDispatchTrait
@@ -26,7 +22,7 @@ trait FormDispatchTrait
         if ( FormControlClassifier::hasDataEntryControls($element) ) {
             $composition = $this->formCompositionPlanner->compose($element, $fallbacks);
             if ( null !== $composition ) {
-                $fallbacks[] = $this->formFallbackFinding($element, $composition['block'], $composition['slot']);
+                $fallbacks[] = $this->formFallbackFindingBuilder->build($element, $composition['block'], $composition['slot']);
                 $this->formRuntimeIslandRecorder->recordForm($element, $composition['block']);
                 return $composition['block'];
             }
@@ -35,7 +31,7 @@ trait FormDispatchTrait
         $readableFormBlock = $this->readableFormBlockBuilder->build($element);
         if ( null !== $readableFormBlock && ! $this->formRuntimeRequirementAnalyzer->requiresPreservation($element) ) {
             if ( FormControlClassifier::hasDataEntryControls($element) ) {
-                $fallbacks[] = $this->formFallbackFinding($element, $readableFormBlock);
+                $fallbacks[] = $this->formFallbackFindingBuilder->build($element, $readableFormBlock);
             }
 
             return $readableFormBlock;
@@ -43,7 +39,7 @@ trait FormDispatchTrait
 
         if ( FormControlClassifier::hasDataEntryControls($element) ) {
             $preservationBlock = $this->htmlPreservationBlock($element);
-            $fallbacks[] = $this->formFallbackFinding($element, $readableFormBlock, $preservationBlock);
+            $fallbacks[] = $this->formFallbackFindingBuilder->build($element, $readableFormBlock, $preservationBlock);
             $this->formRuntimeIslandRecorder->recordForm($element, $readableFormBlock);
 
             return $preservationBlock;
@@ -55,7 +51,7 @@ trait FormDispatchTrait
         // Surface a form fallback finding so a downstream consumer can map the
         // preserved control structure onto a working form provider.
         if ( null === $readableFormBlock || FormControlClassifier::hasDataEntryControls($element) ) {
-            $fallbacks[] = $this->formFallbackFinding($element, $readableFormBlock);
+            $fallbacks[] = $this->formFallbackFindingBuilder->build($element, $readableFormBlock);
         }
 
         return $readableFormBlock;
@@ -69,62 +65,8 @@ trait FormDispatchTrait
         // Some signup/contact widgets pair data-entry controls with a submit-like
         // control inside a plain container. Emit the same finding as a real form.
         if ( $this->pseudoFormAnalyzer->isPseudoForm($element) ) {
-            $fallbacks[] = $this->formFallbackFinding($element, $this->readableFormBlockBuilder->build($element, true));
+            $fallbacks[] = $this->formFallbackFindingBuilder->build($element, $this->readableFormBlockBuilder->build($element, true));
         }
-    }
-
-    /**
-     * Build the shared html_form_fallback finding (issue #315) for an element that
-     * behaves as a form. Both the real <form> path and the div-based pseudo-form
-     * path emit through here so the downstream materializer receives an identical
-     * shape (controls, form metadata, classification, bounded HTML) regardless of
-     * whether the source markup used a <form> element.
-     *
-     * @param array<string, mixed>|null $readableFormBlock
-     * @return array<string, mixed>
-     */
-    private function formFallbackFinding(DOMElement $element, ?array $readableFormBlock, ?array $bindingBlock = null): array
-    {
-        $controls = $this->formControlMetadataBuilder->controls($element);
-        $controlTopology = (new FormControlTopologyBuilder())->build($element);
-        $layoutGraph = (new FormLayoutGraphBuilder())->build($element, $this->authorStyles()->stylesheetAssets(), $this->sourceStyles()->formLayoutCss());
-        $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($element));
-        $replacesRuntimeIsland = null !== $bindingBlock;
-        $bindingBlock ??= $readableFormBlock;
-        $supersededRuntimeSelectors = $this->runtimeIslands->runtimeDomSelectorsForElement($element);
-        if ( $replacesRuntimeIsland ) $supersededRuntimeSelectors[] = $this->runtimeIslandSelector($element);
-
-        $finding = array(
-            'type'            => 'html',
-            'reason'          => 'form_requires_runtime',
-            'diagnostic_code' => 'html_form_fallback',
-            'message'         => 'Form intent and controls were extracted as provider-materializable metadata; the source form markup is preserved until a form provider materializes it.',
-            'source_format'   => 'html',
-            'tag'             => strtolower($element->tagName),
-            'selector'        => $this->elementSelector($element),
-            'attributes'      => $this->htmlAttributes($element),
-            'form'            => $this->formControlMetadataBuilder->form($element),
-            'success_panel'   => $this->formSuccessPanelMetadataBuilder->build($element),
-            'context'         => $this->sourceContext($element),
-            'classification'  => $this->fallbackEmitter()->classifyFallbackSubtree($element),
-            'events'          => $this->eventMetadata($element),
-            'readable_blocks' => null !== $readableFormBlock ? array( $readableFormBlock ) : array(),
-            'binding'         => null !== $bindingBlock ? $this->blockBinding($bindingBlock, 'form', $supersededRuntimeSelectors) : array(),
-            'controls'        => $controls,
-            'control_topology' => $controlTopology,
-            'layout_graph'     => $layoutGraph,
-            'control_count'   => count($controls),
-            'text_length'     => strlen(trim($element->textContent ?? '')),
-            'child_count'     => $this->childElementCount($element),
-            'html'            => $boundedHtml['html'],
-            'html_bytes'      => $boundedHtml['bytes'],
-            'html_truncated'  => $boundedHtml['truncated'],
-        );
-        if ( 'form' !== strtolower($element->tagName) ) {
-            $finding['form_boundary'] = $this->pseudoFormAnalyzer->boundaryMetadata($element);
-        }
-
-        return FallbackDiagnostic::build($finding, $this->transformationProvenance()->fallback());
     }
 
     /**

--- a/php-transformer/tests/unit/form-fallback-finding-builder.php
+++ b/php-transformer/tests/unit/form-fallback-finding-builder.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormControlMetadataBuilder;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormFallbackFindingBuilder;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormFallbackFindingContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormSuccessPanelMetadataBuilder;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\PseudoFormAnalyzer;
+
+$assertions = 0;
+$failures = array();
+$assert = static function (bool $condition, string $label) use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']';
+    }
+};
+
+$elementFrom = static function (string $html): DOMElement {
+    $document = new DOMDocument();
+    $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+    $element = $document->getElementsByTagName('body')->item(0)?->firstElementChild;
+    if ( $element instanceof DOMElement ) {
+        return $element;
+    }
+    throw new RuntimeException('No element parsed');
+};
+
+$selector = static fn (DOMElement $element): string => '#' . ($element->getAttribute('id') ?: strtolower($element->tagName));
+$metadataBuilder = new FormControlMetadataBuilder($selector);
+$successBuilder = new FormSuccessPanelMetadataBuilder(
+    $selector,
+    static fn (DOMElement $element): array => array( 'html' => '<aside>Thanks</aside>', 'bytes' => 21, 'truncated' => false ),
+    static fn (DOMElement $element): string => $element->textContent ?? ''
+);
+$pseudoAnalyzer = new PseudoFormAnalyzer($metadataBuilder, $selector);
+$bindingCalls = array();
+$context = new FormFallbackFindingContext(
+    static fn (): array => array(),
+    static fn (): string => '',
+    static fn (DOMElement $element): array => array( 'html' => '<safe-form>', 'bytes' => 11, 'truncated' => true ),
+    static fn (DOMElement $element): array => array( '#existing-runtime' ),
+    static fn (DOMElement $element): string => '#replacement-runtime',
+    $selector,
+    static fn (DOMElement $element): array => array( 'id' => $element->getAttribute('id') ),
+    static fn (DOMElement $element): array => array( 'source' => 'fixture' ),
+    static fn (DOMElement $element): array => array( 'kind' => 'interactive' ),
+    static fn (DOMElement $element): array => array( 'submit' => 'handler' ),
+    static function (array $block, string $role, array $selectors) use (&$bindingCalls): array {
+        $bindingCalls[] = compact('block', 'role', 'selectors');
+        return array( 'role' => $role, 'selectors' => $selectors, 'blockName' => $block['blockName'] ?? '' );
+    },
+    static fn (DOMElement $element): int => $element->childElementCount,
+    static fn (array $finding): array => array_merge(array( 'provenance' => 'fixture' ), $finding)
+);
+$builder = new FormFallbackFindingBuilder($context, $metadataBuilder, $successBuilder, $pseudoAnalyzer);
+
+$readable = array( 'blockName' => 'core/group' );
+$form = $elementFrom('<form id="signup" action="/join"><label>Email<input name="email" required></label><button type="submit">Join</button></form>');
+$finding = $builder->build($form, $readable);
+$assert('html_form_fallback' === ($finding['diagnostic_code'] ?? ''), 'diagnostic-code');
+$assert('form_requires_runtime' === ($finding['reason'] ?? ''), 'runtime-reason');
+$assert('form' === ($finding['tag'] ?? ''), 'real-form-tag');
+$assert('#signup' === ($finding['selector'] ?? ''), 'element-selector');
+$assert('/join' === ($finding['form']['action'] ?? ''), 'form-metadata');
+$assert(2 === ($finding['control_count'] ?? 0), 'control-count');
+$assert(2 === count($finding['controls'] ?? array()), 'controls-metadata');
+$assert(array( $readable ) === ($finding['readable_blocks'] ?? array()), 'readable-blocks');
+$assert('form' === ($finding['binding']['role'] ?? ''), 'readable-block-defaults-to-binding');
+$assert(array( '#existing-runtime' ) === ($finding['binding']['selectors'] ?? array()), 'default-binding-retains-runtime-selectors');
+$assert('<safe-form>' === ($finding['html'] ?? ''), 'bounded-html');
+$assert(11 === ($finding['html_bytes'] ?? 0) && true === ($finding['html_truncated'] ?? false), 'bounded-html-metadata');
+$assert(array( 'source' => 'fixture' ) === ($finding['context'] ?? array()), 'source-context');
+$assert('fixture' === ($finding['provenance'] ?? ''), 'diagnostic-builder');
+$assert(! isset($finding['form_boundary']), 'real-form-has-no-pseudo-boundary');
+
+$bindingCalls = array();
+$preserved = array( 'blockName' => 'core/html' );
+$replacement = $builder->build($form, $readable, $preserved);
+$assert('core/html' === ($replacement['binding']['blockName'] ?? ''), 'explicit-binding-is-used');
+$assert(array( '#existing-runtime', '#replacement-runtime' ) === ($replacement['binding']['selectors'] ?? array()), 'replacement-binding-supersedes-form-island');
+
+$pseudo = $elementFrom('<div id="signup-shell"><input name="email"><button>Join</button></div>');
+$pseudoFinding = $builder->build($pseudo, null);
+$assert('div' === ($pseudoFinding['tag'] ?? ''), 'pseudo-form-tag');
+$assert(isset($pseudoFinding['form_boundary']), 'pseudo-form-boundary');
+$assert(array() === ($pseudoFinding['readable_blocks'] ?? null), 'null-readable-blocks');
+$assert(array() === ($pseudoFinding['binding'] ?? null), 'null-binding');
+
+if ( $failures ) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Form fallback finding builder tests: ' . $assertions . " passed\n";


### PR DESCRIPTION
## Summary
- extract provider-materializable form diagnostics into `FormFallbackFindingBuilder`
- define the required transformer integration through `FormFallbackFindingContext`
- preserve real-form and pseudo-form metadata, topology, layout graph, bounded HTML, binding, runtime-selector supersession, and provenance behavior
- reduce `FormDispatchTrait` from 163 to 106 lines
- add a 21-assertion direct builder contract

## Verification
- `composer validate --strict`
- `composer test`
- PHP transformer parity: 289 fixtures
- distribution shape: 205 files, 10 monorepo-only trees excluded
- exact-base CSS-attached corpus comparison: byte-identical records for 383 documents / 87 fixtures / 82 fixtures with CSS / 0 throws

Part of #242.

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to extract the form fallback diagnostic boundary, define its explicit collaborator context, implement direct coverage, and run package and exact-base corpus verification.