### PR TITLE
Model dynamic navigation in static parity

### DIFF
--- a/php-transformer/dev/VisualParity/StaticStyleParityRunner.php
+++ b/php-transformer/dev/VisualParity/StaticStyleParityRunner.php
@@ -138,6 +138,50 @@ final class StaticStyleParityRunner
      */
     public static function candidateHtmlFromSerializedBlocks(string $serializedBlocks): string
     {
+        // Navigation blocks also save as a comment-only tree. Reconstruct only
+        // the stable server-rendered structure needed for selector/style probes;
+        // responsive overlays and behavior remain WordPress runtime concerns.
+        $serializedBlocks = preg_replace_callback(
+            '/<!--\s*(\/?)wp:(navigation(?:-submenu|-link)?)(?:\s+(\{(?:(?!-->).)*\}))?\s*(\/?)-->/s',
+            static function (array $match): string {
+                $closing = '/' === ($match[1] ?? '');
+                $name = (string) ($match[2] ?? '');
+                if ($closing) {
+                    return array(
+                        'navigation' => '</ul></nav>',
+                        'navigation-submenu' => '</ul></li>',
+                        'navigation-link' => '</li>',
+                    )[$name] ?? '';
+                }
+
+                $attrs = json_decode((string) ($match[3] ?? ''), true);
+                $attrs = is_array($attrs) ? $attrs : array();
+                $className = htmlspecialchars(trim((string) ($attrs['className'] ?? '')), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+                $selfClosing = '/' === ($match[4] ?? '');
+
+                if ('navigation' === $name) {
+                    $navigation = '<nav class="' . trim('wp-block-navigation ' . $className) . '"><ul class="'
+                        . trim('wp-block-navigation__container wp-block-navigation ' . $className) . '">';
+                    return $navigation . ($selfClosing ? '</ul></nav>' : '');
+                }
+
+                $url = htmlspecialchars((string) ($attrs['url'] ?? '#'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+                $label = strip_tags((string) ($attrs['label'] ?? ''), '<span><strong><em><small><mark>');
+                $itemClasses = htmlspecialchars(trim('wp-block-navigation-item ' . $className), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+                $link = '<a class="wp-block-navigation-item__content" href="' . $url . '">'
+                    . '<span class="wp-block-navigation-item__label">' . $label . '</span></a>';
+
+                if ('navigation-link' === $name) {
+                    return '<li class="' . $itemClasses . '">' . $link . '</li>';
+                }
+
+                $submenu = '<li class="' . trim($itemClasses . ' has-child') . '">' . $link
+                    . '<ul class="wp-block-navigation__submenu-container">';
+                return $submenu . ($selfClosing ? '</ul></li>' : '');
+            },
+            $serializedBlocks
+        ) ?? $serializedBlocks;
+
         // Dynamic social-link children save only block comments. Materialize the
         // stable server-rendered structure so the render-free proxy can compare
         // the source controls and icons without embedding WordPress icon data.

--- a/php-transformer/tests/unit/live-wp-parity-runner.php
+++ b/php-transformer/tests/unit/live-wp-parity-runner.php
@@ -121,6 +121,20 @@ $assert(
     '2b: render-free proxy materializes the stable structure of dynamic social-link children'
 );
 
+$navigationProxy = StaticStyleParityRunner::candidateHtmlFromSerializedBlocks(
+    '<!-- wp:navigation {"className":"main-nav"} --><!-- wp:navigation-submenu {"className":"main-nav__item","label":"Platform \\u003cspan class=\\u0022caret\\u0022\\u003e↓\\u003c/span\\u003e","url":"/platform"} --><!-- wp:navigation-link {"className":"mega-link","label":"Supplier 360\\u003cspan class=\\u0022description\\u0022\\u003eUnified record\\u003c/span\\u003e","url":"/platform#supplier"} /--><!-- /wp:navigation-submenu --><!-- /wp:navigation -->'
+);
+$assert(
+    str_contains($navigationProxy, '<nav class="wp-block-navigation main-nav"><ul class="wp-block-navigation__container wp-block-navigation main-nav">')
+        && str_contains($navigationProxy, '<li class="wp-block-navigation-item main-nav__item has-child">')
+        && str_contains($navigationProxy, '<a class="wp-block-navigation-item__content" href="/platform">')
+        && str_contains($navigationProxy, '<span class="caret">↓</span>')
+        && str_contains($navigationProxy, '<li class="wp-block-navigation-item mega-link">')
+        && str_contains($navigationProxy, '<span class="description">Unified record</span>')
+        && str_ends_with($navigationProxy, '</li></ul></li></ul></nav>'),
+    '2c: render-free proxy materializes nested dynamic navigation block structure'
+);
+
 // ---------------------------------------------------------------------------
 // 3. Faithful live render scores perfectly (parity == 1.0, no findings).
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1389.

`core/navigation`, `core/navigation-submenu`, and `core/navigation-link` preserve their complete canonical block tree but render dynamically. The render-free static-parity proxy previously stripped those comment delimiters without materializing the runtime structure, so every desktop navigation node looked absent.

This adds a bounded navigation-family materializer alongside the existing dynamic social-link proxy. It reconstructs only the stable server-rendered structure needed by selector/style probes:

- navigation and container elements;
- nested submenu/list-item structure;
- navigation anchors;
- block-provided classes and URLs;
- labels, including sanitized nested formatting markup.

Production block serialization remains unchanged. Responsive overlay UI and behavior remain WordPress runtime concerns.

## Signal improvement

`28-enterprise-b2b` before:

```
score             0.7182
property parity   0.9491
coverage          0.7567
matched           395 / 670
findings          273
desktop header presence findings  146
```

After:

```
score             0.7398
property parity   0.9128
coverage          0.8104
matched           420 / 670
findings          328
desktop header presence findings  120
```

The total finding count intentionally increases. Twenty-five additional source elements now find their runtime counterparts, converting opaque presence losses into actionable style deltas. The newly visible desktop failures identify concrete production parity gaps in caret and mega-link description color, display, font size, and weight. This PR improves measurement fidelity; it does not claim to repair those downstream visual differences.

The separate mobile-navigation cluster drops from 83 to 72 findings through more accurate candidate matching. Its root `display:none → revert` divergence remains real and out of scope.

## Verification

```
composer test             passed
canonical/unit            passed (nested navigation proxy contract)
parity                     289 fixtures passed
packaging                  passed
```

---

*AI assistance disclosure: OpenAI GPT-5.6 Sol via OpenCode measured and grouped the post-#1381 fixture findings, traced the desktop losses through canonical navigation serialization and render-free reconstruction, implemented the bounded structural proxy, compared its shape against WordPress core rendering, and ran the full test suite. Chris Huber directed the work and remains responsible for the change.*
