### PR TITLE
Discard inert media placeholders without fallbacks

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Elements/SvgElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/SvgElementConverter.php
@@ -42,6 +42,10 @@ final class SvgElementConverter
             }
         }
 
+        if ( $this->isSafeEmptyMediaPlaceholder($element) ) {
+            return ConversionOutcome::handled(null);
+        }
+
         if ( $this->materializer->isSafeDecorativeSvgElement($element) ) {
             $isDecorativeChrome = $this->context->isVisualLayerElement($element);
             if ( ! $isDecorativeChrome && $this->context->hasDrawableContent($element) ) {
@@ -69,6 +73,32 @@ final class SvgElementConverter
 
         $this->context->captureFallback($element, $fallbacks);
         return ConversionOutcome::handled(null);
+    }
+
+    private function isSafeEmptyMediaPlaceholder(DOMElement $element): bool
+    {
+        if ( $element->hasChildNodes() ) {
+            return false;
+        }
+
+        foreach ( $element->attributes as $attribute ) {
+            if ( str_starts_with(strtolower($attribute->name), 'on') || preg_match('/javascript\s*:/i', $attribute->value) ) {
+                return false;
+            }
+        }
+
+        $parent = $element->parentNode;
+        if ( ! $parent instanceof DOMElement ) {
+            return false;
+        }
+
+        foreach ( array( 'img', 'picture', 'video' ) as $mediaTag ) {
+            if ( 0 < $parent->getElementsByTagName($mediaTag)->length ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /** @return array<string, mixed>|null */

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -4429,6 +4429,10 @@ if ( 'svg' === $tagName ) {
             return $transparentCustomElement;
         }
 
+        if ( $this->isInertRuntimeMediaPlaceholder($element) ) {
+            return null;
+        }
+
         if ( $captureUnsupported ) {
             return $this->unsupportedRecorder->record($element, $tagName, $fallbacks);
         }
@@ -4514,6 +4518,44 @@ if ( 'svg' === $tagName ) {
     {
         if ( $this->runtimeIslands->isRuntimeDomTarget($element) || array() !== $this->eventMetadata($element) || $this->hasMotionStructureToken($element) ) {
             return false;
+        }
+
+        return true;
+    }
+
+    private function isInertRuntimeMediaPlaceholder(DOMElement $element): bool
+    {
+        if ( ! $this->isRuntimeMediaSurfaceElement($element)
+            || ! str_contains(strtolower($element->tagName), '-')
+            || '' !== trim($element->textContent ?? '')
+        ) {
+            return false;
+        }
+
+        foreach ( array_merge(array( $element ), iterator_to_array($element->getElementsByTagName('*'))) as $candidate ) {
+            if ( ! $candidate instanceof DOMElement
+                || ! $this->isSafeTransparentCustomElement($candidate)
+                || '' !== trim($this->attr($candidate, 'role'))
+                || '' !== trim($this->attr($candidate, 'aria-label'))
+            ) {
+                return false;
+            }
+
+            foreach ( array( 'src', 'srcset', 'href', 'data-src', 'data-url' ) as $attribute ) {
+                if ( '' !== trim($this->attr($candidate, $attribute)) ) {
+                    return false;
+                }
+            }
+
+            foreach ( $candidate->attributes as $attribute ) {
+                if ( str_starts_with(strtolower($attribute->name), 'data-') && '' !== trim($attribute->value) ) {
+                    return false;
+                }
+            }
+
+            if ( $candidate !== $element && ! $this->isStructuralTransparentCustomWrapperChild($candidate) ) {
+                return false;
+            }
         }
 
         return true;

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -2716,6 +2716,14 @@ $assertNormalizedFallbackDiagnostic($diagnosticsByCode['html_iframe_embed_fallba
 $assert(! isset($diagnosticsByCode['html_inline_svg_fallback']), 'safe inline SVGs convert to inline core/html blocks instead of fallback diagnostics');
 $assert(! isset($diagnosticsByCode['html_canvas_runtime_fallback']), 'non-runtime canvas does not emit runtime canvas fallback diagnostics');
 
+$emptySvgPlaceholder = ( new HtmlTransformer() )->transform(
+    '<main><div role="button" aria-label="Open gallery image"><svg class="zoom-mask" viewBox="0 0 10000 10000"></svg><img src="portrait.jpg" alt="Portrait"></div></main>'
+)->toArray();
+$assert(array() === ($emptySvgPlaceholder['fallbacks'] ?? array()), 'a structurally empty SVG placeholder does not emit fallback metadata');
+$assert(str_contains((string) ($emptySvgPlaceholder['serialized_blocks'] ?? ''), 'portrait.jpg'), 'discarding an empty SVG placeholder preserves its independent image sibling');
+$unsafeEmptySvg = ( new HtmlTransformer() )->transform('<main><svg onload="alert(1)"></svg></main>')->toArray();
+$assert('html_unsafe_inline_svg' === ($unsafeEmptySvg['fallbacks'][0]['diagnostic_code'] ?? ''), 'an unsafe empty SVG retains its fallback diagnostic');
+
 $coffeeFixturePath = dirname(__DIR__, 3) . '/fixtures/websites/2-onepager-coffee/index.html';
 $coffeeFixtureHtml = (string) file_get_contents($coffeeFixturePath);
 $coffeeResult = ( new HtmlTransformer() )->transform($coffeeFixtureHtml)->toArray();
@@ -2768,6 +2776,12 @@ $assert(str_contains($unknownSerialized, 'Playground'), 'ancestor content around
 $assert(str_contains($unknownSerialized, 'Before embed.'), 'ancestor content before unknown iframe still converts');
 $assert(str_contains($unknownSerialized, 'After embed.'), 'ancestor content after unknown iframe still converts');
 $assert('pass' === ($unknownIframe['source_reports']['wp_block_validity']['status'] ?? ''), 'bounded iframe companion save shape is Gutenberg-valid');
+
+$responsiveIframeWrapper = ( new HtmlTransformer() )->transform(
+    '<main><wix-iframe data-src=""><div class="map-container"><iframe title="Map" src="https://example.test/map" width="1280" height="350"></iframe></div></wix-iframe><wix-iframe data-src=""><div class="map-container"></div></wix-iframe></main>'
+)->toArray();
+$assert(array() === ($responsiveIframeWrapper['fallbacks'] ?? array()), 'an inactive custom media placeholder does not emit an unsupported-element fallback');
+$assert(1 === substr_count((string) ($responsiveIframeWrapper['serialized_blocks'] ?? ''), '<iframe'), 'the active custom media variant still lowers through bounded iframe conversion');
 
 $visualIframeGeometry = ( new HtmlTransformer() )->transform(
     '<main><div style="width:1280px;height:350px;margin:0 80px 10px"><iframe title="Map surface" src="https://example.test/map" width="100%" height="100%"></iframe></div><p>Following content</p></main>'


### PR DESCRIPTION
## Summary

- omit safe empty SVG placeholders when their parent already contains real image or video media
- omit inactive custom media wrappers that expose no runtime API, semantic content, URL, or media child
- retain unsafe SVG diagnostics and active bounded iframe conversion

## Why

Responsive Wix captures can include an empty SVG before an already-materialized gallery image and an empty custom iframe branch beside the active iframe branch. These inert nodes were reported as unsupported fallbacks despite carrying no independent visual or runtime content.

## Verification

- `composer test`
- 289 PHP transformer parity fixtures
- package install proof
- exact affected gallery fragment: zero fallbacks, image retained, zero empty SVG assets
- exact affected contact fragment: zero fallbacks, one active iframe retained
- `composer validate --strict`
- `git diff --check`

## AI assistance

OpenAI gpt-5.6-sol via OpenCode was used to inspect the captured DOM and transformer routing, implement the bounded predicates and regression coverage, and run the verification suite. The changes and evidence were reviewed before publication.