### PR TITLE
Handle min-content widths from mixed button selectors

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2617,6 +2617,10 @@ final class HtmlTransformer
         if ( '' === $wrapperPrelude ) {
             $directWrapperPrelude = $this->directButtonGeometryWrapperPrelude($prelude);
             if ( '' === $directWrapperPrelude ) {
+                $mixedButtonProjection = $this->withoutCollapsedButtonProjectedWidths($projectedPrelude, $body);
+                if ( null !== $mixedButtonProjection ) {
+                    return $mixedButtonProjection;
+                }
                 return $projectedPrelude . '{' . $body . '}';
             }
             [ $geometry, $inner ] = $this->splitDirectButtonGeometryDeclarations($body);
@@ -2635,6 +2639,50 @@ final class HtmlTransformer
         }
 
         return $this->withButtonWrapperInnerFill($wrapperPrelude, $layout, $projectedPrelude . '{' . $control . '}');
+    }
+
+    private function withoutCollapsedButtonProjectedWidths(string $prelude, string $body): ?string
+    {
+        $selectors = CssStylesheetTransformer::splitSelectorList($prelude);
+        if ( null === $selectors ) {
+            return null;
+        }
+
+        $buttonSelectors = array();
+        $otherSelectors = array();
+        foreach ( $selectors as $selector ) {
+            if ( str_contains($selector, '> :where(.wp-block-button__link)') ) {
+                $buttonSelectors[] = $selector;
+            } else {
+                $otherSelectors[] = $selector;
+            }
+        }
+        if ( array() === $buttonSelectors ) {
+            return null;
+        }
+
+        $safe = array();
+        $collapsed = array();
+        foreach ( CssValueSplitter::splitTopLevel($body, array( ';' )) as $declaration ) {
+            $colon = strpos($declaration, ':');
+            $name = strtolower(trim(false === $colon ? $declaration : substr($declaration, 0, $colon)));
+            $value = false === $colon ? '' : trim(substr($declaration, $colon + 1));
+            if ( false !== $colon && $this->isCollapsedButtonKeywordWidth($name, $value) ) {
+                $collapsed[] = $declaration;
+            } else {
+                $safe[] = $declaration;
+            }
+        }
+        if ( array() === $collapsed ) {
+            return null;
+        }
+
+        $css = array() === $safe ? '' : $prelude . '{' . implode(';', $safe) . '}';
+        if ( array() !== $otherSelectors ) {
+            $css .= implode(',', $otherSelectors) . '{' . implode(';', $collapsed) . '}';
+        }
+
+        return $css;
     }
 
     private function buttonPresentationWrapperPrelude(string $prelude): string

--- a/php-transformer/tests/unit/button-link-min-content.php
+++ b/php-transformer/tests/unit/button-link-min-content.php
@@ -96,6 +96,27 @@ $assert(
     $presetCss
 );
 
+$mixed = ( new HtmlTransformer() )->transform(
+    '<style>.button{display:flex;min-width:var(--btn-min-width);--btn-min-width:min-content;padding:8px 16px;background:#111;color:#fff}.button{min-width:min-content!important}</style>'
+    . '<main><div class="button">Decorative box</div><a class="button" href="/book">Book Now</a></main>'
+)->toArray();
+$mixedCss = $cssOf($mixed);
+$mixedMarkup = (string) ( $mixed['serialized_blocks'] ?? '' );
+
+$assert(str_contains($mixedMarkup, 'wp:button') && str_contains($mixedMarkup, 'Book Now'), '10: mixed source selector still converts its CTA', $mixedMarkup);
+$assert(
+    ! preg_match('/wp-block-button__link[^{}]*\{[^}]*min-width:min-content/i', $mixedCss)
+        && ! preg_match('/wp-block-button__link[^{}]*\{[^}]*--btn-min-width:min-content/i', $mixedCss),
+    '11: mixed source selector cannot project collapsing widths onto the button link',
+    $mixedCss
+);
+$assert(
+    str_contains($mixedCss, 'min-width:min-content!important')
+        && str_contains($mixedCss, '--btn-min-width:min-content'),
+    '12: mixed source selector keeps intrinsic widths on non-button matches',
+    $mixedCss
+);
+
 if ( $failures > 0 ) {
     fwrite(STDERR, PHP_EOL . "button link min-content tests: {$passes} passed, {$failures} FAILED" . PHP_EOL);
     exit(1);


### PR DESCRIPTION
Closes #1386.

Follow-up to #1402. The full 360chiro acceptance compile exposed a selector shape not represented by the original tests: a source `.button` rule can match both CTA controls and non-control nodes. That mixed match bypassed the all-button projection path and retained `min-width:min-content!important` on generated `.wp-block-button__link` elements, leaving 18 visible CTAs at roughly 6-8px wide.

## Summary

- split collapsing intrinsic-width declarations from mixed projected rules
- omit those declarations only from generated button-link selectors
- preserve the same declarations for non-button source matches
- cover direct and custom-property `min-content` widths in a mixed selector fixture

## Verification

- `composer test`
- 289 parity fixtures
- button min-content tests: 12 passed
- button wrapper keyword-width tests: 4 passed
- browser root-cause evidence from the 16-page 360chiro materialization

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode ran the full artifact acceptance compile, used Playwright and Chrome DevTools matched-style evidence to isolate the mixed-selector gap, implemented the scoped projection fix, and ran the complete transformer suite. Chris Huber reviewed the diff and is responsible for the submitted change.