### PR TITLE
Introduce ordered element converter registry

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -171,6 +171,7 @@
             "php tests/unit/inline-content-element-converter.php",
             "php tests/unit/flow-container-element-converter.php",
             "php tests/unit/media-dispatch-element-converter.php",
+            "php tests/unit/ordered-element-converter-registry.php",
             "php tests/unit/form-runtime-requirement-analyzer.php",
             "php tests/unit/form-success-panel-metadata-builder.php",
             "php tests/unit/pseudo-form-analyzer.php",

--- a/php-transformer/src/HtmlToBlocks/Elements/DescriptionListElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/DescriptionListElementConverter.php
@@ -6,7 +6,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 use DOMElement;
 
 /** Converts description lists and their term/detail children. */
-final class DescriptionListElementConverter
+final class DescriptionListElementConverter implements ElementConverter
 {
     public function __construct(private readonly DescriptionListElementContext $context)
     {

--- a/php-transformer/src/HtmlToBlocks/Elements/ElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/ElementConverter.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use DOMElement;
+
+/** Common contract for ordered element conversion strategies. */
+interface ElementConverter
+{
+    /** @param array<int, array<string, mixed>> $fallbacks */
+    public function convert(DOMElement $element, string $tagName, array &$fallbacks): ConversionOutcome;
+}

--- a/php-transformer/src/HtmlToBlocks/Elements/FigureElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FigureElementConverter.php
@@ -8,7 +8,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\FigureQuotePatt
 use DOMElement;
 
 /** Converts figures and their captions through the ordered figure strategies. */
-final class FigureElementConverter
+final class FigureElementConverter implements ElementConverter
 {
     public function __construct(private readonly FigureElementContext $context)
     {

--- a/php-transformer/src/HtmlToBlocks/Elements/FlowContainerElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FlowContainerElementConverter.php
@@ -18,7 +18,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\ShellLandmarkPolicy;
 use DOMElement;
 
 /** Converts flow containers through their ordered runtime, pattern, layout, and child strategies. */
-final class FlowContainerElementConverter
+final class FlowContainerElementConverter implements ElementConverter
 {
     public function __construct(private readonly FlowContainerElementContext $context)
     {

--- a/php-transformer/src/HtmlToBlocks/Elements/InlineContentElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/InlineContentElementConverter.php
@@ -9,7 +9,7 @@ use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use DOMElement;
 
 /** Converts phrasing-content elements to editable text or structural carriers. */
-final class InlineContentElementConverter
+final class InlineContentElementConverter implements ElementConverter
 {
     public function __construct(
         private readonly InlineContentElementContext $context,

--- a/php-transformer/src/HtmlToBlocks/Elements/ListElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/ListElementConverter.php
@@ -9,7 +9,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\SocialLinksPatt
 use DOMElement;
 
 /** Converts ordered and unordered lists through their ordered strategies. */
-final class ListElementConverter
+final class ListElementConverter implements ElementConverter
 {
     public function __construct(private readonly ListElementContext $context)
     {

--- a/php-transformer/src/HtmlToBlocks/Elements/MediaDispatchElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/MediaDispatchElementConverter.php
@@ -6,7 +6,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 use DOMElement;
 
 /** Routes native media, linked images, and placeholder media to their materializers. */
-final class MediaDispatchElementConverter
+final class MediaDispatchElementConverter implements ElementConverter
 {
     public function __construct(private readonly MediaDispatchElementContext $context)
     {

--- a/php-transformer/src/HtmlToBlocks/Elements/OrderedElementConverterRegistry.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/OrderedElementConverterRegistry.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use DOMElement;
+
+/** Runs element converters in declaration order and stops at the first handled outcome. */
+final class OrderedElementConverterRegistry implements ElementConverter
+{
+    /** @param list<ElementConverter> $converters */
+    public function __construct(private readonly array $converters)
+    {
+    }
+
+    /** @param array<int, array<string, mixed>> $fallbacks */
+    public function convert(DOMElement $element, string $tagName, array &$fallbacks): ConversionOutcome
+    {
+        foreach ( $this->converters as $converter ) {
+            $outcome = $converter->convert($element, $tagName, $fallbacks);
+            if ( $outcome->handled ) {
+                return $outcome;
+            }
+        }
+
+        return ConversionOutcome::unhandled();
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Elements/RichTextElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/RichTextElementConverter.php
@@ -18,7 +18,7 @@ use DOMElement;
  * shrinking the object surface. This class receives a
  * {@see RichTextElementContext} and is exercised without a transformer.
  */
-final class RichTextElementConverter
+final class RichTextElementConverter implements ElementConverter
 {
     private const HEADING_PATTERN = '/^h([1-6])$/';
 

--- a/php-transformer/src/HtmlToBlocks/Elements/SvgElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/SvgElementConverter.php
@@ -6,7 +6,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 use DOMElement;
 
 /** Routes standalone SVGs to materialized, preserved, decorative, or fallback representations. */
-final class SvgElementConverter
+final class SvgElementConverter implements ElementConverter
 {
     public function __construct(
         private readonly SvgElementContext $context,

--- a/php-transformer/src/HtmlToBlocks/Elements/TableElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/TableElementConverter.php
@@ -13,7 +13,7 @@ use DOMElement;
  * element is offered to data-table classification, because a table used purely
  * for layout must become columns rather than a semantic table.
  */
-final class TableElementConverter
+final class TableElementConverter implements ElementConverter
 {
     public function __construct(private readonly TableElementContext $context)
     {

--- a/php-transformer/src/HtmlToBlocks/Elements/TextLeafElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/TextLeafElementConverter.php
@@ -20,7 +20,7 @@ use DOMElement;
  * converter is consulted at exactly the position the extracted branches
  * occupied, and {@see handles()} matches the same tags those branches matched.
  */
-final class TextLeafElementConverter
+final class TextLeafElementConverter implements ElementConverter
 {
     /**
      * Tags this converter owns, in the transformer's dispatch order.

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -49,6 +49,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ListElementCont
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ListElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\MediaDispatchElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\MediaDispatchElementConverter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\OrderedElementConverterRegistry;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\DescriptionListElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\DescriptionListElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\SvgElementContext;
@@ -283,7 +284,7 @@ final class HtmlTransformer
 
     private readonly SvgElementConverter $svgConverter;
 
-    private readonly InlineContentElementConverter $inlineContentConverter;
+    private readonly OrderedElementConverterRegistry $inlineStructureConverters;
 
     private readonly NavigationToggleSuppressor $navigationToggleSuppressor;
 
@@ -322,10 +323,6 @@ final class HtmlTransformer
     private readonly FlowContainerElementConverter $flowContainerConverter;
 
     private readonly MediaDispatchElementConverter $mediaDispatchConverter;
-
-    private readonly ListElementConverter $listConverter;
-
-    private readonly DescriptionListElementConverter $descriptionListConverter;
 
     private readonly UnsupportedElementRecorder $unsupportedRecorder;
 
@@ -472,7 +469,7 @@ final class HtmlTransformer
                 $this->captureInlineSvgFallback($element, $fallbacks);
             }
         ), $this->svgMaterializer);
-        $this->inlineContentConverter = new InlineContentElementConverter(new InlineContentElementContext(
+        $inlineContentConverter = new InlineContentElementConverter(new InlineContentElementContext(
             fn (DOMElement $element, array &$fallbacks, array $patterns): ?array => $this->recognizePatterns($element, $fallbacks, $patterns),
             fn (DOMElement $element): bool => $this->runtimeIslands->isRuntimeDomTarget($element),
             fn (DOMElement $element): array => $this->htmlPreservationBlock($element),
@@ -618,7 +615,7 @@ final class HtmlTransformer
             fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
             fn (string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement)
         ));
-        $this->listConverter = new ListElementConverter(new ListElementContext(
+        $listConverter = new ListElementConverter(new ListElementContext(
             function (DOMElement $element, array &$fallbacks, array $patterns): ?array {
                 return $this->recognizePatterns($element, $fallbacks, $patterns);
             },
@@ -639,7 +636,7 @@ final class HtmlTransformer
             fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
             fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement)
         ));
-        $this->descriptionListConverter = new DescriptionListElementConverter(new DescriptionListElementContext(
+        $descriptionListConverter = new DescriptionListElementConverter(new DescriptionListElementContext(
             fn (DOMElement $element): ?array => $this->descriptionListBlockFromElement($element),
             fn (DOMElement $element): ?array => $this->metadataGridBlockFromElement($element),
             fn (DOMElement $element): array => $this->definitionListItems($element),
@@ -653,6 +650,11 @@ final class HtmlTransformer
             fn (DOMElement $element): string => $this->richTextContentWithMaterializedInlineStyles($element),
             fn (string $html): bool => '' !== trim($this->runtime->stripAllTags($html)),
             fn (DOMElement $element): bool => $this->hasBlockContentChildren($element)
+        ));
+        $this->inlineStructureConverters = new OrderedElementConverterRegistry(array(
+            $inlineContentConverter,
+            $listConverter,
+            $descriptionListConverter,
         ));
         $this->flowContainerConverter = new FlowContainerElementConverter(new FlowContainerElementContext(
             runtimeAppShellBlock: function (DOMElement $element, array &$fallbacks): ?array {
@@ -4437,18 +4439,9 @@ final class HtmlTransformer
             return $this->buttonLinkDispatcher->convertAnchor($element, $fallbacks);
         }
 
-        if ( $this->inlineContentConverter->handles($tagName) ) {
-            return $this->inlineContentConverter->convert($element, $tagName, $fallbacks)->block;
-        }
-
-        $listDispatch = $this->listConverter->convert($element, $tagName, $fallbacks);
-        if ( $listDispatch->handled ) {
-            return $listDispatch->block;
-        }
-
-        $descriptionListDispatch = $this->descriptionListConverter->convert($element, $tagName, $fallbacks);
-        if ( $descriptionListDispatch->handled ) {
-            return $descriptionListDispatch->block;
+        $inlineStructureDispatch = $this->inlineStructureConverters->convert($element, $tagName, $fallbacks);
+        if ( $inlineStructureDispatch->handled ) {
+            return $inlineStructureDispatch->block;
         }
 
         if ( 'blockquote' === $tagName ) {

--- a/php-transformer/tests/unit/ordered-element-converter-registry.php
+++ b/php-transformer/tests/unit/ordered-element-converter-registry.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ConversionOutcome;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ElementConverter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\OrderedElementConverterRegistry;
+
+$assertions = 0;
+$failures = array();
+$assert = static function (bool $condition, string $label) use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']';
+    }
+};
+
+$document = new DOMDocument();
+$document->loadHTML('<body><div></div></body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+$element = $document->getElementsByTagName('div')->item(0);
+if ( ! $element instanceof DOMElement ) {
+    throw new RuntimeException('No element parsed');
+}
+
+$calls = array();
+$converter = static function (string $name, ConversionOutcome $outcome) use (&$calls): ElementConverter {
+    return new class($name, $outcome, $calls) implements ElementConverter {
+        /** @var array<int, string> */
+        private array $calls;
+
+        /** @param array<int, string> $calls */
+        public function __construct(
+            private readonly string $name,
+            private readonly ConversionOutcome $outcome,
+            array &$calls
+        ) {
+            $this->calls =& $calls;
+        }
+
+        public function convert(DOMElement $element, string $tagName, array &$fallbacks): ConversionOutcome
+        {
+            $this->calls[] = $this->name;
+            $fallbacks[] = array( 'converter' => $this->name );
+            return $this->outcome;
+        }
+    };
+};
+
+$fallbacks = array();
+$registry = new OrderedElementConverterRegistry(array(
+    $converter('first', ConversionOutcome::unhandled()),
+    $converter('second', ConversionOutcome::handled(array( 'blockName' => 'core/group' ))),
+    $converter('third', ConversionOutcome::handled(array( 'blockName' => 'core/paragraph' ))),
+));
+$handled = $registry->convert($element, 'div', $fallbacks);
+$assert($handled->handled && 'core/group' === ($handled->block['blockName'] ?? ''), 'first-handled-outcome-returned');
+$assert(array( 'first', 'second' ) === $calls, 'declaration-order-and-short-circuit');
+$assert(2 === count($fallbacks), 'fallback-reference-shared-through-chain');
+
+$calls = array();
+$fallbacks = array();
+$handledNull = (new OrderedElementConverterRegistry(array(
+    $converter('empty', ConversionOutcome::handled(null)),
+    $converter('late', ConversionOutcome::handled(array( 'blockName' => 'core/group' ))),
+)))->convert($element, 'div', $fallbacks);
+$assert($handledNull->handled && null === $handledNull->block, 'handled-null-preserved');
+$assert(array( 'empty' ) === $calls, 'handled-null-short-circuits');
+
+$calls = array();
+$fallbacks = array();
+$unhandled = (new OrderedElementConverterRegistry(array(
+    $converter('one', ConversionOutcome::unhandled()),
+    $converter('two', ConversionOutcome::unhandled()),
+)))->convert($element, 'div', $fallbacks);
+$assert(! $unhandled->handled && null === $unhandled->block, 'all-declined-remains-unhandled');
+$assert(array( 'one', 'two' ) === $calls, 'all-declined-runs-complete-chain');
+
+$emptyRegistry = (new OrderedElementConverterRegistry(array()))->convert($element, 'div', $fallbacks);
+$assert(! $emptyRegistry->handled, 'empty-registry-unhandled');
+
+if ( $failures ) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Ordered element converter registry tests: ' . $assertions . " passed\n";


### PR DESCRIPTION
## Summary
- formalize the shared `ElementConverter` contract used by all ten extracted element converters
- add a composable `OrderedElementConverterRegistry` that stops at the first handled outcome
- migrate the contiguous inline → list → description-list lane into one ordered registry without crossing remaining precedence barriers
- replace three transformer fields and repeated dispatch branches with one registry collaborator
- add direct coverage for overlapping converters, declined converters, handled-null short-circuiting, fallback mutation, and empty registries

## Verification
- `composer validate --strict`
- `composer test`
- PHP transformer parity: 289 fixtures
- distribution shape: 224 files, 10 monorepo-only trees excluded
- exact-base CSS-attached corpus: byte-identical records for 383 documents / 87 fixtures / 82 fixtures with CSS / 0 throws

Part of #242.

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to formalize the converter contract, implement the ordered registry and direct precedence coverage, migrate the first safe converter lane, and run package and exact-base corpus verification.