### PR TITLE
Fix authored carousel projection

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -71,6 +71,7 @@
       "php tests/unit/srcset-parser.php",
        "php tests/unit/responsive-media-block.php",
        "php tests/unit/visual-iframe-block.php",
+       "php tests/unit/authored-carousel-block.php",
        "php tests/unit/authored-marquee-block.php",
        "php tests/unit/responsive-document-variants.php",
        "php tests/unit/captured-dialog-projector.php",

--- a/php-transformer/src/HtmlToBlocks/Generators/AuthoredCarouselBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/Generators/AuthoredCarouselBlockGenerator.php
@@ -1,0 +1,127 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators;
+
+/** Builds an editable companion block for bounded authored carousels. */
+final class AuthoredCarouselBlockGenerator
+{
+    public const LOCAL_NAME = 'authored-carousel';
+
+    /** @return array<string, mixed> */
+    public function definition(string $namespace): array
+    {
+        $blockName = $namespace . '/' . self::LOCAL_NAME;
+        $attributes = array(
+            'ariaLabel' => array('type' => 'string', 'default' => 'Carousel'),
+            'itemsPerView' => array('type' => 'number', 'default' => 4),
+            'wrap' => array('type' => 'boolean', 'default' => true),
+        );
+        $editor = <<<'JS'
+( function( blocks, blockEditor, element ) {
+    var createElement = element.createElement;
+    var InnerBlocks = blockEditor.InnerBlocks;
+    function normalizedItems( value ) { value = Math.round( Number( value ) || 4 ); return Math.min( 6, Math.max( 1, value ) ); }
+    function rootProps( attributes ) {
+        var items = normalizedItems( attributes.itemsPerView );
+        return { className: 'blocks-engine-authored-carousel blocks-engine-authored-carousel--items-' + items, role: 'region', 'aria-label': attributes.ariaLabel || 'Carousel', 'aria-roledescription': 'carousel', 'data-wrap': false === attributes.wrap ? 'false' : 'true' };
+    }
+    blocks.registerBlockType( '__BLOCK_NAME__', {
+        attributes: __ATTRIBUTES__,
+        supports: { html: false, customClassName: false },
+        edit: function( props ) {
+            return createElement( 'div', { className: 'blocks-engine-authored-carousel-editor' }, createElement( 'strong', null, props.attributes.ariaLabel || 'Carousel' ), createElement( InnerBlocks, { allowedBlocks: [ 'core/image', 'core/group' ], renderAppender: InnerBlocks.ButtonBlockAppender } ) );
+        },
+        save: function( props ) {
+            return createElement( 'div', rootProps( props.attributes ),
+                createElement( 'button', { type: 'button', className: 'blocks-engine-authored-carousel__previous', 'data-carousel-previous': 'true' }, 'Previous' ),
+                createElement( 'div', { className: 'blocks-engine-authored-carousel__viewport', tabIndex: 0 }, createElement( 'div', { className: 'blocks-engine-authored-carousel__track' }, createElement( InnerBlocks.Content ) ) ),
+                createElement( 'button', { type: 'button', className: 'blocks-engine-authored-carousel__next', 'data-carousel-next': 'true' }, 'Next' ),
+                createElement( 'span', { className: 'blocks-engine-authored-carousel__status', 'aria-live': 'polite', 'aria-atomic': 'true' } )
+            );
+        }
+    } );
+} )( window.wp.blocks, window.wp.blockEditor, window.wp.element );
+JS;
+        $view = <<<'JS'
+( function() {
+    function mount( root ) {
+        if ( root.dataset.carouselMounted ) return;
+        var viewport = root.querySelector( '.blocks-engine-authored-carousel__viewport' );
+        var track = root.querySelector( '.blocks-engine-authored-carousel__track' );
+        var previous = root.querySelector( '[data-carousel-previous]' );
+        var next = root.querySelector( '[data-carousel-next]' );
+        var status = root.querySelector( '.blocks-engine-authored-carousel__status' );
+        if ( ! viewport || ! track || ! previous || ! next ) return;
+        var slides = Array.prototype.slice.call( track.children );
+        if ( slides.length < 2 ) return;
+        var index = 0;
+        var wraps = 'false' !== root.dataset.wrap;
+        var reducedMotion = window.matchMedia && window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
+        function visibleItems() {
+            var width = slides[ 0 ].getBoundingClientRect().width;
+            return width > 0 ? Math.max( 1, Math.min( slides.length, Math.round( viewport.clientWidth / width ) ) ) : 1;
+        }
+        function maximumIndex() { return Math.max( 0, slides.length - visibleItems() ); }
+        function update() {
+            var maximum = maximumIndex();
+            index = Math.min( index, maximum );
+            previous.disabled = 0 === maximum || ( ! wraps && 0 === index );
+            next.disabled = 0 === maximum || ( ! wraps && index === maximum );
+            if ( status ) status.textContent = 'Slide ' + ( index + 1 ) + ' of ' + slides.length;
+        }
+        function show( requested ) {
+            var maximum = maximumIndex();
+            index = wraps ? ( requested < 0 ? maximum : requested > maximum ? 0 : requested ) : Math.max( 0, Math.min( maximum, requested ) );
+            viewport.scrollTo( { left: slides[ index ].offsetLeft, behavior: reducedMotion ? 'auto' : 'smooth' } );
+            update();
+        }
+        previous.addEventListener( 'click', function() { show( index - 1 ); } );
+        next.addEventListener( 'click', function() { show( index + 1 ); } );
+        viewport.addEventListener( 'keydown', function( event ) { if ( 'ArrowLeft' === event.key || 'ArrowRight' === event.key ) { event.preventDefault(); show( index + ( 'ArrowLeft' === event.key ? -1 : 1 ) ); } } );
+        if ( window.ResizeObserver ) new ResizeObserver( update ).observe( viewport );
+        root.dataset.carouselMounted = 'true';
+        update();
+    }
+    function mountAll() { document.querySelectorAll( '.blocks-engine-authored-carousel' ).forEach( mount ); }
+    if ( 'loading' === document.readyState ) document.addEventListener( 'DOMContentLoaded', mountAll ); else mountAll();
+} )();
+JS;
+        $style = '.blocks-engine-authored-carousel{--blocks-engine-carousel-gap:1rem;display:grid;grid-template-columns:auto minmax(0,1fr) auto;gap:var(--blocks-engine-carousel-gap);align-items:center;max-width:100%;min-width:0}.blocks-engine-authored-carousel__viewport{min-width:0;overflow:hidden;scroll-behavior:smooth}.blocks-engine-authored-carousel__track{display:grid;grid-auto-flow:column;grid-auto-columns:calc((100% - 3rem)/4);gap:var(--blocks-engine-carousel-gap)}.blocks-engine-authored-carousel--items-1 .blocks-engine-authored-carousel__track{grid-auto-columns:100%}.blocks-engine-authored-carousel--items-2 .blocks-engine-authored-carousel__track{grid-auto-columns:calc((100% - 1rem)/2)}.blocks-engine-authored-carousel--items-3 .blocks-engine-authored-carousel__track{grid-auto-columns:calc((100% - 2rem)/3)}.blocks-engine-authored-carousel--items-5 .blocks-engine-authored-carousel__track{grid-auto-columns:calc((100% - 4rem)/5)}.blocks-engine-authored-carousel--items-6 .blocks-engine-authored-carousel__track{grid-auto-columns:calc((100% - 5rem)/6)}.blocks-engine-authored-carousel__track>*{box-sizing:border-box;min-width:0;margin:0}.blocks-engine-authored-carousel__track>.wp-block-image img{display:block;width:100%;aspect-ratio:3/4;object-fit:cover;border-radius:inherit}.blocks-engine-authored-carousel__previous,.blocks-engine-authored-carousel__next{cursor:pointer}.blocks-engine-authored-carousel__previous:disabled,.blocks-engine-authored-carousel__next:disabled{cursor:default;opacity:.45}.blocks-engine-authored-carousel__status{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}@media(max-width:900px){.blocks-engine-authored-carousel .blocks-engine-authored-carousel__track{grid-auto-columns:calc((100% - 1rem)/2)}}@media(max-width:600px){.blocks-engine-authored-carousel .blocks-engine-authored-carousel__track{grid-auto-columns:100%}}@media(prefers-reduced-motion:reduce){.blocks-engine-authored-carousel__viewport{scroll-behavior:auto}}';
+
+        return array(
+            'name' => self::LOCAL_NAME,
+            'block_json' => array(
+                'apiVersion' => 3,
+                'name' => $blockName,
+                'title' => 'Carousel',
+                'category' => 'media',
+                'description' => 'An editable carousel with bounded previous and next navigation.',
+                'editorScript' => 'file:./index.js',
+                'viewScript' => 'file:./view.js',
+                'style' => 'file:./style.css',
+                'attributes' => $attributes,
+                'supports' => array('html' => false, 'customClassName' => false),
+            ),
+            'assets' => array(
+                'index.js' => str_replace(array('__BLOCK_NAME__', '__ATTRIBUTES__'), array($blockName, json_encode($attributes, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES)), $editor),
+                'style.css' => $style,
+            ),
+            'view_js' => $view,
+            'script_dependencies' => array('index.js' => array('wp-blocks', 'wp-block-editor', 'wp-element')),
+        );
+    }
+
+    /** @param array<string, mixed> $attributes @return array{opening: string, closing: string} */
+    public function shell(array $attributes): array
+    {
+        $label = htmlspecialchars((string) ($attributes['ariaLabel'] ?? 'Carousel'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        $items = min(6, max(1, (int) ($attributes['itemsPerView'] ?? 4)));
+        $wrap = false === ($attributes['wrap'] ?? true) ? 'false' : 'true';
+
+        return array(
+            'opening' => '<div class="blocks-engine-authored-carousel blocks-engine-authored-carousel--items-' . $items . '" role="region" aria-label="' . $label . '" aria-roledescription="carousel" data-wrap="' . $wrap . '"><button type="button" class="blocks-engine-authored-carousel__previous" data-carousel-previous="true">Previous</button><div class="blocks-engine-authored-carousel__viewport" tabindex="0"><div class="blocks-engine-authored-carousel__track">',
+            'closing' => '</div></div><button type="button" class="blocks-engine-authored-carousel__next" data-carousel-next="true">Next</button><span class="blocks-engine-authored-carousel__status" aria-live="polite" aria-atomic="true"></span></div>',
+        );
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -22,6 +22,7 @@ use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
 use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\SrcsetParser;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\ContentRoundTripReporter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthorLayoutBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredCarouselBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredMarqueeBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\CapturedDialogBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\DescriptionListBlockGenerator;
@@ -4492,6 +4493,11 @@ if ( 'svg' === $tagName ) {
 
         if ( ShellLandmarkPolicy::isFlowContainerTag($tagName) ) {
             return $this->convertFlowContainerElement($element, $fallbacks);
+        }
+
+        $carousel = $this->authoredCarouselBlock($element);
+        if ( null !== $carousel ) {
+            return $carousel;
         }
 
         if ( $this->isGeneratedComponentCandidate($element) ) {
@@ -12444,6 +12450,178 @@ if ( 'svg' === $tagName ) {
             'innerHTML' => $markup,
             'innerContent' => array( $markup ),
         );
+    }
+
+    /** @return array<string, mixed>|null */
+    private function authoredCarouselBlock(DOMElement $element): ?array
+    {
+        if ( ! $this->hasCarouselIdentity($element) ) {
+            return null;
+        }
+
+        $hasPrevious = false;
+        $hasNext = false;
+        foreach ( $element->getElementsByTagName('*') as $candidate ) {
+            if ( ! $candidate instanceof DOMElement || ! in_array(strtolower($candidate->tagName), array('a', 'button'), true) ) {
+                continue;
+            }
+            $identity = strtolower(implode(' ', array(
+                $this->attr($candidate, 'aria-label'),
+                $this->attr($candidate, 'title'),
+                $this->attr($candidate, 'class'),
+                $this->attr($candidate, 'data-hook'),
+                $candidate->textContent ?? '',
+            )));
+            $hasPrevious = $hasPrevious || 1 === preg_match('/(?:^|[^a-z])(?:prev|previous)(?:[^a-z]|$)/', $identity);
+            $hasNext = $hasNext || 1 === preg_match('/(?:^|[^a-z])next(?:[^a-z]|$)/', $identity);
+        }
+        if ( ! $hasPrevious || ! $hasNext ) {
+            return null;
+        }
+
+        $list = null;
+        $items = array();
+        foreach ( $element->getElementsByTagName('*') as $candidate ) {
+            if ( ! $candidate instanceof DOMElement || ! $this->isCarouselList($candidate) || $this->isExpandedCarouselState($candidate, $element) ) {
+                continue;
+            }
+            $candidateItems = $this->carouselListItems($candidate);
+            if ( count($candidateItems) >= 2 && $this->carouselItemsHaveImages($candidateItems) ) {
+                $list = $candidate;
+                $items = $candidateItems;
+                break;
+            }
+        }
+        if ( ! $list instanceof DOMElement ) {
+            return null;
+        }
+
+        $slides = array();
+        foreach ( $items as $item ) {
+            $image = $item->getElementsByTagName('img')->item(0);
+            if ( ! $image instanceof DOMElement ) {
+                return null;
+            }
+            $slide = $this->convertImageElement($image);
+            if ( null === $slide || 'core/image' !== ($slide['blockName'] ?? null) ) {
+                return null;
+            }
+            $caption = $this->carouselItemCaption($item);
+            if ( '' !== $caption ) {
+                $slide['attrs']['caption'] = $caption;
+                $slide = $this->blockFactory->create('core/image', $slide['attrs'], array());
+            }
+            $slides[] = $slide;
+        }
+
+        $generator = new AuthoredCarouselBlockGenerator();
+        $this->generatedBlocks()->register(AuthoredCarouselBlockGenerator::class, $generator->definition($this->generatedBlocks()->namespace()));
+        $attributes = array(
+            'ariaLabel' => trim($this->attr($element, 'aria-label')) ?: 'Carousel',
+            'itemsPerView' => min(4, count($slides)),
+            'wrap' => true,
+        );
+        $shell = $generator->shell($attributes);
+        $innerContent = array($shell['opening']);
+        foreach ( $slides as $_ ) {
+            $innerContent[] = null;
+        }
+        $innerContent[] = $shell['closing'];
+
+        return array(
+            'blockName' => $this->generatedBlocks()->blockName(AuthoredCarouselBlockGenerator::LOCAL_NAME),
+            'attrs' => $attributes,
+            'innerBlocks' => $slides,
+            'innerHTML' => $shell['opening'] . $shell['closing'],
+            'innerContent' => $innerContent,
+        );
+    }
+
+    private function hasCarouselIdentity(DOMElement $element): bool
+    {
+        $identity = strtolower(implode(' ', array(
+            $element->tagName,
+            $this->attr($element, 'id'),
+            $this->attr($element, 'class'),
+            $this->attr($element, 'role'),
+            $this->attr($element, 'data-hook'),
+            $this->attr($element, 'data-testid'),
+        )));
+
+        return 1 === preg_match('/(?:^|[^a-z0-9])(?:carousel|gallery|slider|slideshow)(?:[^a-z0-9]|$)/', $identity);
+    }
+
+    private function isCarouselList(DOMElement $element): bool
+    {
+        return 'list' === strtolower(trim($this->attr($element, 'role')))
+            || in_array(strtolower($element->tagName), array('ol', 'ul'), true);
+    }
+
+    /** @return array<int, DOMElement> */
+    private function carouselListItems(DOMElement $list): array
+    {
+        $items = array();
+        foreach ( $list->childNodes as $child ) {
+            if ( $child instanceof DOMElement && ('listitem' === strtolower(trim($this->attr($child, 'role'))) || 'li' === strtolower($child->tagName)) ) {
+                $items[] = $child;
+            }
+        }
+
+        return $items;
+    }
+
+    /** @param array<int, DOMElement> $items */
+    private function carouselItemsHaveImages(array $items): bool
+    {
+        foreach ( $items as $item ) {
+            if ( 0 === $item->getElementsByTagName('img')->length ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isExpandedCarouselState(DOMElement $element, DOMElement $root): bool
+    {
+        for ( $ancestor = $element->parentNode; $ancestor instanceof DOMElement && $ancestor !== $root; $ancestor = $ancestor->parentNode ) {
+            $identity = strtolower(implode(' ', array(
+                $ancestor->tagName,
+                $this->attr($ancestor, 'class'),
+                $this->attr($ancestor, 'role'),
+                $this->attr($ancestor, 'data-hook'),
+            )));
+            if ( 1 === preg_match('/(?:^|[^a-z0-9])(?:dialog|expanded|lightbox|modal)(?:[^a-z0-9]|$)/', $identity) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function carouselItemCaption(DOMElement $item): string
+    {
+        $title = '';
+        $description = '';
+        foreach ( $item->getElementsByTagName('*') as $candidate ) {
+            if ( ! $candidate instanceof DOMElement ) {
+                continue;
+            }
+            $identity = strtolower($this->attr($candidate, 'class') . ' ' . $this->attr($candidate, 'data-hook'));
+            if ( '' === $title && 1 === preg_match('/(?:^|[^a-z0-9])title(?:[^a-z0-9]|$)/', $identity) ) {
+                $title = trim($candidate->textContent ?? '');
+            }
+            if ( '' === $description && 1 === preg_match('/(?:^|[^a-z0-9])description(?:[^a-z0-9]|$)/', $identity) ) {
+                $description = trim($candidate->textContent ?? '');
+            }
+        }
+        if ( '' === $title ) {
+            $title = trim($this->attr($item, 'aria-label'));
+        }
+
+        $title = '' === $title ? '' : '<strong>' . $this->runtime->escapeHtml($title) . '</strong>';
+        $description = $this->runtime->escapeHtml($description);
+        return trim($title . ('' !== $title && '' !== $description ? '<br>' : '') . $description);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Support/ElementConversionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/ElementConversionTrait.php
@@ -231,6 +231,11 @@ trait ElementConversionTrait
             }
         }
 
+        $carousel = $this->authoredCarouselBlock($element);
+        if ( null !== $carousel ) {
+            return $carousel;
+        }
+
         if ( $this->isGeneratedComponentCandidate($element) ) {
             $generated = $this->fallbackEmitter()->maybeGenerateCustomBlock($element, $this->generatedBlocks(), true, true);
             if ( null !== $generated ) {

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -211,6 +211,35 @@ $assert(
         && ! str_contains((string) ($responsiveGallery['serialized_blocks'] ?? ''), '<!-- wp:gallery'),
     'responsive gallery media is preserved as one reusable editable block instead of a gallery with unsupported children'
 );
+$carouselSource = '<div class="service-carousel"><button aria-label="Previous slide">Previous</button><div role="list"><div role="listitem" aria-label="Back pain"><img src="back.jpg" alt="Back pain"><div class="title">Back pain</div><div class="description">Treatment for back pain.</div></div><div role="listitem" aria-label="Sciatica"><img src="sciatica.jpg" alt="Sciatica"><div class="title">Sciatica</div><div class="description">Treatment for sciatica.</div></div></div><button aria-label="Next slide">Next</button><div class="expanded-gallery"><div role="list"><div role="listitem"><img src="back-expanded.jpg" alt="Back pain expanded"></div><div role="listitem"><img src="sciatica-expanded.jpg" alt="Sciatica expanded"></div></div></div></div>';
+$carouselResult = ( new HtmlTransformer() )->transform($carouselSource)->toArray();
+$carouselBlock = $carouselResult['blocks'][0] ?? array();
+$carouselMarkup = (string) ($carouselResult['serialized_blocks'] ?? '');
+$carouselDefinitions = $carouselResult['source_reports']['generated_blocks'] ?? array();
+$assert(
+    'custom/authored-carousel' === ($carouselBlock['blockName'] ?? null)
+        && 2 === count($carouselBlock['innerBlocks'] ?? array())
+        && 'core/image' === ($carouselBlock['innerBlocks'][0]['blockName'] ?? null)
+        && str_contains($carouselMarkup, 'back.jpg')
+        && str_contains($carouselMarkup, 'sciatica.jpg')
+        && str_contains($carouselMarkup, 'Treatment for back pain.')
+        && ! str_contains($carouselMarkup, 'back-expanded.jpg')
+        && ! str_contains($carouselMarkup, 'expanded-gallery'),
+    'bounded carousel topology lowers one primary ordered rail to editable native slide blocks'
+);
+$assert(
+    1 === count($carouselDefinitions)
+        && 'authored-carousel' === ($carouselDefinitions[0]['name'] ?? null)
+        && 'file:./view.js' === ($carouselDefinitions[0]['block_json']['viewScript'] ?? null)
+        && str_contains((string) ($carouselDefinitions[0]['view_js'] ?? ''), 'data-carousel-next')
+        && isset($carouselDefinitions[0]['assets']['style.css']),
+    'bounded carousel projection carries one generic editor block with scoped frontend behavior'
+);
+$staticGalleryResult = ( new HtmlTransformer() )->transform('<div class="service-gallery"><div role="list"><div role="listitem"><img src="one.jpg" alt="One"></div><div role="listitem"><img src="two.jpg" alt="Two"></div></div></div>')->toArray();
+$assert(
+    'custom/authored-carousel' !== ($staticGalleryResult['blocks'][0]['blockName'] ?? null),
+    'an ordered image collection without previous and next controls is not promoted to an interactive carousel'
+);
 
 $referenceAnalyzer = new ReferenceAnalyzer();
 $htmlCandidates = $referenceAnalyzer->htmlReferenceCandidates('<a href="about.html">About</a><img src="assets/logo.png" alt="Logo">', 'index.html');

--- a/php-transformer/tests/unit/authored-carousel-block.php
+++ b/php-transformer/tests/unit/authored-carousel-block.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\CompanionPluginPayload;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredCarouselBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
+
+$assert = static function (bool $condition, string $message): void {
+    if ( ! $condition ) {
+        fwrite(STDERR, 'FAIL: ' . $message . PHP_EOL);
+        exit(1);
+    }
+};
+
+$source = '<div class="service-carousel"><button aria-label="Previous slide">Previous</button><div role="list"><div role="listitem" aria-label="First"><img src="one.jpg" alt="First"><div class="title">First</div><div class="description">First description.</div></div><div role="listitem" aria-label="Second"><img src="two.jpg" alt="Second"><div class="title">Second</div><div class="description">Second description.</div></div></div><button aria-label="Next slide">Next</button><div class="expanded-gallery"><div role="list"><div role="listitem"><img src="expanded-one.jpg"></div><div role="listitem"><img src="expanded-two.jpg"></div></div></div></div>';
+$result = (new HtmlTransformer())->transform($source)->toArray();
+$block = $result['blocks'][0] ?? array();
+$markup = (string) ($result['serialized_blocks'] ?? '');
+$assert('custom/authored-carousel' === ($block['blockName'] ?? null), 'bounded previous/list/next topology uses the generic carousel companion');
+$assert(2 === count($block['innerBlocks'] ?? array()) && 'core/image' === ($block['innerBlocks'][0]['blockName'] ?? null), 'carousel slides remain ordinary editable inner image blocks');
+$assert(str_contains($markup, 'First description.') && !str_contains($markup, 'expanded-one.jpg'), 'the primary rail keeps captions and excludes expanded-state duplicates');
+$assert('pass' === ($result['source_reports']['wp_block_validity']['status'] ?? null), 'carousel serialization is editor-valid');
+$serialized = (new Runtime())->serializeBlocks(array($block));
+$assert('custom/authored-carousel' === ((new Runtime())->parseBlocks($serialized)[0]['blockName'] ?? null), 'the carousel and its inner blocks persist through parse and serialize');
+
+$definition = $result['source_reports']['generated_blocks'][0] ?? array();
+$editor = (string) ($definition['assets']['index.js'] ?? '');
+$view = (string) ($definition['view_js'] ?? '');
+$style = (string) ($definition['assets']['style.css'] ?? '');
+$assert('file:./view.js' === ($definition['block_json']['viewScript'] ?? null) && str_contains($editor, 'InnerBlocks.Content'), 'the companion carries one editable parent block and a scoped frontend script');
+$assert(str_contains($view, "'ArrowLeft'") && str_contains($view, "'ArrowRight'") && str_contains($view, 'requested > maximum ? 0'), 'frontend behavior supports keyboard navigation and deterministic wrapping');
+$assert(str_contains($style, 'grid-auto-flow:column') && str_contains($style, '@media(max-width:600px)') && str_contains($style, 'prefers-reduced-motion:reduce'), 'carousel layout is bounded and responsive with reduced-motion handling');
+
+$shell = (new AuthoredCarouselBlockGenerator())->shell(array('ariaLabel' => 'Care & <support>', 'itemsPerView' => 99, 'wrap' => false));
+$shellMarkup = $shell['opening'] . $shell['closing'];
+$assert(str_contains($shellMarkup, 'aria-label="Care &amp; &lt;support&gt;"') && str_contains($shellMarkup, '--items-6') && str_contains($shellMarkup, 'data-wrap="false"'), 'shell attributes are escaped and bounded');
+
+$payload = (new CompanionPluginPayload())->fromBlockTypes(array(), array(), array(), array($definition));
+$payloadBlock = $payload['blocks'][0] ?? array();
+$assert(CompanionPluginPayload::SCHEMA === ($payload['schema'] ?? null) && 'authored-carousel' === ($payloadBlock['name'] ?? null), 'the generated carousel uses the established companion-plugin payload');
+$assert(isset($payloadBlock['assets']['index.js'], $payloadBlock['assets']['style.css']) && str_contains((string) ($payloadBlock['view_js'] ?? ''), 'data-carousel-next'), 'the companion payload carries editor, style, and frontend behavior assets');
+$assert(!isset($payloadBlock['render'], $payloadBlock['renderer'], $payloadBlock['block_json']['render']), 'the carousel needs no executable PHP renderer');
+
+$customHost = (new HtmlTransformer())->transform('<vendor-carousel><button>Previous</button><div role="list"><div role="listitem"><img src="one.jpg"></div><div role="listitem"><img src="two.jpg"></div></div><button>Next</button></vendor-carousel>')->toArray();
+$assert('custom/authored-carousel' === ($customHost['blocks'][0]['blockName'] ?? null), 'custom-element carousel hosts use the same generic block before generated HTML fallback');
+
+fwrite(STDOUT, "Authored carousel companion tests passed\n");


### PR DESCRIPTION
## Summary

- recognize bounded authored carousels before generated static HTML fallback
- project the primary rail into a reusable companion carousel with editable core image/group slides
- preserve responsive navigation behavior while omitting duplicated expanded-gallery state
- cover carousel topology, false-positive rejection, custom-element hosts, Gutenberg validity, persistence, and companion packaging

Closes #1352.

## Testing

- `composer test`
- `composer validate --strict`
- `git diff --check origin/trunk...HEAD`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode was used to investigate the source artifact, implement the companion-block projection and tests, and run verification. Chris Huber directed the architecture and publication workflow.