### PR TITLE
Match captured menu triggers across responsive documents

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -146,6 +146,7 @@
       "php tests/unit/responsive-canvas-geometry.php",
       "php tests/unit/core-html-fallback-reduction.php",
       "php tests/unit/inert-capture-scaffolding.php",
+      "php tests/unit/captured-dialog-projector.php",
       "php tests/unit/geometry-chain-coalescing.php",
       "php tests/unit/pattern-recursive-converter.php",
       "php tests/unit/pattern-recognizer-registry.php",

--- a/php-transformer/src/ArtifactCompiler/CapturedDialogProjector.php
+++ b/php-transformer/src/ArtifactCompiler/CapturedDialogProjector.php
@@ -110,7 +110,12 @@ final class CapturedDialogProjector
                 $diagnostics[] = $this->diagnostic('captured_dialog_unsafe_or_truncated', 'warning', 'A captured dialog was ignored because its HTML is empty, truncated, or exceeds the byte limit.', array('source_path' => $sourcePath));
                 continue;
             }
-            $triggers = $this->findTriggers($document, $state['trigger']);
+            $resolved = $this->findTriggers($document, $state['trigger']);
+            if ('ambiguous' === $resolved['status']) {
+                $diagnostics[] = $this->diagnostic('captured_dialog_trigger_ambiguous', 'warning', 'A captured dialog trigger matched more than one bounded source element.', array('source_path' => $sourcePath, 'selector' => (string) ($state['trigger']['selector'] ?? '')));
+                continue;
+            }
+            $triggers = $resolved['elements'];
             if (array() === $triggers) {
                 $diagnostics[] = $this->diagnostic('captured_dialog_trigger_unmatched', 'warning', 'A captured dialog trigger did not match a bounded source element set.', array('source_path' => $sourcePath, 'selector' => (string) ($state['trigger']['selector'] ?? '')));
                 continue;
@@ -153,35 +158,221 @@ final class CapturedDialogProjector
         return array('html' => is_string($output) ? $output : $html, 'diagnostics' => $diagnostics, 'projected_count' => $projected);
     }
 
-    /** @param array<string, mixed> $trigger @return array<int, DOMElement> */
+    /**
+     * @param array<string, mixed> $trigger
+     * @return array{status:'matched'|'unmatched'|'ambiguous', elements:array<int, DOMElement>}
+     */
     private function findTriggers(DOMDocument $document, array $trigger): array
     {
+        $scopes = $this->documentScopes($document);
+        if (count($scopes) > self::MAX_STATES_PER_PAGE) {
+            return array('status' => 'ambiguous', 'elements' => array());
+        }
+        $elements = array();
+        foreach ($scopes as $scope) {
+            $matched = $this->matchTriggersInRoot($document, $scope, $trigger);
+            if (count($matched) > 1) {
+                return array('status' => 'ambiguous', 'elements' => array());
+            }
+            if (1 === count($matched)) {
+                $elements[] = $matched[0];
+            }
+        }
+        if (count($elements) > self::MAX_STATES_PER_PAGE) {
+            return array('status' => 'ambiguous', 'elements' => array());
+        }
+        if (array() === $elements) {
+            return array('status' => 'unmatched', 'elements' => array());
+        }
+        return array('status' => 'matched', 'elements' => $elements);
+    }
+
+    /** @return array<int, DOMElement> */
+    private function documentScopes(DOMDocument $document): array
+    {
+        $body = $document->getElementsByTagName('body')->item(0) ?? $document->documentElement;
+        if (! $body instanceof DOMElement) {
+            return array();
+        }
+        $scopes = array();
+        foreach ($body->childNodes as $child) {
+            if ($child instanceof DOMElement && $this->isResponsiveDocument($child)) {
+                $scopes[] = $child;
+            }
+        }
+        return array() === $scopes ? array($body) : $scopes;
+    }
+
+    private function isResponsiveDocument(DOMElement $element): bool
+    {
+        foreach (preg_split('/\s+/', trim($element->getAttribute('class'))) ?: array() as $class) {
+            if (1 === preg_match('/^(?:site-document-variant-[a-z0-9_-]+|data-liberation-[a-z0-9]+-document)$/i', $class)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $trigger
+     * @return array<int, DOMElement>
+     */
+    private function matchTriggersInRoot(DOMDocument $document, DOMDocument|DOMElement $root, array $trigger): array
+    {
         $xpath = new DOMXPath($document);
+        $scoped = $this->scopedQuery($root);
+        $candidates = array();
         $selector = is_string($trigger['selector'] ?? null) ? trim($trigger['selector']) : '';
-        $query = '';
         if (str_starts_with($selector, '#') && 1 === preg_match('/^#[A-Za-z][A-Za-z0-9_.:-]*$/', $selector)) {
-            $query = '//*[@id=' . $this->xpathLiteral(substr($selector, 1)) . ']';
-        } else {
+            $candidates = $this->queryElements($xpath, $scoped . '[@id=' . $this->xpathLiteral(substr($selector, 1)) . ']', $root);
+        }
+        if (array() === $candidates) {
             $bindings = is_array($trigger['dataBindings'] ?? null) ? $trigger['dataBindings'] : array();
             foreach ($bindings as $name => $value) {
                 if (is_string($name) && is_string($value) && 1 === preg_match('/^data-(?:popup|modal|dialog)(?:id|target)?$/i', $name) && '' !== $value) {
-                    $query = '//*[@' . strtolower($name) . '=' . $this->xpathLiteral($value) . ']';
+                    $candidates = $this->queryElements($xpath, $scoped . '[@' . strtolower($name) . '=' . $this->xpathLiteral($value) . ']', $root);
                     break;
                 }
             }
         }
-        if ('' === $query) return array();
-        $matches = $xpath->query($query);
-        if (false === $matches || 0 === $matches->length || $matches->length > self::MAX_STATES_PER_PAGE) return array();
-        $tag = is_string($trigger['tag'] ?? null) ? strtolower($trigger['tag']) : '';
+        if (array() === $candidates) {
+            $candidates = $this->childPathElements($xpath, $root, $selector);
+        }
+        $filtered = $this->filterTriggerEvidence($candidates, $trigger);
+        if (array() !== $filtered) {
+            return $filtered;
+        }
+        $label = is_string($trigger['label'] ?? null) ? trim($trigger['label']) : '';
+        if ('' === $label) {
+            return array();
+        }
+        $labelLiteral = $this->xpathLiteral($label);
+        $evidence = $this->queryElements(
+            $xpath,
+            $scoped . '[(self::button or self::a or self::summary or translate(@role,"BUTTON","button")="button") and (normalize-space(@aria-label)=' . $labelLiteral . ' or normalize-space(.)=' . $labelLiteral . ')]',
+            $root
+        );
+        return $this->filterTriggerEvidence($evidence, $trigger);
+    }
+
+    private function scopedQuery(DOMDocument|DOMElement $root): string
+    {
+        return $root instanceof DOMDocument ? '//*' : './/*';
+    }
+
+    /** @return array<int, DOMElement> */
+    private function queryElements(DOMXPath $xpath, string $query, DOMDocument|DOMElement $root): array
+    {
+        $matches = $root instanceof DOMDocument ? $xpath->query($query) : $xpath->query($query, $root);
+        if (false === $matches || 0 === $matches->length || $matches->length > self::MAX_STATES_PER_PAGE) {
+            return array();
+        }
         $elements = array();
         foreach ($matches as $element) {
-            if (! $element instanceof DOMElement || ('' !== $tag && $tag !== strtolower($element->tagName))) continue;
-            $popup = strtolower(trim($element->getAttribute('aria-haspopup')));
-            if (! in_array($popup, array('dialog', 'true'), true)) continue;
-            $elements[] = $element;
+            if ($element instanceof DOMElement) {
+                $elements[] = $element;
+            }
         }
         return $elements;
+    }
+
+    /** @return array<int, DOMElement> */
+    private function childPathElements(DOMXPath $xpath, DOMDocument|DOMElement $root, string $selector): array
+    {
+        $relative = preg_replace('/^body\s*>\s*/i', '', $selector);
+        $query = $this->childPathQuery(is_string($relative) ? $relative : '');
+        if (null === $query) {
+            return array();
+        }
+        $prefix = $root instanceof DOMDocument ? '/' : './';
+        return $this->queryElements($xpath, $prefix . $query, $root);
+    }
+
+    private function childPathQuery(string $selector): ?string
+    {
+        $selector = trim($selector);
+        if ('' === $selector || 1 !== preg_match('/^[A-Za-z][A-Za-z0-9-]*(?::nth-of-type\([1-9][0-9]*\))?(?: > [A-Za-z][A-Za-z0-9-]*(?::nth-of-type\([1-9][0-9]*\))?)*$/', $selector)) {
+            return null;
+        }
+        $parts = array();
+        foreach (explode(' > ', $selector) as $part) {
+            if (1 !== preg_match('/^([A-Za-z][A-Za-z0-9-]*)(?::nth-of-type\(([1-9][0-9]*)\))?$/', $part, $match)) {
+                return null;
+            }
+            $parts[] = strtolower($match[1]) . (isset($match[2]) ? '[' . $match[2] . ']' : '');
+        }
+        return implode('/', $parts);
+    }
+
+    /**
+     * @param array<int, DOMElement> $elements
+     * @param array<string, mixed> $trigger
+     * @return array<int, DOMElement>
+     */
+    private function filterTriggerEvidence(array $elements, array $trigger): array
+    {
+        $tag = is_string($trigger['tag'] ?? null) ? strtolower($trigger['tag']) : '';
+        $label = is_string($trigger['label'] ?? null) ? trim($trigger['label']) : '';
+        $capturedPopup = strtolower(trim(is_string($trigger['ariaHaspopup'] ?? null) ? $trigger['ariaHaspopup'] : ''));
+        $filtered = array();
+        foreach ($elements as $element) {
+            if (! $this->compatibleTag($tag, strtolower($element->tagName), $element)) {
+                continue;
+            }
+            if ('' !== $capturedPopup) {
+                $popup = strtolower(trim($element->getAttribute('aria-haspopup')));
+                if (! in_array($popup, array('dialog', 'true'), true) || ! in_array($capturedPopup, array('dialog', 'true', $popup), true)) {
+                    continue;
+                }
+            }
+            if ('' !== $label && $label !== $this->accessibleName($element)) {
+                continue;
+            }
+            if (! $this->bindingsCompatible($element, $trigger)) {
+                continue;
+            }
+            $filtered[] = $element;
+        }
+        return $filtered;
+    }
+
+    /** @param array<string, mixed> $trigger */
+    private function bindingsCompatible(DOMElement $element, array $trigger): bool
+    {
+        $bindings = is_array($trigger['dataBindings'] ?? null) ? $trigger['dataBindings'] : array();
+        foreach ($bindings as $name => $value) {
+            if (! is_string($name) || ! is_string($value) || '' === $value) {
+                continue;
+            }
+            if (1 !== preg_match('/^data-[a-z0-9_.:-]+$/i', $name)) {
+                return false;
+            }
+            if (strtolower($element->getAttribute($name)) !== strtolower($value)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private function compatibleTag(string $captured, string $actual, DOMElement $element): bool
+    {
+        if ('' === $captured || $captured === $actual) {
+            return true;
+        }
+        $controls = array('button', 'summary', 'a');
+        if (in_array($captured, $controls, true) && in_array($actual, $controls, true)) {
+            return true;
+        }
+        return in_array($captured, $controls, true) && 'button' === strtolower($element->getAttribute('role'));
+    }
+
+    private function accessibleName(DOMElement $element): string
+    {
+        $aria = trim($element->getAttribute('aria-label'));
+        if ('' !== $aria) {
+            return $aria;
+        }
+        return trim((string) preg_replace('/\s+/u', ' ', $element->textContent ?? ''));
     }
 
     /** @return array{nodes:array<int, \DOMNode>, class:string, aria_label:string, aria_labelledby:string, aria_describedby:string, has_close_control:bool}|null */

--- a/php-transformer/tests/unit/captured-dialog-projector.php
+++ b/php-transformer/tests/unit/captured-dialog-projector.php
@@ -1,0 +1,163 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\CapturedDialogProjector;
+
+$failures = 0;
+$passes = 0;
+$assert = static function (bool $condition, string $message, string $detail = '') use (&$failures, &$passes): void {
+    if ($condition) {
+        ++$passes;
+        return;
+    }
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ('' !== $detail ? ' - ' . $detail : '') . PHP_EOL);
+};
+
+$dialogHtml = '<nav aria-label="Site"><ul><li><a href="/home">Home</a></li></ul></nav>';
+$dialog = array('html' => $dialogHtml, 'htmlBytes' => strlen($dialogHtml), 'htmlTruncated' => false);
+$menuTrigger = array(
+    'selector' => 'body > div > header > nav > div > button',
+    'tag' => 'button',
+    'ariaHaspopup' => '',
+    'label' => 'Menu',
+    'dataBindings' => array(),
+);
+
+$project = static function (array $files) {
+    return (new CapturedDialogProjector())->project($files);
+};
+
+$codes = static function (array $result): array {
+    return array_values(array_map(static fn(array $diagnostic): string => (string) ($diagnostic['code'] ?? ''), $result['diagnostics']));
+};
+
+$triggerIds = static function (string $html): array {
+    if (1 !== preg_match('/data-blocks-engine-triggers="([^"]+)"/', $html, $match)) {
+        return array();
+    }
+    return preg_split('/\s+/', trim($match[1])) ?: array();
+};
+
+$receipt = static function (array $routes): array {
+    return array('path' => 'capture-receipt.json', 'content' => json_encode(array(
+        'schema' => 'data-liberation/capture-receipt/v1',
+        'routes' => $routes,
+    ), JSON_UNESCAPED_SLASHES));
+};
+
+$states = static function (array $pages): array {
+    return array('path' => 'interaction-states.json', 'content' => json_encode(array(
+        'schema' => 'data-liberation/captured-interactions/v1',
+        'pages' => $pages,
+    ), JSON_UNESCAPED_SLASHES));
+};
+
+$page = static function (string $url, array $trigger) use ($dialog): array {
+    return array(
+        'sourceUrl' => $url,
+        'viewport' => array('width' => 390, 'height' => 844),
+        'states' => array(array('status' => 'captured', 'trigger' => $trigger, 'dialog' => $dialog)),
+    );
+};
+
+$responsiveHtml = '<html><body>'
+    . '<div class="data-liberation-desktop-document"><header><nav><details><summary id="desktop-menu" aria-label="Menu">Desktop</summary></details></nav></header></div>'
+    . '<div class="data-liberation-mobile-document"><header><nav><details><summary id="mobile-menu" aria-label="Menu">Mobile</summary></details></nav></header></div>'
+    . '</body></html>';
+
+$matched = $project(array(
+    array('path' => 'website/index.html', 'content' => $responsiveHtml),
+    $receipt(array(array('url' => 'https://example.test/', 'path' => 'website/index.html'))),
+    $states(array($page('https://example.test/', $menuTrigger))),
+));
+$again = $project(array(
+    array('path' => 'website/index.html', 'content' => $responsiveHtml),
+    $receipt(array(array('url' => 'https://example.test/', 'path' => 'website/index.html'))),
+    $states(array($page('https://example.test/', $menuTrigger))),
+));
+$assert(1 === ($matched['projected_count'] ?? null), 'responsive copies project one dialog');
+$assert(array() === $codes($matched), 'responsive copies emit no trigger diagnostics', implode(',', $codes($matched)));
+$assert(array('desktop-menu', 'mobile-menu') === $triggerIds((string) $matched['files'][0]['content']), 'each responsive document contributes one rewritten trigger', implode(' ', $triggerIds((string) $matched['files'][0]['content'])));
+$assert($matched === $again, 'responsive trigger matching is deterministic');
+
+$variantHtml = '<html><body>'
+    . '<div class="site-document-variant-default"><header><nav><button id="default-menu" aria-label="Menu">Desktop</button></nav></header></div>'
+    . '<div class="site-document-variant-mobile"><header><nav><button id="variant-menu" aria-label="Menu">Mobile</button></nav></header></div>'
+    . '</body></html>';
+$variant = $project(array(
+    array('path' => 'website/index.html', 'content' => $variantHtml),
+    $receipt(array(array('url' => 'https://example.test/', 'path' => 'website/index.html'))),
+    $states(array($page('https://example.test/', $menuTrigger))),
+));
+$assert(1 === ($variant['projected_count'] ?? null) && array('default-menu', 'variant-menu') === $triggerIds((string) $variant['files'][0]['content']), 'compiler variant wrappers each bind one trigger');
+
+$ambiguous = $project(array(
+    array('path' => 'website/index.html', 'content' => '<html><body><div class="data-liberation-mobile-document"><header><nav><button aria-label="Menu">One</button><button aria-label="Menu">Two</button></nav></header></div></body></html>'),
+    $receipt(array(array('url' => 'https://example.test/', 'path' => 'website/index.html'))),
+    $states(array($page('https://example.test/', $menuTrigger))),
+));
+$assert(0 === ($ambiguous['projected_count'] ?? null), 'two matching controls in one responsive document do not project');
+$assert(array('captured_dialog_trigger_ambiguous') === $codes($ambiguous), 'ambiguous matches fail closed', implode(',', $codes($ambiguous)));
+
+$missing = $project(array(
+    array('path' => 'website/index.html', 'content' => '<html><body><div class="data-liberation-mobile-document"><header><nav><button aria-label="Search">Search</button></nav></header></div></body></html>'),
+    $receipt(array(array('url' => 'https://example.test/', 'path' => 'website/index.html'))),
+    $states(array($page('https://example.test/', $menuTrigger))),
+));
+$assert(0 === ($missing['projected_count'] ?? null) && array('captured_dialog_trigger_unmatched') === $codes($missing), 'genuinely missing triggers stay unmatched');
+
+$bindingHtml = '<header><nav><a id="contact" role="button" aria-haspopup="dialog" data-popupid="contact">Contact</a></nav></header>';
+$bound = $project(array(
+    array('path' => 'website/index.html', 'content' => $bindingHtml),
+    $receipt(array(array('url' => 'https://example.test/', 'path' => 'website/index.html'))),
+    $states(array(array(
+        'sourceUrl' => 'https://example.test/',
+        'states' => array(array(
+            'status' => 'captured',
+            'trigger' => array('selector' => 'body > header > nav > a', 'tag' => 'a', 'ariaHaspopup' => 'dialog', 'dataBindings' => array('data-popupid' => 'contact')),
+            'dialog' => $dialog,
+        )),
+    ))),
+));
+$assert(1 === ($bound['projected_count'] ?? null) && array('contact') === $triggerIds((string) $bound['files'][0]['content']), 'declarative bindings still match exactly one trigger');
+
+$conflict = $project(array(
+    array('path' => 'website/index.html', 'content' => '<header><nav><a id="contact" role="button" aria-haspopup="dialog" data-popupid="other">Contact</a></nav></header>'),
+    $receipt(array(array('url' => 'https://example.test/', 'path' => 'website/index.html'))),
+    $states(array(array(
+        'sourceUrl' => 'https://example.test/',
+        'states' => array(array(
+            'status' => 'captured',
+            'trigger' => array('selector' => '#contact', 'tag' => 'a', 'ariaHaspopup' => 'dialog', 'label' => 'Contact', 'dataBindings' => array('data-popupid' => 'contact')),
+            'dialog' => $dialog,
+        )),
+    ))),
+));
+$assert(0 === ($conflict['projected_count'] ?? null) && array('captured_dialog_trigger_unmatched') === $codes($conflict), 'conflicting declarative bindings fail closed');
+
+$homeHtml = '<html><body><div class="data-liberation-mobile-document"><header><nav><summary id="home-menu" aria-label="Menu">Home</summary></nav></header></div></body></html>';
+$aboutHtml = '<html><body><div class="data-liberation-mobile-document"><header><nav><summary id="about-menu" aria-label="Menu">About</summary></nav></header></div></body></html>';
+$routed = $project(array(
+    array('path' => 'website/index.html', 'content' => $homeHtml),
+    array('path' => 'website/about/index.html', 'content' => $aboutHtml),
+    $receipt(array(
+        array('url' => 'https://example.test/', 'path' => 'website/index.html'),
+        array('url' => 'https://example.test/about', 'path' => 'website/about/index.html'),
+    )),
+    $states(array(
+        $page('https://example.test/', $menuTrigger),
+        $page('https://example.test/about', $menuTrigger),
+    )),
+));
+$assert(2 === ($routed['projected_count'] ?? null), 'each route binds its own captured menu');
+$assert(array('home-menu') === $triggerIds((string) $routed['files'][0]['content']), 'home route does not bind the about trigger');
+$assert(array('about-menu') === $triggerIds((string) $routed['files'][1]['content']), 'about route does not bind the home trigger');
+
+if ($failures > 0) {
+    fwrite(STDERR, "captured-dialog-projector failed ({$failures} failures, {$passes} passes)\n");
+    exit(1);
+}
+echo "OK: captured-dialog-projector passed ({$passes} assertions)\n";


### PR DESCRIPTION
Closes #1388.

## What

- Match captured dialog triggers inside bounded route documents and typed responsive-document wrappers.
- Keep ID, declarative data-binding, and bounded child-path selectors, then corroborate with tag, accessible name, popup metadata, and bindings after wrapper/control rewrites such as `button` → `summary`.
- Bind one captured state to one dialog, with one trigger per matching responsive document.
- Fail closed on ambiguous in-scope matches and genuinely missing triggers.

## Root cause

`CapturedDialogProjector` only queried `#id` or `data-popup|modal|dialog*` bindings and then required `aria-haspopup` in `{dialog, true}`. Captured mobile menu controls used positional selectors, empty popup metadata, and empty bindings. Compilation wraps equivalent desktop/mobile documents and rewrites the hamburger control, so all three route-scoped states stayed unmatched.

## Verification

- `php tests/unit/captured-dialog-projector.php` (13 assertions)
- `php tests/contract/run.php`
- `php tests/contract/staged-artifact-compilation.php`
- `composer --working-dir=php-transformer test:parity`
- `composer --working-dir=php-transformer test:packaging`
- Three-route recapture: baseline 3 `captured_dialog_trigger_unmatched` / 0 projected; fixed 0 trigger diagnostics / 3 projected, two responsive triggers per route

## AI assistance

- **Model:** OpenAI gpt-5.6-sol
- **Tool:** OpenCode general coding subagent
- **Used for:** Issue and prior-art investigation, root-cause analysis, implementation, regression tests, and verification. Chris Huber remains responsible for every line.