### PR TITLE
Extract figure element converter

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -162,6 +162,7 @@
             "php tests/unit/form-composition-planner.php",
             "php tests/unit/form-fallback-finding-builder.php",
             "php tests/unit/form-dispatcher.php",
+            "php tests/unit/figure-element-converter.php",
             "php tests/unit/form-runtime-requirement-analyzer.php",
             "php tests/unit/form-success-panel-metadata-builder.php",
             "php tests/unit/pseudo-form-analyzer.php",

--- a/php-transformer/src/HtmlToBlocks/Elements/FigureElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FigureElementContext.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Closure;
+use DOMElement;
+
+/** Explicit transformer collaborator surface for {@see FigureElementConverter}. */
+final class FigureElementContext
+{
+    /**
+     * @param Closure(DOMElement, array<int, array<string, mixed>>&): ?array<string, mixed> $mediaGalleryBlock
+     * @param Closure(DOMElement, array<int, array<string, mixed>>&, array<int, class-string>): ?array<string, mixed> $recognizePatterns
+     * @param Closure(DOMElement): ?DOMElement $linkedMediaAnchor
+     * @param Closure(DOMElement, string): ?DOMElement $firstChildElement
+     * @param Closure(DOMElement, ?DOMElement, ?DOMElement): ?array<string, mixed> $convertPicture
+     * @param Closure(DOMElement, ?DOMElement, ?DOMElement, ?DOMElement): ?array<string, mixed> $convertImage
+     * @param Closure(DOMElement, string): ?DOMElement $mediaElement
+     * @param Closure(DOMElement, array<int, array<string, mixed>>&): ?array<string, mixed> $convertGeneric
+     * @param Closure(DOMElement): string $innerHtml
+     * @param Closure(string): bool $hasVisibleText
+     * @param Closure(DOMElement): array<string, mixed> $presentationAttributes
+     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
+     */
+    public function __construct(
+        private readonly Closure $mediaGalleryBlock,
+        private readonly Closure $recognizePatterns,
+        private readonly Closure $linkedMediaAnchor,
+        private readonly Closure $firstChildElement,
+        private readonly Closure $convertPicture,
+        private readonly Closure $convertImage,
+        private readonly Closure $mediaElement,
+        private readonly Closure $convertGeneric,
+        private readonly Closure $innerHtml,
+        private readonly Closure $hasVisibleText,
+        private readonly Closure $presentationAttributes,
+        private readonly Closure $createBlock
+    ) {
+    }
+
+    /** @param array<int, array<string, mixed>> $fallbacks @return array<string, mixed>|null */
+    public function mediaGalleryBlock(DOMElement $element, array &$fallbacks): ?array
+    {
+        return ($this->mediaGalleryBlock)($element, $fallbacks);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @param array<int, class-string> $patterns
+     * @return array<string, mixed>|null
+     */
+    public function recognizePatterns(DOMElement $element, array &$fallbacks, array $patterns): ?array
+    {
+        return ($this->recognizePatterns)($element, $fallbacks, $patterns);
+    }
+
+    public function linkedMediaAnchor(DOMElement $figure): ?DOMElement
+    {
+        return ($this->linkedMediaAnchor)($figure);
+    }
+
+    public function firstChildElement(DOMElement $element, string $tagName): ?DOMElement
+    {
+        return ($this->firstChildElement)($element, $tagName);
+    }
+
+    /** @return array<string, mixed>|null */
+    public function convertPicture(DOMElement $picture, ?DOMElement $figure = null, ?DOMElement $link = null): ?array
+    {
+        return ($this->convertPicture)($picture, $figure, $link);
+    }
+
+    /** @return array<string, mixed>|null */
+    public function convertImage(DOMElement $image, ?DOMElement $figure = null, ?DOMElement $picture = null, ?DOMElement $link = null): ?array
+    {
+        return ($this->convertImage)($image, $figure, $picture, $link);
+    }
+
+    public function mediaElement(DOMElement $figure, string $tagName): ?DOMElement
+    {
+        return ($this->mediaElement)($figure, $tagName);
+    }
+
+    /** @param array<int, array<string, mixed>> $fallbacks @return array<string, mixed>|null */
+    public function convertGeneric(DOMElement $figure, array &$fallbacks): ?array
+    {
+        return ($this->convertGeneric)($figure, $fallbacks);
+    }
+
+    public function innerHtml(DOMElement $element): string
+    {
+        return ($this->innerHtml)($element);
+    }
+
+    public function hasVisibleText(string $html): bool
+    {
+        return ($this->hasVisibleText)($html);
+    }
+
+    /** @return array<string, mixed> */
+    public function presentationAttributes(DOMElement $element): array
+    {
+        return ($this->presentationAttributes)($element);
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     * @param array<int, array<string, mixed>> $innerBlocks
+     * @return array<string, mixed>
+     */
+    public function createBlock(string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array
+    {
+        return ($this->createBlock)($name, $attributes, $innerBlocks, $sourceElement);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Elements/FigureElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FigureElementConverter.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CodeWindowPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\FigureQuotePattern;
+use DOMElement;
+
+/** Converts figures and their captions through the ordered figure strategies. */
+final class FigureElementConverter
+{
+    public function __construct(private readonly FigureElementContext $context)
+    {
+    }
+
+    public function handles(string $tagName): bool
+    {
+        return 'figure' === $tagName || 'figcaption' === $tagName;
+    }
+
+    /** @param array<int, array<string, mixed>> $fallbacks */
+    public function convert(DOMElement $element, string $tagName, array &$fallbacks): ConversionOutcome
+    {
+        if ( ! $this->handles($tagName) ) {
+            return ConversionOutcome::unhandled();
+        }
+
+        if ( 'figcaption' === $tagName ) {
+            $content = $this->context->innerHtml($element);
+            if ( ! $this->context->hasVisibleText($content) ) {
+                return ConversionOutcome::handled(null);
+            }
+
+            return ConversionOutcome::handled($this->context->createBlock(
+                'core/paragraph',
+                array_merge($this->context->presentationAttributes($element), array( 'content' => $content )),
+                array(),
+                $element
+            ));
+        }
+
+        $gallery = $this->context->mediaGalleryBlock($element, $fallbacks);
+        if ( null !== $gallery ) {
+            return ConversionOutcome::handled($gallery);
+        }
+
+        $codeWindow = $this->context->recognizePatterns($element, $fallbacks, array( CodeWindowPattern::class ));
+        if ( null !== $codeWindow ) {
+            return ConversionOutcome::handled($codeWindow);
+        }
+
+        $linkedMedia = $this->context->linkedMediaAnchor($element);
+        if ( $linkedMedia instanceof DOMElement ) {
+            $linkedPicture = $this->context->firstChildElement($linkedMedia, 'picture');
+            if ( $linkedPicture instanceof DOMElement ) {
+                return ConversionOutcome::handled($this->context->convertPicture($linkedPicture, $element, $linkedMedia));
+            }
+
+            $linkedImage = $this->context->firstChildElement($linkedMedia, 'img');
+            if ( $linkedImage instanceof DOMElement ) {
+                return ConversionOutcome::handled($this->context->convertImage($linkedImage, $element, null, $linkedMedia));
+            }
+        }
+
+        $image = $this->context->mediaElement($element, 'img');
+        if ( $image instanceof DOMElement ) {
+            return ConversionOutcome::handled($this->context->convertImage($image, $element));
+        }
+
+        $picture = $this->context->mediaElement($element, 'picture');
+        if ( $picture instanceof DOMElement ) {
+            return ConversionOutcome::handled($this->context->convertPicture($picture, $element));
+        }
+
+        $blockquote = $this->context->firstChildElement($element, 'blockquote');
+        if ( $blockquote instanceof DOMElement ) {
+            return ConversionOutcome::handled($this->context->recognizePatterns($element, $fallbacks, array( FigureQuotePattern::class )));
+        }
+
+        return ConversionOutcome::handled($this->context->convertGeneric($element, $fallbacks));
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -40,6 +40,8 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormDispatchCon
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormDispatcher;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormFallbackFindingBuilder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormFallbackFindingContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FigureElementContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FigureElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormRuntimeRequirementAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormRuntimeIslandRecorder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormSuccessPanelMetadataBuilder;
@@ -300,6 +302,8 @@ final class HtmlTransformer
 
     private readonly TableElementConverter $tableConverter;
 
+    private readonly FigureElementConverter $figureConverter;
+
     private readonly UnsupportedElementRecorder $unsupportedRecorder;
 
     private readonly PatternContext $patternContext;
@@ -536,6 +540,26 @@ final class HtmlTransformer
         ));
         $this->buttonLinkDispatcher = new ButtonLinkDispatcher($this->createButtonLinkDispatchContext());
         $this->tableConverter = new TableElementConverter($this->createTableElementContext());
+        $this->figureConverter = new FigureElementConverter(new FigureElementContext(
+            function (DOMElement $element, array &$fallbacks): ?array {
+                return $this->mediaGalleryBlockFromElement($element, $fallbacks);
+            },
+            function (DOMElement $element, array &$fallbacks, array $patterns): ?array {
+                return $this->recognizePatterns($element, $fallbacks, $patterns);
+            },
+            fn (DOMElement $figure): ?DOMElement => $this->figureLinkedMediaAnchor($figure),
+            fn (DOMElement $element, string $tagName): ?DOMElement => $this->firstChildElement($element, $tagName),
+            fn (DOMElement $picture, ?DOMElement $figure = null, ?DOMElement $link = null): ?array => $this->convertPictureElement($picture, $figure, $link),
+            fn (DOMElement $image, ?DOMElement $figure = null, ?DOMElement $picture = null, ?DOMElement $link = null): ?array => $this->convertImageElement($image, $figure, $picture, $link),
+            fn (DOMElement $figure, string $tagName): ?DOMElement => $this->figureMediaElement($figure, $tagName),
+            function (DOMElement $figure, array &$fallbacks): ?array {
+                return $this->convertFigureGeneric($figure, $fallbacks);
+            },
+            fn (DOMElement $element): string => $this->innerHtml($element),
+            fn (string $html): bool => '' !== trim($this->runtime->stripAllTags($html)),
+            fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
+            fn (string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement)
+        ));
         $this->unsupportedRecorder = new UnsupportedElementRecorder($this->createUnsupportedElementContext(), $this->formControlMetadataBuilder);
     }
 
@@ -4076,8 +4100,9 @@ if ( $this->isInlineContentElement($tagName) ) {
             return $this->recognizePatterns($element, $fallbacks, array(QuotePattern::class));
         }
 
-        if ( 'figure' === $tagName || 'figcaption' === $tagName ) {
-            return $this->convertFigureElement($element, $fallbacks);
+        $figureDispatch = $this->figureConverter->convert($element, $tagName, $fallbacks);
+        if ( $figureDispatch->handled ) {
+            return $figureDispatch->block;
         }
 
         if ( 'noscript' === $tagName ) {

--- a/php-transformer/src/HtmlToBlocks/Support/ElementConversionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/ElementConversionTrait.php
@@ -9,7 +9,6 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CodeWindowPatte
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ColumnsPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CoverPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\DetailsPattern;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\FigureQuotePattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\LogoPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\MediaTextPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationPattern;
@@ -26,70 +25,6 @@ use DOMElement;
  */
 trait ElementConversionTrait
 {
-    /**
-     * Convert one figure or its caption: the media the figure carries, or the caption paragraph that accompanies it.
-     *
-     * @param array<int, array<string, mixed>> $fallbacks
-     * @return array<string, mixed>|null
-     */
-    private function convertFigureElement(DOMElement $element, array &$fallbacks): ?array
-    {
-        $tagName = strtolower($element->tagName);
-
-    if ( 'figure' === $tagName ) {
-        $gallery = $this->mediaGalleryBlockFromElement($element, $fallbacks);
-        if ( null !== $gallery ) {
-            return $gallery;
-        }
-
-        $codeWindow = $this->recognizePatterns($element, $fallbacks, array(CodeWindowPattern::class));
-        if ( null !== $codeWindow ) {
-            return $codeWindow;
-        }
-
-        $linkedMedia = $this->figureLinkedMediaAnchor($element);
-        if ( $linkedMedia instanceof DOMElement ) {
-            $linkedPicture = $this->firstChildElement($linkedMedia, 'picture');
-            if ( $linkedPicture instanceof DOMElement ) {
-                return $this->convertPictureElement($linkedPicture, $element, $linkedMedia);
-            }
-
-            $linkedImage = $this->firstChildElement($linkedMedia, 'img');
-            if ( $linkedImage instanceof DOMElement ) {
-                return $this->convertImageElement($linkedImage, $element, null, $linkedMedia);
-            }
-        }
-
-        $image = $this->figureMediaElement($element, 'img');
-        if ( $image instanceof DOMElement ) {
-            return $this->convertImageElement($image, $element);
-        }
-
-        $picture = $this->figureMediaElement($element, 'picture');
-        if ( $picture instanceof DOMElement ) {
-            return $this->convertPictureElement($picture, $element);
-        }
-
-        $blockquote = $this->firstChildElement($element, 'blockquote');
-        if ( $blockquote instanceof DOMElement ) {
-            return $this->recognizePatterns($element, $fallbacks, array(FigureQuotePattern::class));
-        }
-
-        return $this->convertFigureGeneric($element, $fallbacks);
-    }
-
-    if ( 'figcaption' === $tagName ) {
-        $content = $this->innerHtml($element);
-        if ( '' === trim($this->runtime->stripAllTags($content)) ) {
-            return null;
-        }
-
-        return $this->createBlock('core/paragraph', array_merge($this->styleResolver->presentationAttributes($element), array( 'content' => $content )), array(), $element);
-    }
-
-        return null;
-    }
-
     /**
      * Convert one list structure: ordered and unordered lists, description lists, and the terms and details they contain.
      *

--- a/php-transformer/tests/unit/figure-element-converter.php
+++ b/php-transformer/tests/unit/figure-element-converter.php
@@ -1,0 +1,138 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FigureElementContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FigureElementConverter;
+
+$assertions = 0;
+$failures = array();
+$assert = static function (bool $condition, string $label) use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']';
+    }
+};
+
+$elementFrom = static function (string $html): DOMElement {
+    $document = new DOMDocument();
+    $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+    $element = $document->getElementsByTagName('body')->item(0)?->firstElementChild;
+    if ( $element instanceof DOMElement ) {
+        return $element;
+    }
+    throw new RuntimeException('No element parsed');
+};
+
+$mode = 'generic';
+$calls = array();
+$context = new FigureElementContext(
+    static function (DOMElement $element, array &$fallbacks) use (&$mode, &$calls): ?array {
+        $calls[] = 'gallery';
+        return 'gallery' === $mode ? array( 'blockName' => 'core/gallery' ) : null;
+    },
+    static function (DOMElement $element, array &$fallbacks, array $patterns) use (&$mode, &$calls): ?array {
+        $pattern = basename(str_replace('\\', '/', $patterns[0]));
+        $calls[] = $pattern;
+        if ( 'code' === $mode && 'CodeWindowPattern' === $pattern ) {
+            return array( 'blockName' => 'core/code' );
+        }
+        if ( 'quote' === $mode && 'FigureQuotePattern' === $pattern ) {
+            return array( 'blockName' => 'core/quote' );
+        }
+        return null;
+    },
+    static function (DOMElement $figure) use (&$mode, &$calls): ?DOMElement {
+        $calls[] = 'linked';
+        return str_starts_with($mode, 'linked-') ? $figure->getElementsByTagName('a')->item(0) : null;
+    },
+    static function (DOMElement $element, string $tagName): ?DOMElement {
+        $child = $element->getElementsByTagName($tagName)->item(0);
+        return $child instanceof DOMElement ? $child : null;
+    },
+    static fn (DOMElement $picture, ?DOMElement $figure = null, ?DOMElement $link = null): array => array(
+        'blockName' => 'core/image',
+        'attrs' => array( 'source' => 'picture', 'linked' => $link instanceof DOMElement ),
+    ),
+    static fn (DOMElement $image, ?DOMElement $figure = null, ?DOMElement $picture = null, ?DOMElement $link = null): array => array(
+        'blockName' => 'core/image',
+        'attrs' => array( 'source' => 'image', 'linked' => $link instanceof DOMElement ),
+    ),
+    static function (DOMElement $figure, string $tagName) use (&$mode, &$calls): ?DOMElement {
+        $calls[] = 'media-' . $tagName;
+        if ( $mode !== $tagName ) {
+            return null;
+        }
+        $media = $figure->getElementsByTagName($tagName)->item(0);
+        return $media instanceof DOMElement ? $media : null;
+    },
+    static function (DOMElement $figure, array &$fallbacks) use (&$calls): array {
+        $calls[] = 'generic';
+        return array( 'blockName' => 'core/group' );
+    },
+    static fn (DOMElement $element): string => $element->ownerDocument?->saveHTML($element) ?: '',
+    static fn (string $html): bool => '' !== trim(strip_tags($html)),
+    static fn (DOMElement $element): array => array( 'className' => 'caption' ),
+    static fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => array(
+        'blockName' => $name,
+        'attrs' => $attributes,
+        'innerBlocks' => $innerBlocks,
+        'sourceTag' => $sourceElement?->tagName,
+    )
+);
+$converter = new FigureElementConverter($context);
+
+$assert($converter->handles('figure') && $converter->handles('figcaption'), 'handles-figure-family');
+$assert(! $converter->handles('div'), 'declines-other-tags');
+$fallbacks = array();
+$unhandled = $converter->convert($elementFrom('<div></div>'), 'div', $fallbacks);
+$assert(! $unhandled->handled && null === $unhandled->block, 'unhandled-outcome');
+
+$mode = 'gallery';
+$result = $converter->convert($elementFrom('<figure></figure>'), 'figure', $fallbacks);
+$assert('core/gallery' === ($result->block['blockName'] ?? ''), 'gallery-wins');
+
+$mode = 'code';
+$result = $converter->convert($elementFrom('<figure></figure>'), 'figure', $fallbacks);
+$assert('core/code' === ($result->block['blockName'] ?? ''), 'code-window-follows-gallery');
+
+$mode = 'linked-picture';
+$result = $converter->convert($elementFrom('<figure><a><picture><img></picture></a></figure>'), 'figure', $fallbacks);
+$assert('picture' === ($result->block['attrs']['source'] ?? '') && true === ($result->block['attrs']['linked'] ?? false), 'linked-picture');
+
+$mode = 'linked-image';
+$result = $converter->convert($elementFrom('<figure><a><img></a></figure>'), 'figure', $fallbacks);
+$assert('image' === ($result->block['attrs']['source'] ?? '') && true === ($result->block['attrs']['linked'] ?? false), 'linked-image');
+
+$mode = 'img';
+$result = $converter->convert($elementFrom('<figure><img></figure>'), 'figure', $fallbacks);
+$assert('image' === ($result->block['attrs']['source'] ?? '') && false === ($result->block['attrs']['linked'] ?? true), 'direct-image');
+
+$mode = 'picture';
+$result = $converter->convert($elementFrom('<figure><picture><img></picture></figure>'), 'figure', $fallbacks);
+$assert('picture' === ($result->block['attrs']['source'] ?? '') && false === ($result->block['attrs']['linked'] ?? true), 'direct-picture');
+
+$mode = 'quote';
+$result = $converter->convert($elementFrom('<figure><blockquote>Words</blockquote></figure>'), 'figure', $fallbacks);
+$assert('core/quote' === ($result->block['blockName'] ?? ''), 'figure-quote');
+
+$mode = 'generic';
+$result = $converter->convert($elementFrom('<figure><video></video></figure>'), 'figure', $fallbacks);
+$assert('core/group' === ($result->block['blockName'] ?? ''), 'generic-figure-fallback');
+
+$emptyCaption = $converter->convert($elementFrom('<figcaption><span></span></figcaption>'), 'figcaption', $fallbacks);
+$assert($emptyCaption->handled && null === $emptyCaption->block, 'empty-caption-handled-without-block');
+
+$caption = $converter->convert($elementFrom('<figcaption>Caption <em>text</em></figcaption>'), 'figcaption', $fallbacks);
+$assert('core/paragraph' === ($caption->block['blockName'] ?? ''), 'caption-paragraph');
+$assert('caption' === ($caption->block['attrs']['className'] ?? ''), 'caption-presentation');
+$assert(str_contains((string) ($caption->block['attrs']['content'] ?? ''), '<em>text</em>'), 'caption-html');
+$assert('figcaption' === ($caption->block['sourceTag'] ?? ''), 'caption-source');
+
+if ( $failures ) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Figure element converter tests: ' . $assertions . " passed\n";


### PR DESCRIPTION
## Summary
- extract figure and figcaption routing into `FigureElementConverter`
- expose transformer-owned media and pattern operations through `FigureElementContext`
- use `ConversionOutcome` to distinguish unhandled tags from handled figures that intentionally produce no block
- preserve gallery, code-window, linked media, direct media, quote, generic figure, and caption ordering
- reduce `ElementConversionTrait` from 606 to 541 lines
- add a 16-assertion direct converter contract

## Verification
- `composer validate --strict`
- `composer test`
- PHP transformer parity: 289 fixtures
- distribution shape: 208 files, 10 monorepo-only trees excluded
- exact-base CSS-attached corpus comparison: byte-identical records for 383 documents / 87 fixtures / 82 fixtures with CSS / 0 throws

Part of #242.

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to identify and extract the first `ElementConversionTrait` family, implement its direct ordered-routing contract, and run package and exact-base corpus verification.