### PR TITLE
Collapse indefinite percentage-height shells

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1087,6 +1087,16 @@ final class HtmlTransformer
                 'min_width' => $ambiguity['min_width'],
             );
         }
+        foreach ( $this->transformationEvidence()->responsiveHeightAmbiguities() as $ambiguity ) {
+            $diagnostics[] = array(
+                'code' => 'responsive_geometry_ambiguous_percentage_height',
+                'message' => 'A percentage-height rule matches both auto-sized structural wrappers and height-owning content, so it was retained without a responsive projection.',
+                'source' => self::class,
+                'severity' => 'warning',
+                'selector' => $ambiguity['selector'],
+                'height' => $ambiguity['height'],
+            );
+        }
         $headMetadata = $this->headMetadataReport($html);
         if ( array() !== $headMetadata ) {
             $diagnostics[] = array(
@@ -2383,6 +2393,7 @@ final class HtmlTransformer
     {
         return ( new CssStylesheetTransformer() )->transformStyleRules($stylesheet, function (string $prelude, string $body): string {
             $body = $this->projectResponsiveCanvasMinimumWidth($prelude, $body);
+            $body = $this->projectAutoSizedStructuralPercentageHeight($prelude, $body);
             $declarations = $this->styleResolver->cssDeclarations($body);
             $margins = array_filter($declarations, static fn (string $name): bool => 'margin' === $name || str_starts_with($name, 'margin-'), ARRAY_FILTER_USE_KEY);
             $imagePrelude = $this->projectAuthorImageSelectorPrelude($prelude);
@@ -2472,6 +2483,89 @@ final class HtmlTransformer
             $pixels *= self::ROOT_FONT_SIZE_PX;
         }
         return $pixels >= 640;
+    }
+
+    /**
+     * A percentage height computes to auto when its containing block has an
+     * indefinite height. Preserve that source behavior after block wrappers are
+     * introduced, because those wrappers can otherwise make the height definite.
+     */
+    private function projectAutoSizedStructuralPercentageHeight(string $prelude, string $body): string
+    {
+        $declarations = $this->styleResolver->cssDeclarations($body);
+        $height = (string) ($declarations['height'] ?? '');
+        if ( '100%' !== strtolower($this->cssValueWithoutImportant($height)) ) {
+            return $body;
+        }
+
+        $selectors = CssStylesheetTransformer::splitSelectorList($prelude);
+        if ( null === $selectors ) {
+            return $body;
+        }
+
+        $matchedSurface = false;
+        foreach ( $selectors as $selector ) {
+            $parsed = $this->parsedCssSelector($selector);
+            if ( ! $parsed['supported'] ) {
+                return $body;
+            }
+            $matches = $this->matchingAuthorSourceElements($selector, $parsed);
+            if ( array() === $matches ) {
+                continue;
+            }
+            $matchedSurface = true;
+            $autoSizedMatches = array_filter($matches, fn (DOMElement $element): bool => $this->isAutoSizedStructuralPercentageHeight($element));
+            if ( count($autoSizedMatches) !== count($matches) ) {
+                if ( array() !== $autoSizedMatches ) {
+                    $this->transformationEvidence()->recordResponsiveHeightAmbiguity($selector, $height);
+                }
+                return $body;
+            }
+        }
+
+        if ( ! $matchedSurface ) {
+            return $body;
+        }
+
+        $important = $this->cssValueIsImportant($height) ? '!important' : '';
+        $retained = array();
+        foreach ( CssValueSplitter::splitTopLevel($body, array( ';' )) as $declaration ) {
+            if ( 'height' !== strtolower(trim(strtok($declaration, ':'))) ) {
+                $retained[] = $declaration;
+            }
+        }
+        $retained[] = 'height:auto' . $important;
+        return implode(';', $retained);
+    }
+
+    private function isAutoSizedStructuralPercentageHeight(DOMElement $element): bool
+    {
+        if ( in_array(strtolower($element->tagName), array( 'canvas', 'embed', 'iframe', 'img', 'input', 'object', 'picture', 'svg', 'video' ), true) ) {
+            return false;
+        }
+
+        $elementStyle = $this->styleResolver->structuralPresentationDeclarations($element);
+        if ( in_array(strtolower($this->cssValueWithoutImportant((string) ($elementStyle['position'] ?? ''))), array( 'absolute', 'fixed' ), true) ) {
+            return false;
+        }
+
+        $ancestor = $element->parentNode;
+        while ( $ancestor instanceof DOMElement && $ancestor !== $this->authorStyles()->sourceBody() ) {
+            $style = $this->styleResolver->structuralPresentationDeclarations($ancestor);
+            if ( in_array(strtolower($this->cssValueWithoutImportant((string) ($style['position'] ?? ''))), array( 'absolute', 'fixed' ), true) ) {
+                return false;
+            }
+            $ancestorHeight = strtolower($this->cssValueWithoutImportant((string) ($style['height'] ?? '')));
+            if ( ! in_array($ancestorHeight, array( '', 'auto', '100%' ), true) ) {
+                return false;
+            }
+            if ( in_array(strtolower($ancestor->tagName), array( 'footer', 'header', 'section' ), true) ) {
+                return in_array($ancestorHeight, array( '', 'auto' ), true);
+            }
+            $ancestor = $ancestor->parentNode;
+        }
+
+        return false;
     }
 
     private function isPageShellOrSectionSurface(DOMElement $element): bool

--- a/php-transformer/src/HtmlToBlocks/Session/TransformationEvidenceState.php
+++ b/php-transformer/src/HtmlToBlocks/Session/TransformationEvidenceState.php
@@ -20,6 +20,9 @@ final class TransformationEvidenceState
     /** @var array<string, array{selector: string, min_width: string}> */
     private array $responsiveGeometryAmbiguities = array();
 
+    /** @var array<string, array{selector: string, height: string}> */
+    private array $responsiveHeightAmbiguities = array();
+
     /** @var list<array{selector: string, direct_child_count: int, block_child_count: int, source_tags: list<string>, block_tags: list<string>}> */
     private array $authorLayoutTopologies = array();
 
@@ -91,6 +94,20 @@ final class TransformationEvidenceState
     public function responsiveGeometryAmbiguities(): array
     {
         return array_values($this->responsiveGeometryAmbiguities);
+    }
+
+    public function recordResponsiveHeightAmbiguity(string $selector, string $height): void
+    {
+        $this->responsiveHeightAmbiguities[$selector . "\0" . $height] = array(
+            'selector' => $selector,
+            'height' => $height,
+        );
+    }
+
+    /** @return list<array{selector: string, height: string}> */
+    public function responsiveHeightAmbiguities(): array
+    {
+        return array_values($this->responsiveHeightAmbiguities);
     }
 
     /**

--- a/php-transformer/tests/unit/responsive-canvas-geometry.php
+++ b/php-transformer/tests/unit/responsive-canvas-geometry.php
@@ -47,6 +47,20 @@ $assert(
     'mixed shell and content minimum-width selectors remain intact and emit a diagnostic'
 );
 
+$percentageHeight = (new HtmlTransformer())->transform(
+    '<style>footer{height:auto}.footer-frame{height:100%!important}.footer-grid{display:grid;grid-template-rows:1fr min-content;height:100%}.footer-background{position:absolute;inset:0;height:100%}.definite-frame{height:320px}.definite-frame>.fill{height:100%}.media-fill{height:100%;object-fit:cover}.mixed-fill{height:100%}@media(max-width:600px){.mobile-footer-frame{height:100%}}</style>'
+    . '<footer><div class="footer-frame"><div class="footer-grid"><nav>Links</nav><p>Copyright</p></div><div class="footer-background"></div></div></footer>'
+    . '<section><div class="mobile-footer-frame"><p>Mobile links</p><p>Mobile copyright</p></div></section>'
+    . '<div class="definite-frame"><div class="fill">Card</div><img class="media-fill" src="card.jpg" alt=""></div>'
+    . '<footer><div class="mixed-fill">Safe shell</div></footer><div class="definite-frame"><div class="mixed-fill">Definite fill</div></div>'
+)->toArray();
+$percentageHeightCss = $css($percentageHeight);
+$assert(str_contains($percentageHeightCss, '.footer-frame{height:auto!important}') && str_contains($percentageHeightCss, '.footer-grid{display:grid;grid-template-rows:1fr min-content;height:auto}'), 'indefinite-height footer wrappers collapse without changing grid tracks or declaration priority');
+$assert(str_contains($percentageHeightCss, '@media(max-width:600px){.mobile-footer-frame{height:auto}}'), 'responsive structural variants receive the same percentage-height projection');
+$assert(str_contains($percentageHeightCss, '.footer-background{position:absolute;inset:0;height:100%}') && str_contains($percentageHeightCss, '.definite-frame>.fill{height:100%}') && str_contains($percentageHeightCss, '.media-fill{height:100%;object-fit:cover}'), 'positioned layers, definite-height components, and replaced media retain authored fill geometry');
+$assert(str_contains($percentageHeightCss, '.mixed-fill{height:100%}'), 'mixed structural and height-owning selectors retain their authored percentage height');
+$assert(in_array('responsive_geometry_ambiguous_percentage_height', array_column($percentageHeight['diagnostics'] ?? array(), 'code'), true), 'mixed percentage-height selectors emit a bounded ambiguity diagnostic');
+
 if ( $failures > 0 ) {
     fwrite(STDERR, "Responsive canvas geometry unit tests: {$failures} failed, {$passes} passed\n");
     exit(1);


### PR DESCRIPTION
## Summary

- project `height: 100%` to `height: auto` only for flow wrappers whose landmark containing-height chain is indefinite
- preserve percentage fills for positioned layers, replaced media, and components with definite-height ancestors
- retain mixed safe/unsafe selector rules and emit a bounded ambiguity diagnostic
- cover desktop and responsive structural variants without removing either authored tree

## Root cause

Captured builder footers can use `height: 100%` wrapper chains inside auto-height landmarks. Those percentages compute as `auto` in the source, but Gutenberg reparenting can introduce a definite containing height. The wrappers then stretch, and fractional grid tracks consume the new height as a large empty footer region.

## Verification

- `php tests/unit/responsive-canvas-geometry.php`
- `php tests/unit/author-selector-semantics.php`
- `php tests/unit/responsive-document-variants.php`
- `php tests/contract/shared-shell-plan.php`
- `php tests/contract/run.php`
- `composer --working-dir=php-transformer test`

Closes #1387.

## AI assistance

OpenAI gpt-5.6-sol via OpenCode general coding subagent was used to inspect the issue context and reproduction evidence, identify the generic containing-block root cause, implement the upstream fix and deterministic regression coverage, and run verification. Chris Huber reviewed the result and remains responsible for the submitted work.