### PR TITLE
Compress native wrappers under depth pressure

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -14,6 +14,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeSelectorS
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\TransformationEvidenceState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\TransformationProvenanceState;
 use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionReportProjection;
+use Automattic\BlocksEngine\PhpTransformer\Contract\EditabilityPolicy;
 use Automattic\BlocksEngine\PhpTransformer\Contract\EditabilityReport;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\CoreBlockCapabilityMatrix;
 use Automattic\BlocksEngine\PhpTransformer\Contract\CoreHtmlFallbackEvidence;
@@ -1232,6 +1233,9 @@ final class HtmlTransformer
         $this->collectGeneratedComponentCandidates($body);
         $blocks      = $this->navigationBlockNormalizer->normalize($this->convertChildren($body, $fallbacks, true), $this->transformationProvenance()->sources(), $this->transformationProvenance()->sourceBaseHiddenStates());
         $blocks = $this->compressProjectedGroupChains($blocks);
+        if (EditabilityPolicy::THRESHOLDS['max_nesting_depth'] < $this->blockTreeDepth($blocks)) {
+            $blocks = $this->compressProjectedGroupChains($blocks, true);
+        }
         $fallbacks = array_merge($fallbacks, $this->transformationEvidence()->responsiveImageFallbacks());
         if (! $this->session->usesFallbackReductionMode()) {
             $blocks = $this->reduceCoreHtmlFallbackBlocks($blocks);
@@ -6756,13 +6760,13 @@ if ( 'svg' === $tagName ) {
     }
 
     /** @param array<int, array<string, mixed>> $blocks @return array<int, array<string, mixed>> */
-    private function compressProjectedGroupChains(array $blocks): array
+    private function compressProjectedGroupChains(array $blocks, bool $underDepthPressure = false): array
     {
-        return array_values(array_map(fn (array $block): array => $this->compressProjectedGroupBlock($block), $blocks));
+        return array_values(array_map(fn (array $block): array => $this->compressProjectedGroupBlock($block, $underDepthPressure), $blocks));
     }
 
     /** @param array<string, mixed> $block @return array<string, mixed> */
-    private function compressProjectedGroupBlock(array $block): array
+    private function compressProjectedGroupBlock(array $block, bool $underDepthPressure = false): array
     {
         $chain = array();
         $cursor = $block;
@@ -6785,7 +6789,7 @@ if ( 'svg' === $tagName ) {
             && null !== ($branchDescriptor = $this->groupWrapperDescriptor($cursor))
         ) {
             $chain[] = array('block' => $cursor, 'descriptor' => $branchDescriptor);
-            $terminalBlocks = $this->compressProjectedGroupChains($cursorChildren);
+            $terminalBlocks = $this->compressProjectedGroupChains($cursorChildren, $underDepthPressure);
             $terminal = array();
             $terminalIsShell = false;
             $branchEndpoint = true;
@@ -6801,7 +6805,7 @@ if ( 'svg' === $tagName ) {
             $terminalIsShell = false;
             $emptyEndpoint = true;
         } else {
-            $terminal = array() !== $chain ? $this->compressProjectedGroupBlock($cursor) : $cursor;
+            $terminal = array() !== $chain ? $this->compressProjectedGroupBlock($cursor, $underDepthPressure) : $cursor;
             $terminalIsShell = $this->isLayoutShellBlock($terminal);
             $terminalBlocks = $terminalIsShell
                 ? $terminal['innerBlocks']
@@ -6809,7 +6813,9 @@ if ( 'svg' === $tagName ) {
         }
         $projectedCount = count(array_filter($chain, fn (array $entry): bool => $this->hasSourceProjectionClass($entry['block'])));
         $minimumLength = $branchEndpoint || $emptyEndpoint ? 2 : ($projectedCount === count($chain) ? 2 : 3);
-        if ((0 < $projectedCount && $minimumLength <= count($chain)) || (1 === count($chain) && $terminalIsShell && 0 < $projectedCount)) {
+        $identifiedCount = count(array_filter($chain, fn (array $entry): bool => $this->hasSourceWrapperIdentity($entry['block'])));
+        $depthPressureCandidate = $underDepthPressure && 0 < $identifiedCount && (2 <= count($chain) || (1 === count($chain) && $terminalIsShell));
+        if ($depthPressureCandidate || (0 < $projectedCount && $minimumLength <= count($chain)) || (1 === count($chain) && $terminalIsShell && 0 < $projectedCount)) {
             $wrappers = array_column($chain, 'descriptor');
             $terminalRuntimeOwned = $terminalIsShell && !empty($terminal['_editability_runtime_owned']);
             $terminalVisualOwned = $terminalIsShell && !empty($terminal['_editability_visual_owned']);
@@ -6838,9 +6844,20 @@ if ( 'svg' === $tagName ) {
         }
 
         if (is_array($block['innerBlocks'] ?? null)) {
-            $block['innerBlocks'] = $this->compressProjectedGroupChains($block['innerBlocks']);
+            $block['innerBlocks'] = $this->compressProjectedGroupChains($block['innerBlocks'], $underDepthPressure);
         }
         return $block;
+    }
+
+    /** @param array<int, array<string, mixed>> $blocks */
+    private function blockTreeDepth(array $blocks): int
+    {
+        $depth = 0;
+        foreach ($blocks as $block) {
+            $innerBlocks = is_array($block['innerBlocks'] ?? null) ? $block['innerBlocks'] : array();
+            $depth = max($depth, 1 + $this->blockTreeDepth($innerBlocks));
+        }
+        return $depth;
     }
 
     /** @param array<string, mixed> $block */
@@ -6867,6 +6884,13 @@ if ( 'svg' === $tagName ) {
     private function hasSourceProjectionClass(array $block): bool
     {
         return (bool) preg_match('/(?:^|\s)blocks-engine-(?:attribute|css-owned|editor-anchor|semantic|source)-/', (string) ($block['attrs']['className'] ?? ''));
+    }
+
+    /** @param array<string, mixed> $block */
+    private function hasSourceWrapperIdentity(array $block): bool
+    {
+        $attrs = is_array($block['attrs'] ?? null) ? $block['attrs'] : array();
+        return '' !== trim((string) ($attrs['className'] ?? '')) || '' !== trim((string) ($attrs['anchor'] ?? ''));
     }
 
     /** @param array<string, mixed> $block @return array{tagName: string, attributes: array<string, string>, opening: string, closing: string}|null */

--- a/php-transformer/tests/unit/projected-branch-compression.php
+++ b/php-transformer/tests/unit/projected-branch-compression.php
@@ -81,6 +81,44 @@ $assert(!in_array('editability_policy_failed', $shallowCodes, true) && 'failed' 
 $assert(1 === substr_count($shallowBlocks, '<!-- wp:custom/layout-shell'), 'A shallow two-wrapper branch uses the same layout-shell representation.');
 $assert(!str_contains($shallowBlocks, '<!-- wp:group') && str_contains($shallowBlocks, 'id="dp-outer-1"') && str_contains($shallowBlocks, 'id="dp-branch-1"'), 'The shallow shell preserves both source wrappers.');
 
+// Native wrapper chains normally remain ordinary Groups. Once the document
+// exceeds policy, their exact serialized wrappers may use the same bounded
+// layout-shell representation rather than failing the whole site plan.
+$nativeMarkup = '<h3>Native leaf heading</h3><p>Native editable copy.</p>';
+for ($level = 24; 1 <= $level; $level--) {
+    $nativeMarkup = '<div class="native-shell-' . $level . '" style="padding-left:' . $level . 'px">' . $nativeMarkup . '</div>';
+}
+$nativeArtifact = array(
+    'schema' => ArtifactCompiler::INPUT_SCHEMA,
+    'entrypoint' => 'website/index.html',
+    'files' => array(array(
+        'path' => 'website/index.html',
+        'content' => '<!doctype html><html><body>' . $nativeMarkup . '</body></html>',
+    )),
+);
+$nativeResult = (new ArtifactCompiler())->compile($nativeArtifact)->toArray();
+$nativeCodes = array_column($nativeResult['diagnostics'] ?? array(), 'code');
+$nativeMetrics = $nativeResult['source_reports']['editability_report']['metrics'] ?? array();
+$nativeBlocks = (string) ($nativeResult['serialized_blocks'] ?? '');
+$nativeShell = $nativeResult['blocks'][0] ?? array();
+
+$assert(!in_array('editability_policy_failed', $nativeCodes, true) && 'failed' !== ($nativeResult['status'] ?? null), 'A deeply nested native Group chain no longer fails the whole compile.');
+$assert(20 >= ($nativeMetrics['max_nesting_depth'] ?? PHP_INT_MAX), 'Depth-pressure compression brings native Group chains within the editability maximum.');
+$assert(1 === substr_count($nativeBlocks, '<!-- wp:custom/layout-shell') && 24 === count($nativeShell['attrs']['wrappers'] ?? array()), 'The bounded shell preserves every native source wrapper.');
+$assert(str_contains($nativeBlocks, '>Native leaf heading<') && str_contains($nativeBlocks, '>Native editable copy.<'), 'The bounded shell preserves native editable leaf content.');
+
+$shallowNative = (new ArtifactCompiler())->compile(array(
+    'schema' => ArtifactCompiler::INPUT_SCHEMA,
+    'entrypoint' => 'website/index.html',
+    'files' => array(array(
+        'path' => 'website/index.html',
+        'content' => '<!doctype html><html><body><div class="native-outer" style="padding-left:2px"><div class="native-inner" style="padding-left:1px"><p>Shallow native copy.</p></div></div></body></html>',
+    )),
+))->toArray();
+$shallowNativeBlocks = (string) ($shallowNative['serialized_blocks'] ?? '');
+
+$assert(!str_contains($shallowNativeBlocks, '<!-- wp:custom/layout-shell') && 2 === substr_count($shallowNativeBlocks, '<!-- wp:group'), 'An in-policy native Group chain keeps its ordinary block representation.');
+
 // Responsive copies of a provider form may each be absorbed into a projected
 // shell. Their source identities must rebase onto the final emitted shells.
 $responsiveForm = static fn(string $viewport): string => '<div id="' . $viewport . '-shell" class="blocks-engine-source-div-' . $viewport . '-shell-1">'


### PR DESCRIPTION
## Summary

- run a last-resort Group-chain compression pass only when native List View depth still exceeds the editability policy
- admit identified, exactly serializable native wrappers into `layout-shell` while preserving rendered DOM and editable leaf blocks
- retain ordinary Group output for in-policy documents and preserve rejection of anonymous pathological nesting

Fixes #1311.

## Evidence

The regression artifact starts as 24 identified native wrapper Groups around editable heading and paragraph blocks. Before this change it compiles at depth 25 with `editability_policy_failed`; after this change it compiles successfully at depth 2 with one `layout-shell` carrying all 24 rendered wrappers. An equivalent shallow two-Group document remains two ordinary `core/group` blocks.

## Verification

- `composer validate --strict`
- `php -d memory_limit=1G tests/unit/projected-branch-compression.php`
- `php -d memory_limit=1G tests/contract/wordpress-site-plan.php`
- `COMPOSER_MEMORY_LIMIT=-1 php -d memory_limit=1G "$(command -v composer)" test`
- Full suite passed, including 289 parity fixtures and package-install proof.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode investigated the ownership boundary, implemented the depth-pressure compression and regression coverage, and ran the focused and full verification suites. Chris Huber directed and reviewed the change.