### PR TITLE
Extract media dispatch element converter

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -170,6 +170,7 @@
             "php tests/unit/svg-element-converter.php",
             "php tests/unit/inline-content-element-converter.php",
             "php tests/unit/flow-container-element-converter.php",
+            "php tests/unit/media-dispatch-element-converter.php",
             "php tests/unit/form-runtime-requirement-analyzer.php",
             "php tests/unit/form-success-panel-metadata-builder.php",
             "php tests/unit/pseudo-form-analyzer.php",

--- a/php-transformer/src/HtmlToBlocks/Elements/MediaDispatchElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/MediaDispatchElementContext.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Closure;
+use DOMElement;
+
+/** Explicit transformer collaborator surface for {@see MediaDispatchElementConverter}. */
+final class MediaDispatchElementContext
+{
+    public function __construct(
+        private readonly Closure $recognizePlaceholder,
+        private readonly Closure $convertImage,
+        private readonly Closure $convertPicture,
+        private readonly Closure $convertIframe,
+        private readonly Closure $convertMedia,
+        private readonly Closure $linkedImageBlock
+    ) {
+    }
+
+    /** @param array<int, array<string, mixed>> $fallbacks @return array<string, mixed>|null */
+    public function recognizePlaceholder(DOMElement $element, array &$fallbacks): ?array
+    {
+        return ($this->recognizePlaceholder)($element, $fallbacks);
+    }
+
+    /** @return array<string, mixed>|null */
+    public function convertImage(DOMElement $element): ?array
+    {
+        return ($this->convertImage)($element);
+    }
+
+    /** @return array<string, mixed>|null */
+    public function convertPicture(DOMElement $element): ?array
+    {
+        return ($this->convertPicture)($element);
+    }
+
+    /** @param array<int, array<string, mixed>> $fallbacks @return array<string, mixed>|null */
+    public function convertIframe(DOMElement $element, array &$fallbacks): ?array
+    {
+        return ($this->convertIframe)($element, $fallbacks);
+    }
+
+    /** @return array<string, mixed>|null */
+    public function convertMedia(DOMElement $element): ?array
+    {
+        return ($this->convertMedia)($element);
+    }
+
+    /** @return array<string, mixed>|null */
+    public function linkedImageBlock(DOMElement $element): ?array
+    {
+        return ($this->linkedImageBlock)($element);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Elements/MediaDispatchElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/MediaDispatchElementConverter.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use DOMElement;
+
+/** Routes native media, linked images, and placeholder media to their materializers. */
+final class MediaDispatchElementConverter
+{
+    public function __construct(private readonly MediaDispatchElementContext $context)
+    {
+    }
+
+    public function handles(string $tagName): bool
+    {
+        return in_array($tagName, array( 'a', 'audio', 'iframe', 'img', 'picture', 'video' ), true);
+    }
+
+    /** @param array<int, array<string, mixed>> $fallbacks */
+    public function convert(DOMElement $element, string $tagName, array &$fallbacks): ConversionOutcome
+    {
+        $placeholder = $this->context->recognizePlaceholder($element, $fallbacks);
+        if ( null !== $placeholder ) {
+            return ConversionOutcome::handled($placeholder);
+        }
+
+        if ( ! $this->handles($tagName) ) {
+            return ConversionOutcome::unhandled();
+        }
+
+        if ( 'img' === $tagName ) {
+            return ConversionOutcome::handled($this->context->convertImage($element));
+        }
+        if ( 'picture' === $tagName ) {
+            return ConversionOutcome::handled($this->context->convertPicture($element));
+        }
+        if ( 'iframe' === $tagName ) {
+            return ConversionOutcome::handled($this->context->convertIframe($element, $fallbacks));
+        }
+        if ( 'audio' === $tagName || 'video' === $tagName ) {
+            return ConversionOutcome::handled($this->context->convertMedia($element));
+        }
+
+        $linkedImage = $this->context->linkedImageBlock($element);
+        return null !== $linkedImage
+            ? ConversionOutcome::handled($linkedImage)
+            : ConversionOutcome::unhandled();
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -47,6 +47,8 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FlowContainerEl
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FlowContainerElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ListElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ListElementConverter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\MediaDispatchElementContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\MediaDispatchElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\DescriptionListElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\DescriptionListElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\SvgElementContext;
@@ -318,6 +320,8 @@ final class HtmlTransformer
     private readonly FigureElementConverter $figureConverter;
 
     private readonly FlowContainerElementConverter $flowContainerConverter;
+
+    private readonly MediaDispatchElementConverter $mediaDispatchConverter;
 
     private readonly ListElementConverter $listConverter;
 
@@ -710,6 +714,16 @@ final class HtmlTransformer
             shouldPreserveWrapper: fn (DOMElement $element): bool => $this->shouldPreserveWrapper($element),
             presentationAttributes: fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
             emptyVisualSpacerBlock: fn (DOMElement $element): array => $this->emptyVisualSpacerBlock($element),
+        ));
+        $this->mediaDispatchConverter = new MediaDispatchElementConverter(new MediaDispatchElementContext(
+            function (DOMElement $element, array &$fallbacks): ?array {
+                return $this->recognizePatterns($element, $fallbacks, array( PlaceholderMediaPattern::class ));
+            },
+            fn (DOMElement $element): ?array => $this->convertImageElement($element),
+            fn (DOMElement $element): ?array => $this->convertPictureElement($element),
+            fn (DOMElement $element, array &$fallbacks): ?array => $this->convertIframeElement($element, $fallbacks),
+            fn (DOMElement $element): ?array => $this->convertMediaElement($element),
+            fn (DOMElement $element): ?array => $this->imageBlockFromAnchor($element)
         ));
         $this->unsupportedRecorder = new UnsupportedElementRecorder($this->createUnsupportedElementContext(), $this->formControlMetadataBuilder);
     }
@@ -4400,9 +4414,9 @@ final class HtmlTransformer
                 : $this->responsiveMediaBlock($element);
         }
 
-        $mediaDispatch = $this->convertMediaDispatchElement($element, $tagName, $fallbacks);
-        if ( $mediaDispatch['handled'] ) {
-            return $mediaDispatch['block'];
+        $mediaDispatch = $this->mediaDispatchConverter->convert($element, $tagName, $fallbacks);
+        if ( $mediaDispatch->handled ) {
+            return $mediaDispatch->block;
         }
 
         if ($this->session->usesFallbackReductionMode() && ( 'button' === $tagName || ( 'a' === $tagName && '' === trim($this->attr($element, 'aria-label')) ) )) {
@@ -4720,43 +4734,6 @@ if ( 'svg' === $tagName ) {
     private function isStructuralTransparentCustomWrapperChild(DOMElement $element): bool
     {
         return in_array(strtolower($element->tagName), array( 'article', 'aside', 'blockquote', 'div', 'dl', 'figure', 'footer', 'form', 'header', 'main', 'nav', 'ol', 'p', 'pre', 'section', 'table', 'ul' ), true);
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $fallbacks
-     * @return array{handled: bool, block: array<string, mixed>|null}
-     */
-    private function convertMediaDispatchElement(DOMElement $element, string $tagName, array &$fallbacks): array
-    {
-        $placeholderMedia = $this->recognizePatterns($element, $fallbacks, array(PlaceholderMediaPattern::class));
-        if ( null !== $placeholderMedia ) {
-            return array( 'handled' => true, 'block' => $placeholderMedia );
-        }
-
-        if ( 'img' === $tagName ) {
-            return array( 'handled' => true, 'block' => $this->convertImageElement($element) );
-        }
-
-        if ( 'picture' === $tagName ) {
-            return array( 'handled' => true, 'block' => $this->convertPictureElement($element) );
-        }
-
-        if ( 'iframe' === $tagName ) {
-            return array( 'handled' => true, 'block' => $this->convertIframeElement($element, $fallbacks) );
-        }
-
-        if ( in_array($tagName, array( 'audio', 'video' ), true) ) {
-            return array( 'handled' => true, 'block' => $this->convertMediaElement($element) );
-        }
-
-        if ( 'a' === $tagName ) {
-            $linkedImage = $this->imageBlockFromAnchor($element);
-            if ( null !== $linkedImage ) {
-                return array( 'handled' => true, 'block' => $linkedImage );
-            }
-        }
-
-        return array( 'handled' => false, 'block' => null );
     }
 
     /**

--- a/php-transformer/tests/unit/media-dispatch-element-converter.php
+++ b/php-transformer/tests/unit/media-dispatch-element-converter.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\MediaDispatchElementContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\MediaDispatchElementConverter;
+
+$assertions = 0;
+$failures = array();
+$assert = static function (bool $condition, string $label) use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']';
+    }
+};
+
+$elementFrom = static function (string $html): DOMElement {
+    $document = new DOMDocument();
+    $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+    $element = $document->getElementsByTagName('body')->item(0)?->firstElementChild;
+    if ( $element instanceof DOMElement ) {
+        return $element;
+    }
+    throw new RuntimeException('No element parsed');
+};
+
+$context = new MediaDispatchElementContext(
+    static fn (DOMElement $element, array &$fallbacks): ?array => $element->hasAttribute('data-placeholder') ? array( 'blockName' => 'core/group' ) : null,
+    static fn (DOMElement $element): ?array => $element->hasAttribute('data-drop') ? null : array( 'blockName' => 'core/image' ),
+    static fn (DOMElement $element): ?array => array( 'blockName' => 'core/picture' ),
+    static function (DOMElement $element, array &$fallbacks): ?array {
+        $fallbacks[] = array( 'iframe' => true );
+        return array( 'blockName' => 'core/embed' );
+    },
+    static fn (DOMElement $element): ?array => array( 'blockName' => 'core/' . strtolower($element->tagName) ),
+    static fn (DOMElement $element): ?array => $element->getElementsByTagName('img')->length > 0 ? array( 'blockName' => 'core/image', 'linked' => true ) : null
+);
+$converter = new MediaDispatchElementConverter($context);
+$fallbacks = array();
+
+$assert($converter->handles('img') && $converter->handles('a') && ! $converter->handles('div'), 'handles-native-media-and-anchors');
+$placeholder = $converter->convert($elementFrom('<div data-placeholder="true"></div>'), 'div', $fallbacks);
+$assert($placeholder->handled && 'core/group' === ($placeholder->block['blockName'] ?? ''), 'placeholder-precedes-tag-routing');
+$assert(! $converter->convert($elementFrom('<div></div>'), 'div', $fallbacks)->handled, 'ordinary-div-unhandled');
+
+$assert('core/image' === ($converter->convert($elementFrom('<img src="x">'), 'img', $fallbacks)->block['blockName'] ?? ''), 'image-routed');
+$droppedImage = $converter->convert($elementFrom('<img data-drop="true">'), 'img', $fallbacks);
+$assert($droppedImage->handled && null === $droppedImage->block, 'handled-image-may-emit-no-block');
+$assert('core/picture' === ($converter->convert($elementFrom('<picture></picture>'), 'picture', $fallbacks)->block['blockName'] ?? ''), 'picture-routed');
+
+$fallbacks = array();
+$assert('core/embed' === ($converter->convert($elementFrom('<iframe></iframe>'), 'iframe', $fallbacks)->block['blockName'] ?? '') && 1 === count($fallbacks), 'iframe-routed-with-fallbacks');
+$assert('core/audio' === ($converter->convert($elementFrom('<audio></audio>'), 'audio', $fallbacks)->block['blockName'] ?? ''), 'audio-routed');
+$assert('core/video' === ($converter->convert($elementFrom('<video></video>'), 'video', $fallbacks)->block['blockName'] ?? ''), 'video-routed');
+$assert(true === ($converter->convert($elementFrom('<a><img src="x"></a>'), 'a', $fallbacks)->block['linked'] ?? false), 'linked-image-anchor-routed');
+$assert(! $converter->convert($elementFrom('<a>Text</a>'), 'a', $fallbacks)->handled, 'ordinary-anchor-unhandled');
+
+if ( $failures ) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Media dispatch element converter tests: ' . $assertions . " passed\n";


### PR DESCRIPTION
## Summary
- extract placeholder and native media routing into `MediaDispatchElementConverter`
- replace the ad hoc `{ handled, block }` array contract with `ConversionOutcome`
- preserve placeholder recognition before tag routing, including placeholder wrappers outside the native media tag set
- keep image, picture, iframe, audio/video, linked-image anchor, handled-null, and unhandled-anchor semantics explicit
- add an 11-assertion direct routing contract

## Verification
- `composer validate --strict`
- `composer test`
- PHP transformer parity: 289 fixtures
- distribution shape: 222 files, 10 monorepo-only trees excluded
- exact-base CSS-attached corpus: byte-identical records for 383 documents / 87 fixtures / 82 fixtures with CSS / 0 throws

Part of #242.

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to extract and type the media dispatch boundary, implement direct routing coverage, and run package and exact-base corpus verification.