### PR TITLE
Fix inline runtime selector projection

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -619,6 +619,7 @@ final class ArtifactCompiler
             ? $reduction['inline_shell_compilation']
             : $this->compileSharedInlineShells($normalized['files'], $entryPath, $companionPluginPayloadBuilder->blockNamespace($artifact));
         $authorStylesheetProjections = $entryBlocks['author_stylesheet_projections'];
+        $runtimeScriptProjections = $entryBlocks['runtime_script_projections'];
         $allDiagnostics = $this->entryTransformDiagnostics($entryBlocks['diagnostics'], $entryPath);
         $allFallbacks = $entryBlocks['fallbacks'];
         $allGeneratedBlocks = $entryBlocks['generated_blocks'];
@@ -626,6 +627,7 @@ final class ArtifactCompiler
         $coreHtmlFallbackEvidence = array($entryBlocks['core_html_fallback_evidence']);
         foreach ( $compiledHtmlDocuments as $sourcePath => $compiledHtmlDocument ) {
             $authorStylesheetProjections = array_merge($authorStylesheetProjections, $compiledHtmlDocument['author_stylesheet_projections'] ?? array());
+            $runtimeScriptProjections = array_merge($runtimeScriptProjections, $compiledHtmlDocument['runtime_script_projections'] ?? array());
             $allDiagnostics = array_merge($allDiagnostics, $this->entryTransformDiagnostics($compiledHtmlDocument['diagnostics'] ?? array(), (string) $sourcePath));
             $allFallbacks = array_merge($allFallbacks, $compiledHtmlDocument['fallbacks'] ?? array());
             $allGeneratedBlocks = array_merge($allGeneratedBlocks, $compiledHtmlDocument['generated_blocks'] ?? array());
@@ -636,6 +638,7 @@ final class ArtifactCompiler
         $normalized['runtime_declarations'] = $this->runtimeDeclarationsFromFallbacks($normalized['runtime_declarations'], $allFallbacks, $entryPath, $normalized['files']);
         $runtimeIslandPackage = ( new RuntimeIslandPackageBuilder() )->fromRuntimeIslands($entryBlocks['runtime_islands'], $normalized['files'], $entryPath);
         $normalized['files'] = $this->applyAuthorStylesheetProjections($normalized['files'], $authorStylesheetProjections, $entryBlocks['author_stylesheet_projections']);
+        $normalized['files'] = $this->applyRuntimeScriptProjections($normalized['files'], $runtimeScriptProjections);
         $wordpressCompatAsset = $this->wordpressCompatAsset($normalized['files']);
         $referenceReports = $this->referenceReports($normalized['files']);
         $manifestAssets = $this->assetManifest($normalized['files'], $entryPath, $referenceReports['asset_references'], $html);
@@ -1927,7 +1930,7 @@ final class ArtifactCompiler
 
     /**
      * @param array<int, array<string, mixed>> $files
-     * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>, assets: array<int, array<string, mixed>>, runtime_islands: array<int, array<string, mixed>>, generated_blocks: array<int, array<string, mixed>>, gutenberg_gaps: array<int, array<string, mixed>>, interaction_candidates: array<int, array<string, mixed>>, superseded_selectors: array<int, string>, author_stylesheet_projections: array<int, array<string, mixed>>, shell_artifacts: array<int, array<string, mixed>>, core_html_fallback_evidence: array<string, mixed>}
+     * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>, assets: array<int, array<string, mixed>>, runtime_islands: array<int, array<string, mixed>>, generated_blocks: array<int, array<string, mixed>>, gutenberg_gaps: array<int, array<string, mixed>>, interaction_candidates: array<int, array<string, mixed>>, superseded_selectors: array<int, string>, author_stylesheet_projections: array<int, array<string, mixed>>, runtime_script_projections: array<int, array<string, mixed>>, shell_artifacts: array<int, array<string, mixed>>, core_html_fallback_evidence: array<string, mixed>}
      */
     private function compileEntryBlocks(string $html, string $entryPath, array $files, string $generatedBlockNamespace = ''): array
     {
@@ -1945,6 +1948,7 @@ final class ArtifactCompiler
             'interaction_candidates' => $result['interaction_candidates'],
             'superseded_selectors' => $result['superseded_selectors'],
             'author_stylesheet_projections' => $result['author_stylesheet_projections'],
+            'runtime_script_projections' => $result['runtime_script_projections'],
             'shell_artifacts' => $result['shell_artifacts'],
             'core_html_fallback_evidence' => $result['core_html_fallback_evidence'],
             'runtime_block_paths' => $result['runtime_block_paths'] ?? array(),
@@ -1971,6 +1975,7 @@ final class ArtifactCompiler
                 'interaction_candidates' => array(),
                 'superseded_selectors' => array(),
                 'author_stylesheet_projections' => array(),
+                'runtime_script_projections' => array(),
                 'shell_artifacts' => array(),
                 'core_html_fallback_evidence' => CoreHtmlFallbackEvidence::fromBlocks(array(), array(), array()),
                 'reusable_components' => array(),
@@ -1990,6 +1995,7 @@ final class ArtifactCompiler
                 'interaction_candidates' => array(),
                 'superseded_selectors' => array(),
                 'author_stylesheet_projections' => array(),
+                'runtime_script_projections' => array(),
                 'shell_artifacts' => array(),
                 'core_html_fallback_evidence' => CoreHtmlFallbackEvidence::fromBlocks(array(), array(), array()),
                 'reusable_components' => array(),
@@ -2002,6 +2008,7 @@ final class ArtifactCompiler
             ? $this->htmlTransformerAnalysisCache ??= new HtmlTransformerAnalysisCache()
             : new HtmlTransformerAnalysisCache();
         $runtimeDomSelectors = $this->runtimeDomSelectors($html, $sourcePath, $files);
+        $runtimeProjectionSelectors = $this->runtimeProjectionSelectors($html, $sourcePath, $files);
         $result = (new HtmlTransformer(analysisCache: $analysisCache))->transform($this->safeHtmlDocumentHtml($html, $sourcePath, $files), array(
             'source'                    => $sourcePath,
             'source_scope'              => $sourceScope,
@@ -2014,6 +2021,8 @@ final class ArtifactCompiler
             'runtime_script_metadata'   => $this->runtimeScriptMetadataForSource($html, $sourcePath, $files),
             'runtime_dom_selectors'     => $runtimeDomSelectors,
             'runtime_behavioral_selectors' => $runtimeDomSelectors,
+            'runtime_projection_selectors' => $runtimeProjectionSelectors,
+            'runtime_projection_script_assets' => $this->runtimeProjectionScriptAssetsForSource($html, $sourcePath, $files),
             'runtime_canvas_selectors'  => $this->runtimeCanvasSelectors($html, $sourcePath, $files),
             'generated_block_namespace' => $generatedBlockNamespace,
             'generated_asset_root'       => $this->generatedAssetRoot,
@@ -2046,6 +2055,7 @@ final class ArtifactCompiler
                 static fn (mixed $selector): bool => is_string($selector) && '' !== $selector
             )),
             'author_stylesheet_projections' => is_array($result['source_reports']['author_stylesheet_projections'] ?? null) ? $result['source_reports']['author_stylesheet_projections'] : array(),
+            'runtime_script_projections' => is_array($result['source_reports']['runtime_script_projections'] ?? null) ? $result['source_reports']['runtime_script_projections'] : array(),
             'shell_artifacts' => is_array($result['source_reports']['shell_artifacts'] ?? null) ? $result['source_reports']['shell_artifacts'] : array(),
         );
     }
@@ -2711,6 +2721,61 @@ final class ArtifactCompiler
             $file['provenance']['hash'] = hash('sha256', $content);
         }
         unset($file);
+        return $files;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $files
+     * @param array<int, array<string, mixed>> $projections
+     * @return array<int, array<string, mixed>>
+     */
+    private function applyRuntimeScriptProjections(array $files, array $projections): array
+    {
+        $byPath = array();
+        foreach ( $projections as $projection ) {
+            if ( ! is_array($projection) || ! is_string($projection['path'] ?? null) || ! is_array($projection['selectors'] ?? null) ) {
+                continue;
+            }
+            foreach ( $projection['selectors'] as $selector => $markers ) {
+                if ( ! is_string($selector) || ! is_array($markers) ) {
+                    continue;
+                }
+                foreach ( $markers as $marker ) {
+                    if ( is_string($marker) && '' !== $marker ) {
+                        $byPath[$projection['path']][$selector][$marker] = true;
+                    }
+                }
+            }
+        }
+
+        foreach ( $files as &$file ) {
+            $selectorMarkers = $byPath[$file['path'] ?? ''] ?? null;
+            if ( ! is_array($selectorMarkers) || ! in_array($file['kind'] ?? '', array('js', 'mjs'), true) || ! is_string($file['content'] ?? null) ) {
+                continue;
+            }
+            $content = $file['content'];
+            foreach ( $selectorMarkers as $selector => $markers ) {
+                $projectedSelector = implode(',', array_map(static fn (string $marker): string => '.' . $marker, array_keys($markers)));
+                $selectorPattern = preg_quote($selector, '~');
+                $content = preg_replace_callback(
+                    '~((?:querySelector(?:All)?|closest|matches)\s*\(\s*)(["\'])' . $selectorPattern . '\2~',
+                    static fn (array $match): string => $match[1] . $match[2] . $projectedSelector . $match[2],
+                    $content
+                ) ?? $content;
+            }
+            if ( $content === $file['content'] ) {
+                continue;
+            }
+            $file['content'] = $content;
+            unset($file['content_base64']);
+            $file['bytes'] = strlen($content);
+            $file['encoding'] = 'text';
+            $file['binary'] = false;
+            $file['provenance']['projected_from_hash'] = $file['provenance']['hash'] ?? '';
+            $file['provenance']['hash'] = hash('sha256', $content);
+        }
+        unset($file);
+
         return $files;
     }
 
@@ -3500,6 +3565,27 @@ final class ArtifactCompiler
                     continue;
                 }
                 if ( isset($statusFeedbackSelectors[$selector]) ) {
+                    $selectors[$selector] = true;
+                }
+            }
+        }
+
+        return array_keys($selectors);
+    }
+
+    /**
+     * Presentation-only scripts still need stable DOM identities when editable
+     * block serialization cannot retain their source data attributes.
+     *
+     * @param array<int, array<string, mixed>> $files
+     * @return array<int, string>
+     */
+    private function runtimeProjectionSelectors(string $html, string $sourcePath, array $files): array
+    {
+        $selectors = array();
+        foreach ( $this->documentScriptContents($html, $sourcePath, $files) as $script ) {
+            foreach ( $this->scriptDomSelectors($script) as $selector ) {
+                if ( str_contains($selector, '[data-') && $this->isPresentationOnlyScriptSelector($script, $selector) ) {
                     $selectors[$selector] = true;
                 }
             }
@@ -4516,6 +4602,33 @@ final class ArtifactCompiler
         }
 
         return $this->dedupeRows($metadata);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $files
+     * @return array<int, array{path: string, content: string}>
+     */
+    private function runtimeProjectionScriptAssetsForSource(string $html, string $sourcePath, array $files): array
+    {
+        if ( ! preg_match_all('/<script\b([^>]*)>(.*?)<\/script>/is', $html, $matches, PREG_SET_ORDER) ) {
+            return array();
+        }
+
+        $assets = array();
+        $scriptIndex = 0;
+        foreach ( $matches as $match ) {
+            ++$scriptIndex;
+            $src = $this->htmlAttribute((string) $match[1], 'src');
+            $asset = '' === $src
+                ? $this->findInlineScriptAsset($sourcePath, $scriptIndex, $files)
+                : $this->findAssetByHtmlReference($src, $sourcePath, $files);
+            if ( ! is_array($asset) || ! $this->isMaterializedScriptAsset($asset) || ! is_string($asset['path'] ?? null) || ! is_string($asset['content'] ?? null) ) {
+                continue;
+            }
+            $assets[] = array('path' => $asset['path'], 'content' => $asset['content']);
+        }
+
+        return $this->dedupeRows($assets);
     }
 
     /**

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -636,9 +636,12 @@ final class ArtifactCompiler
         }
         $allGutenbergGaps = $this->dedupeRows($allGutenbergGaps);
         $normalized['runtime_declarations'] = $this->runtimeDeclarationsFromFallbacks($normalized['runtime_declarations'], $allFallbacks, $entryPath, $normalized['files']);
-        $runtimeIslandPackage = ( new RuntimeIslandPackageBuilder() )->fromRuntimeIslands($entryBlocks['runtime_islands'], $normalized['files'], $entryPath);
         $normalized['files'] = $this->applyAuthorStylesheetProjections($normalized['files'], $authorStylesheetProjections, $entryBlocks['author_stylesheet_projections']);
         $normalized['files'] = $this->applyRuntimeScriptProjections($normalized['files'], $runtimeScriptProjections);
+        $runtimeIslandPackage = $this->applyRuntimeScriptPackageProjections(
+            ( new RuntimeIslandPackageBuilder() )->fromRuntimeIslands($entryBlocks['runtime_islands'], $normalized['files'], $entryPath),
+            $runtimeScriptProjections
+        );
         $wordpressCompatAsset = $this->wordpressCompatAsset($normalized['files']);
         $referenceReports = $this->referenceReports($normalized['files']);
         $manifestAssets = $this->assetManifest($normalized['files'], $entryPath, $referenceReports['asset_references'], $html);
@@ -2731,38 +2734,14 @@ final class ArtifactCompiler
      */
     private function applyRuntimeScriptProjections(array $files, array $projections): array
     {
-        $byPath = array();
-        foreach ( $projections as $projection ) {
-            if ( ! is_array($projection) || ! is_string($projection['path'] ?? null) || ! is_array($projection['selectors'] ?? null) ) {
-                continue;
-            }
-            foreach ( $projection['selectors'] as $selector => $markers ) {
-                if ( ! is_string($selector) || ! is_array($markers) ) {
-                    continue;
-                }
-                foreach ( $markers as $marker ) {
-                    if ( is_string($marker) && '' !== $marker ) {
-                        $byPath[$projection['path']][$selector][$marker] = true;
-                    }
-                }
-            }
-        }
+        $byPath = $this->runtimeScriptProjectionMap($projections, 'path');
 
         foreach ( $files as &$file ) {
-            $selectorMarkers = $byPath[$file['path'] ?? ''] ?? null;
-            if ( ! is_array($selectorMarkers) || ! in_array($file['kind'] ?? '', array('js', 'mjs'), true) || ! is_string($file['content'] ?? null) ) {
+            $pathProjection = $byPath[$file['path'] ?? ''] ?? null;
+            if ( ! is_array($pathProjection) || ! in_array($file['kind'] ?? '', array('js', 'mjs'), true) || ! is_string($file['content'] ?? null) ) {
                 continue;
             }
-            $content = $file['content'];
-            foreach ( $selectorMarkers as $selector => $markers ) {
-                $projectedSelector = implode(',', array_map(static fn (string $marker): string => '.' . $marker, array_keys($markers)));
-                $selectorPattern = preg_quote($selector, '~');
-                $content = preg_replace_callback(
-                    '~((?:querySelector(?:All)?|closest|matches)\s*\(\s*)(["\'])' . $selectorPattern . '\2~',
-                    static fn (array $match): string => $match[1] . $match[2] . $projectedSelector . $match[2],
-                    $content
-                ) ?? $content;
-            }
+            $content = $this->projectRuntimeScriptContent($file['content'], $pathProjection);
             if ( $content === $file['content'] ) {
                 continue;
             }
@@ -2777,6 +2756,118 @@ final class ArtifactCompiler
         unset($file);
 
         return $files;
+    }
+
+    /** @param array<string, mixed> $package @param array<int, array<string, mixed>> $projections @return array<string, mixed> */
+    private function applyRuntimeScriptPackageProjections(array $package, array $projections): array
+    {
+        if ( ! is_array($package['islands'] ?? null) ) {
+            return $package;
+        }
+        foreach ( $package['islands'] as &$island ) {
+            if ( ! is_array($island['scripts'] ?? null) ) {
+                continue;
+            }
+            foreach ( $island['scripts'] as &$script ) {
+                if ( ! is_string($script['content'] ?? null) ) {
+                    continue;
+                }
+                $projection = $this->runtimeScriptProjectionForContent($script['content'], $projections);
+                if ( is_array($projection) ) {
+                    $script['content'] = $this->projectRuntimeScriptContent($script['content'], $projection);
+                }
+            }
+            unset($script);
+        }
+        unset($island);
+
+        return $package;
+    }
+
+    /** @param array<int, array<string, mixed>> $projections @return array<string, array<string, true>> */
+    private function runtimeScriptProjectionForContent(string $content, array $projections): array
+    {
+        $matched = array();
+        foreach ( $projections as $projection ) {
+            if ( ! is_array($projection) ) {
+                continue;
+            }
+            foreach ( $projection['selectors'] ?? array() as $selector => $markers ) {
+                if ( ! is_string($selector) || ! is_array($markers) || ! preg_match('~(?:querySelector(?:All)?|closest|matches)\s*\(\s*(["\'])' . preg_quote($selector, '~') . '\1~', $content) ) {
+                    continue;
+                }
+                foreach ( $markers as $marker ) {
+                    if ( is_string($marker) && '' !== $marker ) {
+                        $matched[$selector][$marker] = true;
+                    }
+                }
+            }
+            foreach ( $projection['superseded_ids'] ?? array() as $id ) {
+                if ( is_string($id) && '' !== $id && preg_match('~getElementById\s*\(\s*(["\'])' . preg_quote($id, '~') . '\1\s*\)~', $content) ) {
+                    $matched['superseded_ids'][$id] = true;
+                }
+            }
+        }
+
+        return $matched;
+    }
+
+    /** @param array<int, array<string, mixed>> $projections @return array<string, array<string, array<string, true>>> */
+    private function runtimeScriptProjectionMap(array $projections, string $identityKey): array
+    {
+        $map = array();
+        foreach ( $projections as $projection ) {
+            if ( ! is_array($projection) ) {
+                continue;
+            }
+            $identity = $projection[$identityKey] ?? null;
+            if ( ! is_string($identity) || '' === $identity || ! is_array($projection['selectors'] ?? null) || ! is_array($projection['superseded_ids'] ?? null) ) {
+                continue;
+            }
+            foreach ( $projection['selectors'] as $selector => $markers ) {
+                if ( ! is_string($selector) || ! is_array($markers) ) {
+                    continue;
+                }
+                foreach ( $markers as $marker ) {
+                    if ( is_string($marker) && '' !== $marker ) {
+                        $map[$identity][$selector][$marker] = true;
+                    }
+                }
+            }
+            foreach ( $projection['superseded_ids'] as $id ) {
+                if ( is_string($id) && '' !== $id ) {
+                    $map[$identity]['superseded_ids'][$id] = true;
+                }
+            }
+        }
+
+        return $map;
+    }
+
+    /** @param array<string, array<string, true>> $projection */
+    private function projectRuntimeScriptContent(string $content, array $projection): string
+    {
+        foreach ( $projection as $selector => $markers ) {
+            if ( 'superseded_ids' === $selector ) {
+                continue;
+            }
+            $projectedSelector = implode(',', array_map(static fn (string $marker): string => '.' . $marker, array_keys($markers)));
+            $selectorPattern = preg_quote($selector, '~');
+            $content = preg_replace_callback(
+                '~((?:querySelector(?:All)?|closest|matches)\s*\(\s*)(["\'])' . $selectorPattern . '\2~',
+                static fn (array $match): string => $match[1] . $match[2] . $projectedSelector . $match[2],
+                $content
+            ) ?? $content;
+        }
+        foreach ( array_keys($projection['superseded_ids'] ?? array()) as $id ) {
+            $content = preg_replace_callback(
+                '~document\s*\.\s*getElementById\s*\(\s*(["\'])' . preg_quote($id, '~') . '\1\s*\)~',
+                static fn (array $match): string => '(' . $match[0] . " || document.createElement('div'))",
+                $content
+            ) ?? $content;
+        }
+
+        return $content;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -744,7 +744,8 @@ final class HtmlTransformer
             fn (string $selector): array => $this->parsedCssSelector($selector),
             fn (string $className): string => $this->promotedClassName($className),
             fn (string $url): string => $this->resolvedAssetImageUrl($url),
-            fn (string $id): string => $this->safeAnchor($id)
+            fn (string $id): string => $this->safeAnchor($id),
+            fn (DOMElement $element): bool => $this->authorSelectorProjections()->isRuntimeAttributePath($this->sourceElementIdentity($element))
         );
     }
 
@@ -2627,13 +2628,14 @@ final class HtmlTransformer
         return $projections;
     }
 
-    /** @return list<array{path: string, selectors: array<string, list<string>>}> */
+    /** @return list<array{path: string, selectors: array<string, list<string>>, superseded_ids: list<string>}> */
     private function runtimeScriptProjections(): array
     {
         $selectorMarkers = $this->authorSelectorProjections()->runtimeAttributeSelectorMarkers();
-        if ( array() === $selectorMarkers ) {
-            return array();
-        }
+        $supersededIds = array_values(array_filter(array_map(
+            static fn (string $selector): string => str_starts_with($selector, '#') ? substr($selector, 1) : '',
+            $this->runtimeSelectors()->supersededSelectors()
+        )));
 
         $projections = array();
         foreach ( $this->runtimeBehavior()->runtimeProjectionScriptAssets() as $asset ) {
@@ -2647,8 +2649,11 @@ final class HtmlTransformer
                     $selectors[$selector] = $markers;
                 }
             }
-            if ( array() !== $selectors ) {
-                $projections[] = array('path' => $asset['path'], 'selectors' => $selectors);
+            $assetSupersededIds = array_values(array_filter($supersededIds, static function (string $id) use ($asset): bool {
+                return 1 === preg_match('~getElementById\s*\(\s*(["\'])' . preg_quote($id, '~') . '\1\s*\)~', $asset['content']);
+            }));
+            if ( array() !== $selectors || array() !== $assetSupersededIds ) {
+                $projections[] = array('path' => $asset['path'], 'selectors' => $selectors, 'superseded_ids' => $assetSupersededIds);
             }
         }
 

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1129,6 +1129,9 @@ final class HtmlTransformer
         ));
         $this->session->configurePolicy(! empty($options['extract_global_shell']), ! empty($options['fallback_reduction_mode']));
         $this->runtimeBehavior()->installRuntimeScriptMetadata($this->runtimeIslands->runtimeScriptMetadataFromOptions($options));
+        $this->runtimeBehavior()->installRuntimeProjectionScriptAssets(
+            is_array($options['runtime_projection_script_assets'] ?? null) ? $options['runtime_projection_script_assets'] : array()
+        );
         $staticCss = (string) ($options['static_css'] ?? '');
         $styleAnalysis = $this->composedStyleAnalysis($this->stylesheetPayloads($html, $staticCss, $options));
         $this->sourceStyles()->installStylesheetAnalysis($this->detectStaticClassPromotions($html), $styleAnalysis);
@@ -1245,6 +1248,7 @@ final class HtmlTransformer
         $reusableComponentRecognition = $this->reusableComponents()->report($this->materializedAssets()->assets());
         $sourceProvenance = $this->transformationProvenance()->resolveBlockPaths($blocks);
         $authorStylesheetProjections = $this->authorStylesheetProjections();
+        $runtimeScriptProjections = $this->runtimeScriptProjections();
         $this->materializeAuthorStylesheet(
             $html,
             (string) ($options['static_css'] ?? ''),
@@ -1373,6 +1377,9 @@ final class HtmlTransformer
         );
         if ( array() !== $authorStylesheetProjections ) {
             $sourceReports['author_stylesheet_projections'] = $authorStylesheetProjections;
+        }
+        if ( array() !== $runtimeScriptProjections ) {
+            $sourceReports['runtime_script_projections'] = $runtimeScriptProjections;
         }
         $sourceReports['conversion_report'] = ConversionReportProjection::fromResultParts('html', $blocks, $fallbacks, $sourceReports, array(), $provenance, $metrics);
 
@@ -2070,6 +2077,7 @@ final class HtmlTransformer
             : implode("\n\n", array_column($stylesheetAssets, 'content'));
         $this->session->installAuthorStyleAnalysis(new AuthorStyleAnalysis($html, $combinedAuthorCss, $stylesheetAssets, $sourceBody));
         $this->sourceStyles()->setFormLayoutCss($combinedAuthorCss);
+        $this->discoverRuntimeAttributeSelectorPaths($options);
 
         if ( '' === $combinedAuthorCss ) {
             return;
@@ -2237,6 +2245,34 @@ final class HtmlTransformer
                 }
             }
 		}
+    }
+
+    /** @param array<string, mixed> $options */
+    private function discoverRuntimeAttributeSelectorPaths(array $options): void
+    {
+        $selectors = is_array($options['runtime_projection_selectors'] ?? null) ? $options['runtime_projection_selectors'] : array();
+        foreach ( $selectors as $selector ) {
+            if ( ! is_string($selector) || ! preg_match('/\[\s*data-[a-z0-9_-]+(?:\s*[~|^$*]?=|\s*\])/i', $selector) ) {
+                continue;
+            }
+            $parsed = $this->parsedCssSelector($selector);
+            if ( ! $parsed['supported'] ) {
+                continue;
+            }
+            $markers = array();
+            foreach ( $this->matchingAuthorSourceElements($selector, $parsed) as $element ) {
+                $path = $this->sourceElementIdentity($element);
+                if ( '' === $path ) {
+                    continue;
+                }
+                $marker = $this->authorSelectorProjections()->ensureAttributeMarker($path);
+                $element->setAttribute('class', $this->mergeClassNames($this->attr($element, 'class'), $marker));
+                $markers[] = $marker;
+            }
+            if ( array() !== $markers ) {
+                $this->authorSelectorProjections()->installRuntimeAttributeSelectorMarkers($selector, $markers);
+            }
+        }
     }
 
 	/** @param list<array{selector:string,parsed:array<string,mixed>}> $authorSelectors */
@@ -2588,6 +2624,34 @@ final class HtmlTransformer
                 'attribute_state_markers' => $this->authorSelectorProjections()->attributeNegationMarkers(),
             );
         }
+        return $projections;
+    }
+
+    /** @return list<array{path: string, selectors: array<string, list<string>>}> */
+    private function runtimeScriptProjections(): array
+    {
+        $selectorMarkers = $this->authorSelectorProjections()->runtimeAttributeSelectorMarkers();
+        if ( array() === $selectorMarkers ) {
+            return array();
+        }
+
+        $projections = array();
+        foreach ( $this->runtimeBehavior()->runtimeProjectionScriptAssets() as $asset ) {
+            if ( ! is_array($asset) || ! is_string($asset['path'] ?? null) || ! is_string($asset['content'] ?? null) ) {
+                continue;
+            }
+            $selectors = array();
+            foreach ( $selectorMarkers as $selector => $markers ) {
+                $selectorPattern = preg_quote($selector, '~');
+                if ( preg_match('~(?:querySelector(?:All)?|closest|matches)\s*\(\s*(["\'])' . $selectorPattern . '\1~', $asset['content']) ) {
+                    $selectors[$selector] = $markers;
+                }
+            }
+            if ( array() !== $selectors ) {
+                $projections[] = array('path' => $asset['path'], 'selectors' => $selectors);
+            }
+        }
+
         return $projections;
     }
 
@@ -3200,6 +3264,11 @@ final class HtmlTransformer
 
         $rewritten = array();
         foreach ( $selectors as $selector ) {
+            $runtimeProjection = $this->projectRuntimeAttributeSelector($selector);
+            if ( null !== $runtimeProjection ) {
+                array_push($rewritten, ...$runtimeProjection);
+                continue;
+            }
             $selector = $this->projectSourceAttributeNegationStateSelector($selector);
             $selector = $this->projectSourceBodyStateSelector($selector);
             $parsed = $this->parsedCssSelector($selector);
@@ -3326,6 +3395,33 @@ final class HtmlTransformer
             }
         }
         return implode(',', $rewritten);
+    }
+
+    /** @return list<string>|null */
+    private function projectRuntimeAttributeSelector(string $selector): ?array
+    {
+        $selectorMarkers = $this->authorSelectorProjections()->runtimeAttributeSelectorMarkers();
+        uksort($selectorMarkers, static fn (string $left, string $right): int => strlen($right) <=> strlen($left));
+        foreach ( $selectorMarkers as $runtimeSelector => $markers ) {
+            if ( ! str_starts_with($selector, $runtimeSelector) ) {
+                continue;
+            }
+            $suffix = substr($selector, strlen($runtimeSelector));
+            if ( '' !== $suffix && ! in_array($suffix[0], array('.', ':'), true) ) {
+                continue;
+            }
+            $parsed = $this->parsedCssSelector($runtimeSelector);
+            if ( ! $parsed['supported'] ) {
+                continue;
+            }
+            $shims = $this->selectorSpecificityShims($parsed);
+            return array_map(
+                static fn (string $marker): string => ':where(.' . $marker . ')' . $shims . $suffix,
+                $markers
+            );
+        }
+
+        return null;
     }
 
     /** @param array<string, mixed> $parsed @param array<int, DOMElement> $matches @return array<int, string>|null */

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -3400,6 +3400,7 @@ final class HtmlTransformer
     /** @return list<string>|null */
     private function projectRuntimeAttributeSelector(string $selector): ?array
     {
+        $selector = trim($selector);
         $selectorMarkers = $this->authorSelectorProjections()->runtimeAttributeSelectorMarkers();
         uksort($selectorMarkers, static fn (string $left, string $right): int => strlen($right) <=> strlen($left));
         foreach ( $selectorMarkers as $runtimeSelector => $markers ) {

--- a/php-transformer/src/HtmlToBlocks/Session/RuntimeBehaviorState.php
+++ b/php-transformer/src/HtmlToBlocks/Session/RuntimeBehaviorState.php
@@ -11,6 +11,9 @@ final class RuntimeBehaviorState
     /** @var array<int, array<string, mixed>> */
     private array $runtimeScriptMetadata = array();
 
+    /** @var array<int, array<string, mixed>> */
+    private array $runtimeProjectionScriptAssets = array();
+
     /** @var array<string, true> */
     private array $nativeDisclosureRootPaths = array();
 
@@ -31,6 +34,18 @@ final class RuntimeBehaviorState
     public function hasRuntimeScriptMetadata(): bool
     {
         return array() !== $this->runtimeScriptMetadata;
+    }
+
+    /** @param array<int, array<string, mixed>> $assets */
+    public function installRuntimeProjectionScriptAssets(array $assets): void
+    {
+        $this->runtimeProjectionScriptAssets = $assets;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function runtimeProjectionScriptAssets(): array
+    {
+        return $this->runtimeProjectionScriptAssets;
     }
 
     /** @param array<string, mixed> $metadata */

--- a/php-transformer/src/HtmlToBlocks/Style/AuthorSelectorProjectionState.php
+++ b/php-transformer/src/HtmlToBlocks/Style/AuthorSelectorProjectionState.php
@@ -152,6 +152,22 @@ final class AuthorSelectorProjectionState
         return $this->runtimeAttributeSelectorMarkers;
     }
 
+    public function isRuntimeAttributePath(string $path): bool
+    {
+        $marker = $this->attributeMarkers[$path] ?? '';
+        if ( '' === $marker ) {
+            return false;
+        }
+
+        foreach ( $this->runtimeAttributeSelectorMarkers as $markers ) {
+            if ( in_array($marker, $markers, true) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function installAttributeNegationMarker(string $selector, string $marker): void
     {
         $this->attributeNegationMarkers[$selector] = $marker;

--- a/php-transformer/src/HtmlToBlocks/Style/AuthorSelectorProjectionState.php
+++ b/php-transformer/src/HtmlToBlocks/Style/AuthorSelectorProjectionState.php
@@ -28,6 +28,9 @@ final class AuthorSelectorProjectionState
     /** @var array<string, string> */
     private array $attributeMarkers = array();
 
+    /** @var array<string, list<string>> */
+    private array $runtimeAttributeSelectorMarkers = array();
+
     /** @var array<string, string> */
     private array $attributeNegationMarkers = array();
 
@@ -135,6 +138,18 @@ final class AuthorSelectorProjectionState
     public function attributeMarker(string $path): string
     {
         return $this->attributeMarkers[$path] ?? '';
+    }
+
+    /** @param list<string> $markers */
+    public function installRuntimeAttributeSelectorMarkers(string $selector, array $markers): void
+    {
+        $this->runtimeAttributeSelectorMarkers[$selector] = array_values(array_unique(array_filter($markers)));
+    }
+
+    /** @return array<string, list<string>> */
+    public function runtimeAttributeSelectorMarkers(): array
+    {
+        return $this->runtimeAttributeSelectorMarkers;
     }
 
     public function installAttributeNegationMarker(string $selector, string $marker): void

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionContext.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionContext.php
@@ -32,6 +32,7 @@ final class StyleResolutionContext
      * @param Closure(string): string                  $promotedClassName
      * @param Closure(string): string                  $resolvedAssetImageUrl
      * @param Closure(string): string                  $safeAnchor
+     * @param Closure(DOMElement): bool                $hasRetainedPresentationRuntime
      */
     public function __construct(
         private readonly Closure $authorStyles,
@@ -47,7 +48,8 @@ final class StyleResolutionContext
         private readonly Closure $parsedCssSelector,
         private readonly Closure $promotedClassName,
         private readonly Closure $resolvedAssetImageUrl,
-        private readonly Closure $safeAnchor
+        private readonly Closure $safeAnchor,
+        private readonly Closure $hasRetainedPresentationRuntime
     ) {
     }
 
@@ -122,5 +124,10 @@ final class StyleResolutionContext
     public function safeAnchor(string $id): string
     {
         return ($this->safeAnchor)($id);
+    }
+
+    public function hasRetainedPresentationRuntime(DOMElement $element): bool
+    {
+        return ($this->hasRetainedPresentationRuntime)($element);
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
@@ -1634,7 +1634,7 @@ final class StyleResolver
      */
     private function stripFrozenHiddenState(DOMElement $element, array $declarations): array
     {
-        if ( array() === $declarations || $this->isDecorativeHiddenElement($element) ) {
+        if ( array() === $declarations || $this->isDecorativeHiddenElement($element) || $this->context->hasRetainedPresentationRuntime($element) ) {
             return $declarations;
         }
 

--- a/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
+++ b/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
@@ -55,7 +55,7 @@ $runtimeReveal = ( new ArtifactCompiler() )->compile(array( 'files' => array(
   [data-reveal] { opacity:0; transform:translateY(20px) }
   [data-reveal].in-view { opacity:1; transform:translateY(0) }
 </style>
-<main><section data-reveal><p>Story</p></section><section data-reveal><p>Menu</p></section></main>
+<main><section id="story" data-reveal><p>Story</p></section><section data-reveal><p>Menu</p></section></main>
 <script>const revealEls = document.querySelectorAll('[data-reveal]'); const observer = new IntersectionObserver(function (entries) { entries.forEach(function (entry) { if (entry.isIntersecting) { entry.target.classList.add('in-view'); observer.unobserve(entry.target); } }); }); revealEls.forEach(function (el) { observer.observe(el); });</script>
 HTML ),
 ) ) )->toArray();
@@ -67,7 +67,16 @@ preg_match_all('/blocks-engine-attribute-[a-f0-9]+-\d+/', $runtimeRevealMarkup, 
 $runtimeRevealMarkers = array_keys(array_fill_keys($runtimeRevealMarkerMatches[0] ?? array(), true));
 $assert(2 === count($runtimeRevealMarkers) && ! str_contains($runtimeRevealMarkup, 'wp:html'), 'inline presentation runtime targets remain separate editable native blocks with deterministic identities');
 $assert(! str_contains($runtimeRevealCss, '[data-reveal]') && array() === array_filter($runtimeRevealMarkers, static fn (string $marker): bool => ! str_contains($runtimeRevealCss, ':where(.' . $marker . ')') || ! str_contains($runtimeRevealCss, ':where(.' . $marker . '):not(.blocks-engine-specificity-class-') || ! str_contains($runtimeRevealCss, '.in-view')), 'initial and runtime-mutated author selectors project onto every editable runtime target');
+$assert(array() === array_filter($runtimeRevealMarkers, static fn (string $marker): bool => str_contains($runtimeRevealCss, ':root .' . $marker . '{opacity:1!important')), 'retained presentation runtimes keep their authored closed state instead of receiving inert-content visibility repairs');
 $assert(! str_contains($runtimeRevealJs, '[data-reveal]') && array() === array_filter($runtimeRevealMarkers, static fn (string $marker): bool => ! str_contains($runtimeRevealJs, '.' . $marker)), 'materialized inline script queries the same projected identities as author CSS');
+
+$restaurantRuntime = ( new ArtifactCompiler() )->compile(array('files' => array(
+    array('path' => 'index.html', 'kind' => 'html', 'content' => file_get_contents(dirname(__DIR__, 2) . '/../fixtures/websites/14-restaurant/index.html')),
+)))->toArray();
+$restaurantRuntimeJs = implode("\n", array_column(array_filter($restaurantRuntime['assets'] ?? array(), static fn (array $asset): bool => in_array($asset['kind'] ?? '', array('js', 'mjs'), true)), 'content'));
+$restaurantIslandPackage = json_encode($restaurantRuntime['source_reports']['runtime_island_package'] ?? array());
+$assert(str_contains($restaurantRuntimeJs, "document.getElementById('nav-toggle') || document.createElement('div')") && str_contains($restaurantRuntimeJs, "document.getElementById('nav-links') || document.createElement('div')"), 'mixed runtime scripts use inert targets for superseded controls so retained presentation behavior can continue');
+$assert(is_string($restaurantIslandPackage) && ! str_contains($restaurantIslandPackage, '[data-reveal]') && str_contains($restaurantIslandPackage, 'blocks-engine-attribute-') && str_contains($restaurantIslandPackage, "document.createElement('div')"), 'companion runtime packages carry the same projected script as the theme asset');
 $assert('pass' === ($runtimeReveal['source_reports']['runtime_dependency_parity']['status'] ?? ''), 'runtime dependency parity validates the projected inline script against materialized block markup');
 
 $contentBox = ( new ArtifactCompiler() )->compile(array( 'files' => array(

--- a/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
+++ b/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
@@ -51,7 +51,10 @@ $assert(str_contains((string) ($assetsByPath['a.occurrence-2-generated-1.css']['
 
 $runtimeReveal = ( new ArtifactCompiler() )->compile(array( 'files' => array(
     array( 'path' => 'index.html', 'kind' => 'html', 'content' => <<<'HTML'
-<style>[data-reveal]{opacity:0;transform:translateY(20px)}[data-reveal].in-view{opacity:1;transform:translateY(0)}</style>
+<style>
+  [data-reveal] { opacity:0; transform:translateY(20px) }
+  [data-reveal].in-view { opacity:1; transform:translateY(0) }
+</style>
 <main><section data-reveal><p>Story</p></section><section data-reveal><p>Menu</p></section></main>
 <script>const revealEls = document.querySelectorAll('[data-reveal]'); const observer = new IntersectionObserver(function (entries) { entries.forEach(function (entry) { if (entry.isIntersecting) { entry.target.classList.add('in-view'); observer.unobserve(entry.target); } }); }); revealEls.forEach(function (el) { observer.observe(el); });</script>
 HTML ),

--- a/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
+++ b/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
@@ -49,6 +49,24 @@ $assert(! str_contains((string) ($assetsByPath['a.css']['content'] ?? ''), 'a.ct
 $assert(hash('sha256', '.hero p{color:green}') === ($assetsByPath['index.inline-2.css']['source_hash'] ?? null) && ! str_contains((string) ($assetsByPath['index.inline-2.css']['content'] ?? ''), '.hero p') && str_contains((string) ($assetsByPath['index.inline-2.css']['content'] ?? ''), ':where(.blocks-engine-source-p-'), 'inline CSS is rewritten in place with original source provenance');
 $assert(str_contains((string) ($assetsByPath['a.occurrence-2-generated-1.css']['content'] ?? ''), '> :where(.wp-block-button__link):hover') && '.authored-collision{color:purple}' === ($assetsByPath['a.occurrence-2.css']['content'] ?? ''), 'allocated occurrence alias is referenced while authored collision CSS remains a deterministic orphan asset');
 
+$runtimeReveal = ( new ArtifactCompiler() )->compile(array( 'files' => array(
+    array( 'path' => 'index.html', 'kind' => 'html', 'content' => <<<'HTML'
+<style>[data-reveal]{opacity:0;transform:translateY(20px)}[data-reveal].in-view{opacity:1;transform:translateY(0)}</style>
+<main><section data-reveal><p>Story</p></section><section data-reveal><p>Menu</p></section></main>
+<script>const revealEls = document.querySelectorAll('[data-reveal]'); const observer = new IntersectionObserver(function (entries) { entries.forEach(function (entry) { if (entry.isIntersecting) { entry.target.classList.add('in-view'); observer.unobserve(entry.target); } }); }); revealEls.forEach(function (el) { observer.observe(el); });</script>
+HTML ),
+) ) )->toArray();
+$runtimeRevealMarkup = (string) ($runtimeReveal['serialized_blocks'] ?? '');
+$runtimeRevealAssets = $runtimeReveal['assets'] ?? array();
+$runtimeRevealCss = implode("\n", array_column(array_filter($runtimeRevealAssets, static fn (array $asset): bool => 'css' === ($asset['kind'] ?? '')), 'content'));
+$runtimeRevealJs = implode("\n", array_column(array_filter($runtimeRevealAssets, static fn (array $asset): bool => in_array($asset['kind'] ?? '', array('js', 'mjs'), true)), 'content'));
+preg_match_all('/blocks-engine-attribute-[a-f0-9]+-\d+/', $runtimeRevealMarkup, $runtimeRevealMarkerMatches);
+$runtimeRevealMarkers = array_keys(array_fill_keys($runtimeRevealMarkerMatches[0] ?? array(), true));
+$assert(2 === count($runtimeRevealMarkers) && ! str_contains($runtimeRevealMarkup, 'wp:html'), 'inline presentation runtime targets remain separate editable native blocks with deterministic identities');
+$assert(! str_contains($runtimeRevealCss, '[data-reveal]') && array() === array_filter($runtimeRevealMarkers, static fn (string $marker): bool => ! str_contains($runtimeRevealCss, ':where(.' . $marker . ')') || ! str_contains($runtimeRevealCss, ':where(.' . $marker . '):not(.blocks-engine-specificity-class-') || ! str_contains($runtimeRevealCss, '.in-view')), 'initial and runtime-mutated author selectors project onto every editable runtime target');
+$assert(! str_contains($runtimeRevealJs, '[data-reveal]') && array() === array_filter($runtimeRevealMarkers, static fn (string $marker): bool => ! str_contains($runtimeRevealJs, '.' . $marker)), 'materialized inline script queries the same projected identities as author CSS');
+$assert('pass' === ($runtimeReveal['source_reports']['runtime_dependency_parity']['status'] ?? ''), 'runtime dependency parity validates the projected inline script against materialized block markup');
+
 $contentBox = ( new ArtifactCompiler() )->compile(array( 'files' => array(
     array( 'path' => 'index.html', 'kind' => 'html', 'content' => '<style>.cascade-stack{display:block;width:640px;padding:48px;background:#fff;border:2px solid #18231d}</style><div class="cascade-stack"><p>Copy</p></div>' ),
 ) ) )->toArray();


### PR DESCRIPTION
## Summary
- project presentation-only runtime data selectors onto the same deterministic classes as editable native blocks
- rewrite initial and mutated author CSS, theme scripts, and companion runtime scripts consistently
- preserve active reveal closed states while isolating lookups for controls superseded by native blocks
- cover multiline CSS and the restaurant fixture mixed-runtime path

Fixes #1417.

## Verification
- `composer test:canonical`
- `composer test:parity` (289 fixtures)
- `php tests/unit/artifact-author-stylesheet-projection.php`
- `git diff --check`
- built an SSI development package from `3724e478` and imported `fixtures/websites/14-restaurant` into a fresh WordPress Studio site
- browser verification at 1440x900 reported zero page errors; all 28 reveal targets started at opacity 0, received `in-view` while scrolling, and finished at opacity 1
- full-page rendering contained all sections through the footer

## AI Assistance
GPT-5.6-sol via OpenCode was used to investigate the compiler/runtime mismatch, implement the projection changes, run deterministic and browser verification, and draft this pull request.