### PR TITLE
Fix shared shell materialized SVG assets

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -4165,9 +4165,7 @@ final class ArtifactCompiler
                     'placement' => array('kind' => 'inline_shared_shell', 'source_path' => 'wordpress-site-plan/shared/' . $slug, 'source_paths' => array_keys($documents), 'variant' => $variant + 1),
                 ));
                 foreach ($compiled['assets'] as $asset) {
-                    // Binary assets are already materialized by the full page
-                    // compilation. Only shell-specific support CSS is new here.
-                    if (!is_array($asset) || 'css' !== ($asset['kind'] ?? null)) continue;
+                    if (!is_array($asset)) continue;
                     $asset['compilation'] = array('scope' => 'shared');
                     $assets[] = $asset;
                 }

--- a/php-transformer/tests/contract/shared-shell-plan.php
+++ b/php-transformer/tests/contract/shared-shell-plan.php
@@ -109,6 +109,15 @@ $sourceDivergentResult = (new ArtifactCompiler())->compile(array('entrypoint' =>
 $sourceDivergentArtifacts = $sourceDivergentResult['source_reports']['compiled_site']['inline_shell_artifacts'] ?? array();
 $assert(!array_filter($sourceDivergentArtifacts, static fn(array $artifact): bool => 'header' === ($artifact['area'] ?? null)) && 2 === count(array_filter($sourceDivergentArtifacts, static fn(array $artifact): bool => 'footer' === ($artifact['area'] ?? null))), 'A divergent source variant rejects the complete area bundle while an independently shared area remains canonical.');
 
+$styledSvg = '<svg viewBox="0 0 16 16"><path fill="#123456" d="M1 1h14v14H1z"/></svg>';
+$styledSvgDocument = static fn(string $title): string => '<style>.logo svg{width:100%;height:100%}</style><div class="desktop-document"><header class="desktop-header"><div class="logo">' . $styledSvg . '</div></header><main><h1>' . $title . '</h1></main></div><div class="mobile-document"><header class="mobile-header"><div class="logo">' . $styledSvg . '</div></header><main><h1>' . $title . ' mobile</h1></main></div>';
+$styledSvgResult = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => $styledSvgDocument('Home'), 'about.html' => $styledSvgDocument('About'))))->toArray();
+$styledSvgCompiled = $styledSvgResult['source_reports']['compiled_site'] ?? array();
+$styledSvgAssetPaths = array_column(array_filter($styledSvgCompiled['assets'] ?? array(), static fn(array $asset): bool => 'inline-svg' === ($asset['source'] ?? null)), 'path');
+$styledSvgShellPaths = array();
+foreach ($styledSvgCompiled['inline_shell_artifacts'] ?? array() as $artifact) if (preg_match_all('@assets/materialized-svg/[^" ]+@', $artifact['block_markup'] ?? '', $matches)) $styledSvgShellPaths = array_merge($styledSvgShellPaths, $matches[0]);
+$assert('failed' !== ($styledSvgResult['status'] ?? null) && 2 === count($styledSvgAssetPaths) && array() === array_diff($styledSvgShellPaths, $styledSvgAssetPaths), 'Shared shell compilation declares its CSS-context-specific materialized SVG asset instead of leaving an unresolved local browser reference.');
+
 $responsiveDivergentResult = $responsiveResult;
 foreach ($responsiveDivergentResult['source_reports']['compiled_site']['pages'] as &$responsivePage) $responsivePage['block_markup'] = $responsiveMarkup('index.html' === $responsivePage['source_path'] ? 'Home' : 'About', 'about.html' === $responsivePage['source_path'] ? 'Different mobile header' : 'Mobile header'); unset($responsivePage);
 $responsiveDivergent = (new WordPressSitePlan())->fromResult($responsiveDivergentResult);


### PR DESCRIPTION
Fixes #1408.

## What changed

- Retain every asset generated while compiling canonical shared shells, rather than retaining only CSS.
- Add a regression where authored SVG CSS gives isolated shell compilation a different content-addressed SVG than full-page compilation.

## Root cause

The issue initially appeared to be a tokenization gap, but the isolated shell compiler was emitting markup for its own materialized SVG while deliberately discarding that non-CSS asset. Full-page compilation produced a different SVG hash because generated state classes differ by compilation context, so canonicalization correctly could not tokenize the undeclared shell-only path.

## Verification

- `composer test:canonical`
- `composer test:parity` (289 fixtures)
- `composer test:packaging`
- Recompiled the original four-route DLA artifact: `success_with_warnings`, 4 documents, no `wordpress_site_plan_invalid_declaration`.

## AI assistance

OpenAI gpt-5.6-sol via OpenCode traced the compiler asset lifecycle, reduced the real artifact failure to a contract fixture, implemented the fix, and ran verification. Chris Huber orchestrated and reviewed the work.