### PR TITLE
Add portable source manifest fixture

### DIFF
--- a/fixtures/solved/89-static-site-importer-architecture/.static-site-importer-source.json
+++ b/fixtures/solved/89-static-site-importer-architecture/.static-site-importer-source.json
@@ -1,0 +1,15 @@
+{
+  "schema": "static-site-importer/portable-source/v1",
+  "root": ".",
+  "entrypoint": "index.html",
+  "files": [
+    {
+      "path": "index.html",
+      "sha256": "c31305742577aacc80d67ca6f304ae887d6ba8e694465f18613b9abca5a43076"
+    },
+    {
+      "path": "css/site.css",
+      "sha256": "10469cfb88ac30dd42f2bacc63c98945722267fd74869024c713e05073a75c2d"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add the portable source manifest to solved fixture 89
- declare `index.html` and `css/site.css` as the complete website payload
- leave `fixture.json` available as corpus metadata without compiling it into generated themes

## Dependency

This exercises the contract introduced by Automattic/static-site-importer#1416.

## Verification

- validated the manifest JSON
- verified both declared SHA-256 hashes against the fixture bytes
- built an SSI development package from Automattic/static-site-importer#1416
- imported this fixture through Automattic/studio#4725 using `site create --from`
- verified the generated theme excludes `fixture.json` and the portable manifest while retaining `css/site.css`

## AI Assistance

OpenAI GPT-5.6-Sol via OpenCode was used to add the fixture manifest and run integrity and end-to-end verification. The change and evidence were reviewed and directed by Chris Huber.
