### PR TITLE
Resolve captured triggers across responsive variants

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -73,6 +73,7 @@
        "php tests/unit/visual-iframe-block.php",
        "php tests/unit/authored-marquee-block.php",
        "php tests/unit/responsive-document-variants.php",
+       "php tests/unit/captured-dialog-projector.php",
        "php tests/unit/editability-report.php",
       "php tests/unit/projected-branch-compression.php",
       "php tests/unit/core-block-capability-matrix.php",

--- a/php-transformer/src/ArtifactCompiler/CapturedDialogProjector.php
+++ b/php-transformer/src/ArtifactCompiler/CapturedDialogProjector.php
@@ -110,7 +110,12 @@ final class CapturedDialogProjector
                 $diagnostics[] = $this->diagnostic('captured_dialog_unsafe_or_truncated', 'warning', 'A captured dialog was ignored because its HTML is empty, truncated, or exceeds the byte limit.', array('source_path' => $sourcePath));
                 continue;
             }
-            $triggers = $this->findTriggers($document, $state['trigger']);
+            $found = $this->findTriggers($document, $state['trigger']);
+            if ('ambiguous' === $found['status']) {
+                $diagnostics[] = $this->diagnostic('captured_dialog_trigger_ambiguous', 'warning', 'A captured dialog trigger matched multiple source elements in the same route or responsive document scope.', array('source_path' => $sourcePath, 'selector' => (string) ($state['trigger']['selector'] ?? '')));
+                continue;
+            }
+            $triggers = $found['elements'];
             if (array() === $triggers) {
                 $diagnostics[] = $this->diagnostic('captured_dialog_trigger_unmatched', 'warning', 'A captured dialog trigger did not match a bounded source element set.', array('source_path' => $sourcePath, 'selector' => (string) ($state['trigger']['selector'] ?? '')));
                 continue;
@@ -153,35 +158,300 @@ final class CapturedDialogProjector
         return array('html' => is_string($output) ? $output : $html, 'diagnostics' => $diagnostics, 'projected_count' => $projected);
     }
 
-    /** @param array<string, mixed> $trigger @return array<int, DOMElement> */
+    /**
+     * @param array<string, mixed> $trigger
+     * @return array{status:'matched'|'unmatched'|'ambiguous', elements:array<int, DOMElement>}
+     */
     private function findTriggers(DOMDocument $document, array $trigger): array
     {
+        $scopes = $this->documentScopes($document);
+        if (count($scopes) > self::MAX_STATES_PER_PAGE) {
+            return array('status' => 'ambiguous', 'elements' => array());
+        }
+        $elements = array();
+        foreach ($scopes as $scope) {
+            $matched = $this->matchInScope($scope, $trigger);
+            if (count($matched) > 1) {
+                return array('status' => 'ambiguous', 'elements' => array());
+            }
+            if (1 === count($matched)) {
+                $elements[] = $matched[0];
+            }
+        }
+        if (count($elements) > self::MAX_STATES_PER_PAGE) {
+            return array('status' => 'ambiguous', 'elements' => array());
+        }
+        if (array() === $elements) {
+            return array('status' => 'unmatched', 'elements' => array());
+        }
+        return array('status' => 'matched', 'elements' => $elements);
+    }
+
+    /** @return array<int, DOMElement> */
+    private function documentScopes(DOMDocument $document): array
+    {
+        $body = $document->getElementsByTagName('body')->item(0) ?? $document->documentElement;
+        if (! $body instanceof DOMElement) {
+            return array();
+        }
+        $scopes = array();
+        foreach ($body->childNodes as $child) {
+            if ($child instanceof DOMElement && $this->isResponsiveDocumentWrapper($child)) {
+                $scopes[] = $child;
+            }
+        }
+        return array() === $scopes ? array($body) : $scopes;
+    }
+
+    private function isResponsiveDocumentWrapper(DOMElement $element): bool
+    {
+        foreach (preg_split('/\s+/', trim($element->getAttribute('class'))) ?: array() as $class) {
+            if (str_starts_with($class, 'site-document-variant-') || in_array($class, array('data-liberation-desktop-document', 'data-liberation-mobile-document'), true)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $trigger
+     * @return array<int, DOMElement>
+     */
+    private function matchInScope(DOMElement $scope, array $trigger): array
+    {
+        $identity = $this->identityMatches($scope, $trigger);
+        if (array() !== $identity) {
+            return $this->filterCandidates($identity, $trigger);
+        }
+        $selector = $this->selectorMatches($scope, $trigger);
+        if (array() !== $selector) {
+            return $this->filterCandidates($selector, $trigger);
+        }
+        return $this->filterCandidates($this->evidenceMatches($scope, $trigger), $trigger);
+    }
+
+    /**
+     * @param array<string, mixed> $trigger
+     * @return array<int, DOMElement>
+     */
+    private function identityMatches(DOMElement $scope, array $trigger): array
+    {
+        $document = $scope->ownerDocument;
+        if (! $document instanceof DOMDocument) {
+            return array();
+        }
         $xpath = new DOMXPath($document);
         $selector = is_string($trigger['selector'] ?? null) ? trim($trigger['selector']) : '';
         $query = '';
         if (str_starts_with($selector, '#') && 1 === preg_match('/^#[A-Za-z][A-Za-z0-9_.:-]*$/', $selector)) {
-            $query = '//*[@id=' . $this->xpathLiteral(substr($selector, 1)) . ']';
+            $query = './/*[@id=' . $this->xpathLiteral(substr($selector, 1)) . ']';
         } else {
             $bindings = is_array($trigger['dataBindings'] ?? null) ? $trigger['dataBindings'] : array();
             foreach ($bindings as $name => $value) {
                 if (is_string($name) && is_string($value) && 1 === preg_match('/^data-(?:popup|modal|dialog)(?:id|target)?$/i', $name) && '' !== $value) {
-                    $query = '//*[@' . strtolower($name) . '=' . $this->xpathLiteral($value) . ']';
+                    $query = './/*[@' . strtolower($name) . '=' . $this->xpathLiteral($value) . ']';
                     break;
                 }
             }
         }
-        if ('' === $query) return array();
-        $matches = $xpath->query($query);
-        if (false === $matches || 0 === $matches->length || $matches->length > self::MAX_STATES_PER_PAGE) return array();
-        $tag = is_string($trigger['tag'] ?? null) ? strtolower($trigger['tag']) : '';
+        if ('' === $query) {
+            return array();
+        }
+        $matches = $xpath->query($query, $scope);
+        if (false === $matches || 0 === $matches->length) {
+            return array();
+        }
         $elements = array();
         foreach ($matches as $element) {
-            if (! $element instanceof DOMElement || ('' !== $tag && $tag !== strtolower($element->tagName))) continue;
-            $popup = strtolower(trim($element->getAttribute('aria-haspopup')));
-            if (! in_array($popup, array('dialog', 'true'), true)) continue;
+            if ($element instanceof DOMElement) {
+                $elements[] = $element;
+            }
+        }
+        return $elements;
+    }
+
+    /**
+     * @param array<string, mixed> $trigger
+     * @return array<int, DOMElement>
+     */
+    private function selectorMatches(DOMElement $scope, array $trigger): array
+    {
+        $selector = is_string($trigger['selector'] ?? null) ? trim($trigger['selector']) : '';
+        if ('' === $selector || str_contains($selector, ',') || ! str_contains($selector, '>')) {
+            return array();
+        }
+        $parts = preg_split('/\s*>\s*/', $selector);
+        if (! is_array($parts) || array() === $parts) {
+            return array();
+        }
+        if ('body' === strtolower($parts[0])) {
+            array_shift($parts);
+        }
+        if (array() === $parts) {
+            return array();
+        }
+        $current = array($scope);
+        foreach ($parts as $index => $part) {
+            if (1 !== preg_match('/^([a-z][a-z0-9]*)(#([A-Za-z][A-Za-z0-9_.:-]*))?(:nth-of-type\((\d+)\))?$/i', $part, $tokens)) {
+                return array();
+            }
+            $tag = strtolower($tokens[1]);
+            $id = $tokens[3] ?? '';
+            $nth = isset($tokens[5]) && '' !== $tokens[5] ? (int) $tokens[5] : 0;
+            $isLast = $index === array_key_last($parts);
+            $next = array();
+            foreach ($current as $node) {
+                $seen = array();
+                foreach ($node->childNodes as $child) {
+                    if (! $child instanceof DOMElement) {
+                        continue;
+                    }
+                    $childTag = strtolower($child->tagName);
+                    $seen[$childTag] = ($seen[$childTag] ?? 0) + 1;
+                    $tagMatches = $childTag === $tag || ($isLast && $this->tagCompatible($tag, $childTag));
+                    if (! $tagMatches) {
+                        continue;
+                    }
+                    if ('' !== $id && $child->getAttribute('id') !== $id) {
+                        continue;
+                    }
+                    if ($nth > 0 && ($seen[$tag] ?? 0) !== $nth) {
+                        continue;
+                    }
+                    $next[] = $child;
+                }
+            }
+            if (array() === $next) {
+                return array();
+            }
+            if (count($next) > self::MAX_STATES_PER_PAGE) {
+                return $next;
+            }
+            $current = $next;
+        }
+        return $current;
+    }
+
+    /**
+     * @param array<string, mixed> $trigger
+     * @return array<int, DOMElement>
+     */
+    private function evidenceMatches(DOMElement $scope, array $trigger): array
+    {
+        $label = $this->normalizedLabel(is_string($trigger['label'] ?? null) ? $trigger['label'] : '');
+        if ('' === $label) {
+            return array();
+        }
+        $elements = array();
+        foreach ($scope->getElementsByTagName('*') as $element) {
+            if (! $element instanceof DOMElement || $this->insideProjectedDialog($element) || ! $this->isInteractiveControl($element)) {
+                continue;
+            }
+            if ($label !== $this->accessibleName($element)) {
+                continue;
+            }
             $elements[] = $element;
         }
         return $elements;
+    }
+
+    /**
+     * @param array<int, DOMElement> $elements
+     * @param array<string, mixed> $trigger
+     * @return array<int, DOMElement>
+     */
+    private function filterCandidates(array $elements, array $trigger): array
+    {
+        $tag = is_string($trigger['tag'] ?? null) ? strtolower(trim($trigger['tag'])) : '';
+        $label = $this->normalizedLabel(is_string($trigger['label'] ?? null) ? $trigger['label'] : '');
+        $capturedPopup = strtolower(trim(is_string($trigger['ariaHaspopup'] ?? null) ? $trigger['ariaHaspopup'] : ''));
+        $filtered = array();
+        foreach ($elements as $element) {
+            if (! $this->tagCompatible($tag, strtolower($element->tagName)) || ! $this->isInteractiveControl($element)) {
+                continue;
+            }
+            if ('' !== $label && $label !== $this->accessibleName($element)) {
+                continue;
+            }
+            $popup = strtolower(trim($element->getAttribute('aria-haspopup')));
+            if ('' !== $capturedPopup && $popup !== $capturedPopup && ! (in_array($capturedPopup, array('dialog', 'true'), true) && in_array($popup, array('dialog', 'true'), true))) {
+                continue;
+            }
+            if (! $this->bindingsCompatible($element, $trigger)) {
+                continue;
+            }
+            $filtered[] = $element;
+        }
+        return array_values($filtered);
+    }
+
+    /** @param array<string, mixed> $trigger */
+    private function bindingsCompatible(DOMElement $element, array $trigger): bool
+    {
+        $bindings = is_array($trigger['dataBindings'] ?? null) ? $trigger['dataBindings'] : array();
+        foreach ($bindings as $name => $value) {
+            if (! is_string($name) || ! is_string($value) || '' === $value || 1 !== preg_match('/^data-[a-z0-9_.:-]+$/i', $name)) {
+                if (is_string($value) && '' !== $value) {
+                    return false;
+                }
+                continue;
+            }
+            if (strtolower($element->getAttribute($name)) !== strtolower($value)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private function tagCompatible(string $captured, string $actual): bool
+    {
+        if ('' === $captured || $captured === $actual) {
+            return true;
+        }
+        $interactive = array('a', 'button', 'input', 'summary');
+        return in_array($captured, $interactive, true) && in_array($actual, $interactive, true);
+    }
+
+    private function isInteractiveControl(DOMElement $element): bool
+    {
+        $tag = strtolower($element->tagName);
+        if (in_array($tag, array('button', 'summary'), true)) {
+            return true;
+        }
+        if ('a' === $tag) {
+            return true;
+        }
+        if ('input' === $tag && in_array(strtolower($element->getAttribute('type')), array('button', 'submit'), true)) {
+            return true;
+        }
+        if ('button' === strtolower(trim($element->getAttribute('role')))) {
+            return true;
+        }
+        return in_array(strtolower(trim($element->getAttribute('aria-haspopup'))), array('dialog', 'menu', 'true'), true);
+    }
+
+    private function accessibleName(DOMElement $element): string
+    {
+        $label = $this->normalizedLabel($element->getAttribute('aria-label'));
+        if ('' !== $label) {
+            return $label;
+        }
+        return $this->normalizedLabel($element->textContent ?? '');
+    }
+
+    private function normalizedLabel(string $value): string
+    {
+        return strtolower(trim(preg_replace('/\s+/', ' ', $value) ?? $value));
+    }
+
+    private function insideProjectedDialog(DOMElement $element): bool
+    {
+        for ($parent = $element->parentNode; $parent instanceof DOMElement; $parent = $parent->parentNode) {
+            if ('dialog' === strtolower($parent->tagName) && 'true' === $parent->getAttribute('data-blocks-engine-captured-dialog')) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /** @return array{nodes:array<int, \DOMNode>, class:string, aria_label:string, aria_labelledby:string, aria_describedby:string, has_close_control:bool}|null */

--- a/php-transformer/tests/unit/captured-dialog-projector.php
+++ b/php-transformer/tests/unit/captured-dialog-projector.php
@@ -1,0 +1,127 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\CapturedDialogProjector;
+
+$failures = 0;
+$passes = 0;
+$assert = static function (bool $condition, string $message) use (&$failures, &$passes): void {
+    if ($condition) {
+        ++$passes;
+        return;
+    }
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . PHP_EOL);
+};
+
+$dialogHtml = '<nav aria-label="Site"><a href="/features">Features</a></nav>';
+$project = static function (array $files) use ($dialogHtml): array {
+    return (new CapturedDialogProjector())->project($files);
+};
+$codes = static function (array $result): array {
+    return array_values(array_filter(array_map(static fn(array $row): string => (string) ($row['code'] ?? ''), $result['diagnostics'] ?? array())));
+};
+$state = static function (array $trigger) use ($dialogHtml): array {
+    return array(
+        'status' => 'captured',
+        'trigger' => $trigger,
+        'dialog' => array('html' => $dialogHtml, 'htmlBytes' => strlen($dialogHtml), 'htmlTruncated' => false),
+    );
+};
+$files = static function (array $pages, array $statesByUrl) use ($state): array {
+    $routes = array();
+    $pageRows = array();
+    $reportPages = array();
+    foreach ($pages as $url => $html) {
+        $path = $pages === array() ? 'website/index.html' : 'website/' . trim(parse_url($url, PHP_URL_PATH) ?: '/', '/') . '/index.html';
+        if ('website//index.html' === $path || 'website/index.html' === $path) {
+            $path = 'website/index.html';
+        }
+        $routes[] = array('url' => $url, 'path' => $path);
+        $pageRows[] = array('path' => $path, 'content' => $html);
+        $reportPages[] = array('sourceUrl' => $url, 'states' => $statesByUrl[$url] ?? array());
+    }
+    $pageRows[] = array('path' => 'capture-receipt.json', 'content' => json_encode(array('schema' => 'data-liberation/capture-receipt/v1', 'routes' => $routes), JSON_UNESCAPED_SLASHES));
+    $pageRows[] = array('path' => 'interaction-states.json', 'content' => json_encode(array('schema' => 'data-liberation/captured-interactions/v1', 'pages' => $reportPages), JSON_UNESCAPED_SLASHES));
+    return $pageRows;
+};
+
+$bindingTrigger = array('selector' => 'body > header > nav > a:nth-of-type(2)', 'tag' => 'a', 'ariaHaspopup' => 'dialog', 'label' => 'Contact', 'dataBindings' => array('data-popupid' => 'contact'));
+$bindingHtml = '<html><body><header><nav><a href="/">Home</a><a role="button" aria-haspopup="dialog" data-popupid="contact">Contact</a></nav></header></body></html>';
+$binding = $project($files(array('https://example.test/' => $bindingHtml), array('https://example.test/' => array($state($bindingTrigger)))));
+$assert(1 === ($binding['projected_count'] ?? 0), 'declarative bindings still project one dialog');
+$assert(! in_array('captured_dialog_trigger_unmatched', $codes($binding), true), 'declarative bindings do not emit unmatched diagnostics');
+$assert(str_contains((string) $binding['files'][0]['content'], 'data-blocks-engine-captured-dialog="true"'), 'declarative bindings inject a captured dialog');
+
+$menuTrigger = array(
+    'selector' => 'body > div > div > div:nth-of-type(2) > header > nav > div > button',
+    'tag' => 'button',
+    'ariaHaspopup' => '',
+    'label' => 'Menu',
+    'dataBindings' => array(),
+);
+$responsiveHtml = '<html><body>'
+    . '<div class="data-liberation-desktop-document"><div><div><div></div><div><header><nav><div><details><summary aria-label="Menu">Menu</summary></details></div></nav></header></div></div></div></div>'
+    . '<div class="data-liberation-mobile-document"><div><div><div></div><div><header><nav><div><details><summary aria-label="Menu">Menu</summary></details></div></nav></header></div></div></div></div>'
+    . '</body></html>';
+$responsive = $project($files(array('https://example.test/' => $responsiveHtml), array('https://example.test/' => array($state($menuTrigger)))));
+$responsiveAgain = $project($files(array('https://example.test/' => $responsiveHtml), array('https://example.test/' => array($state($menuTrigger)))));
+$assert(1 === ($responsive['projected_count'] ?? 0), 'responsive document scopes project one dialog for equivalent rewritten triggers');
+$assert(array() === $codes($responsive), 'responsive document scopes emit no trigger diagnostics');
+$assert($responsive === $responsiveAgain, 'responsive trigger matching and generated identities are deterministic');
+$assert(1 === preg_match('/data-blocks-engine-triggers="([^"]+)"/', (string) $responsive['files'][0]['content'], $triggerIds), 'responsive matches expose trigger ids');
+$assert(2 === count(preg_split('/\s+/', trim($triggerIds[1] ?? '')) ?: array()), 'each responsive document contributes one trigger');
+
+$variantHtml = '<html><body>'
+    . '<div class="site-document-variant-default"><header><button aria-label="Menu">Menu</button></header></div>'
+    . '<div class="site-document-variant-mobile"><header><button aria-label="Menu">Menu</button></header></div>'
+    . '</body></html>';
+$variant = $project($files(array('https://example.test/variant' => $variantHtml), array('https://example.test/variant' => array($state($menuTrigger)))));
+$assert(1 === ($variant['projected_count'] ?? 0) && array() === $codes($variant), 'site document variant wrappers match one trigger per scope');
+
+$homeHtml = '<html><body><div class="data-liberation-mobile-document"><button aria-label="Menu">Menu</button></div></body></html>';
+$aboutHtml = '<html><body><div class="data-liberation-mobile-document"><button aria-label="Menu">Menu</button></div></body></html>';
+$routed = $project($files(
+    array('https://example.test/' => $homeHtml, 'https://example.test/about' => $aboutHtml),
+    array('https://example.test/' => array($state($menuTrigger)))
+));
+$assert(1 === ($routed['projected_count'] ?? 0), 'route scoped matching projects only the captured route');
+$assert(str_contains((string) $routed['files'][0]['content'], 'data-blocks-engine-captured-dialog="true"'), 'the captured route receives the dialog');
+$assert(! str_contains((string) $routed['files'][1]['content'], 'data-blocks-engine-captured-dialog'), 'an uncaptured route does not receive another route trigger');
+
+$bothRoutes = $project($files(
+    array('https://example.test/' => $homeHtml, 'https://example.test/about' => $aboutHtml),
+    array('https://example.test/' => array($state($menuTrigger)), 'https://example.test/about' => array($state($menuTrigger)))
+));
+$assert(2 === ($bothRoutes['projected_count'] ?? 0) && array() === $codes($bothRoutes), 'each captured route binds its own dialog');
+
+$ambiguousHtml = '<html><body><header><button aria-label="Menu">Menu</button><button aria-label="Menu">Menu</button></header></body></html>';
+$ambiguous = $project($files(array('https://example.test/ambiguous' => $ambiguousHtml), array('https://example.test/ambiguous' => array($state($menuTrigger)))));
+$assert(0 === ($ambiguous['projected_count'] ?? -1), 'ambiguous matches fail closed');
+$assert(in_array('captured_dialog_trigger_ambiguous', $codes($ambiguous), true), 'ambiguous matches emit a fail-closed diagnostic');
+$assert(! str_contains((string) $ambiguous['files'][0]['content'], 'data-blocks-engine-captured-dialog'), 'ambiguous matches do not inject a dialog');
+$assert($ambiguousHtml === $ambiguous['files'][0]['content'], 'ambiguous matching does not mutate the source document');
+
+$missingHtml = '<html><body><header><button aria-label="Search">Search</button></header></body></html>';
+$missing = $project($files(array('https://example.test/missing' => $missingHtml), array('https://example.test/missing' => array($state($menuTrigger)))));
+$assert(0 === ($missing['projected_count'] ?? -1), 'missing matches fail closed');
+$assert(in_array('captured_dialog_trigger_unmatched', $codes($missing), true), 'missing matches emit unmatched diagnostics');
+
+$conflicting = $project($files(array('https://example.test/conflict' => '<html><body><header><button aria-label="Search">Open</button></header></body></html>'), array(
+    'https://example.test/conflict' => array($state(array('selector' => 'body > header > button', 'tag' => 'button', 'ariaHaspopup' => '', 'label' => 'Menu', 'dataBindings' => array()))),
+)));
+$assert(0 === ($conflicting['projected_count'] ?? -1), 'conflicting captured metadata vetoes a structural match');
+$assert(in_array('captured_dialog_trigger_unmatched', $codes($conflicting), true), 'a vetoed structural match does not fall through to weaker evidence');
+
+$selectorHtml = '<html><body><div class="data-liberation-mobile-document"><div><div><div></div><div><header><nav><div><button type="button">Open</button></div></nav></header></div></div></div></div></body></html>';
+$selectorTrigger = array('selector' => 'body > div > div > div:nth-of-type(2) > header > nav > div > button', 'tag' => 'button', 'ariaHaspopup' => '', 'label' => '', 'dataBindings' => array());
+$selector = $project($files(array('https://example.test/selector' => $selectorHtml), array('https://example.test/selector' => array($state($selectorTrigger)))));
+$assert(1 === ($selector['projected_count'] ?? 0), 'wrapper-normalized positional selectors match inside a responsive document');
+
+if (0 !== $failures) {
+    fwrite(STDERR, "captured-dialog-projector failed: {$failures} failure(s), {$passes} pass(es)\n");
+    exit(1);
+}
+echo "OK: captured-dialog-projector passed ({$passes} assertions)\n";


### PR DESCRIPTION
Closes #1388.

## What

- Matches captured dialog triggers within bounded route and typed responsive-document scopes.
- Uses ordered identity, safe positional-selector, and corroborating accessible-control evidence after responsive normalization.
- Preserves deterministic responsive trigger ordering while accepting compatible interactive rewrites such as `button` to `summary`.
- Treats captured labels, popup metadata, and data bindings as constraints and emits a dedicated ambiguity diagnostic without mutating source HTML.
- Adds route isolation, responsive matching, deterministic output, conflicting-evidence, missing-trigger, and ambiguity regression coverage.

## Root cause

`CapturedDialogProjector` only attempted exact ID or approved declarative data-binding queries, then required `aria-haspopup` to identify a dialog control. Captured mobile menu controls had no such identity or popup metadata, and responsive normalization had rewritten the source control and wrapped equivalent desktop/mobile documents, so all three route-scoped states remained unmatched.

## Verification

- `php tests/unit/captured-dialog-projector.php` (22 assertions)
- `php tests/contract/run.php`
- `composer --working-dir=php-transformer test`
- Three-route acceptance artifact: baseline 3 unmatched / 0 projected; fixed 0 trigger diagnostics / 3 projected

## AI assistance

- **Model:** OpenAI gpt-5.6-sol
- **Tool:** OpenCode general coding subagent
- **Used for:** Issue and prior-art investigation, root-cause analysis, implementation, regression tests, and verification. Chris Huber reviewed the changes and remains responsible for every line.