### PR TITLE
Discard inert data DOM stores under conditional CSS

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -12284,10 +12284,13 @@ if ( 'svg' === $tagName ) {
 
     private function isInertHiddenSvgStorage(DOMElement $element): bool
     {
+        $isDomStore = $element->hasAttribute('data-dom-store');
         if ( ! $this->sourceElementStartsHidden($element)
-            || $this->styleResolver->hasConditionalStyleFamily($element, 'layout')
-            || $this->styleResolver->hasConditionalStyleFamily($element, 'visibility')
-            || $this->styleResolver->hasConditionalStyleFamily($element, 'opacity')
+            || (! $isDomStore && (
+                $this->styleResolver->hasConditionalStyleFamily($element, 'layout')
+                || $this->styleResolver->hasConditionalStyleFamily($element, 'visibility')
+                || $this->styleResolver->hasConditionalStyleFamily($element, 'opacity')
+            ))
             || '' !== trim($this->attr($element, 'aria-label'))
             || '' !== trim($this->attr($element, 'aria-labelledby'))
             || '' !== trim($this->attr($element, 'title'))

--- a/php-transformer/tests/unit/inert-capture-scaffolding.php
+++ b/php-transformer/tests/unit/inert-capture-scaffolding.php
@@ -29,6 +29,17 @@ $assert(str_contains((string) ($referencedStore['serialized_blocks'] ?? ''), 'id
 $materializedSvg = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), array_filter($referencedStore['assets'] ?? array(), static fn (array $asset): bool => 'inline-svg' === ($asset['source'] ?? ''))));
 $assert(str_contains($materializedSvg, 'id="mark"') && str_contains($materializedSvg, 'href="#mark"'), 'referenced SVG symbols remain available to materialized images');
 
+$conditionalStyles = '<style>@media (max-width:600px){svg{display:block}}</style>';
+$conditionalStore = $transform($conditionalStyles . '<main><svg data-dom-store style="display:none"><defs id="conditional-unused"></defs></svg><p>Visible copy</p></main>');
+$assert(! str_contains((string) ($conditionalStore['serialized_blocks'] ?? ''), 'conditional-unused'), 'unreferenced data DOM store stays inert under conditional SVG styles');
+
+$conditionalReferencedStore = $transform($conditionalStyles . '<main><svg data-dom-store style="display:none"><defs><symbol id="conditional-mark"><path d="M0 0h1v1z"/></symbol></defs></svg><svg viewBox="0 0 1 1"><use href="#conditional-mark"/></svg></main>');
+$assert(str_contains((string) ($conditionalReferencedStore['serialized_blocks'] ?? ''), 'conditional-mark'), 'referenced data DOM store survives conditional SVG styles');
+
+$conditionalOrdinaryStore = $transform($conditionalStyles . '<main><svg style="display:none"><defs><symbol id="ordinary-store"><path d="M0 0h1v1z"/></symbol></defs></svg><p>Visible copy</p></main>');
+$conditionalOrdinarySvg = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), array_filter($conditionalOrdinaryStore['assets'] ?? array(), static fn (array $asset): bool => 'inline-svg' === ($asset['source'] ?? ''))));
+$assert(str_contains((string) ($conditionalOrdinaryStore['serialized_blocks'] ?? ''), 'assets/materialized-svg/') && str_contains($conditionalOrdinarySvg, 'ordinary-store'), 'ordinary hidden SVG retains conditional visibility safeguards');
+
 $capturedCollection = $transform('<main><fluid-columns-repeater><div><svg viewBox="0 0 1 1"><defs><link rel="stylesheet" href="/assets/icon.css"></defs><path d="M0 0h1v1z"/></svg><p>One</p></div><div><p>Two</p></div></fluid-columns-repeater></main>');
 $generatedRender = implode("\n", array_map(static fn (array $block): string => (string) ($block['render'] ?? ''), $capturedCollection['source_reports']['generated_blocks'] ?? array()));
 $assert('' !== $generatedRender && ! str_contains($generatedRender, '<link'), 'generated custom blocks strip captured stylesheet links from nested SVG markup');


### PR DESCRIPTION
## Summary

- treat explicitly marked, unreferenced `data-dom-store` definition SVGs as inert even when unrelated conditional SVG styles exist
- preserve referenced stores and ordinary hidden SVG conditional-state safeguards
- cover all three paths in the inert capture scaffolding contract

Closes #1329.

## Verification

- `composer validate --strict`
- `composer test`
- 289 parity fixtures pass
- inert capture scaffolding: 16 assertions pass

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the conditional-CSS retention defect, implemented the bounded storage predicate change, added regression coverage, and ran the verification suite. Chris Huber directed the work and remains responsible for it.