### PR TITLE
Extract quote element converter

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -172,6 +172,7 @@
             "php tests/unit/flow-container-element-converter.php",
             "php tests/unit/media-dispatch-element-converter.php",
             "php tests/unit/ordered-element-converter-registry.php",
+            "php tests/unit/quote-element-converter.php",
             "php tests/unit/form-runtime-requirement-analyzer.php",
             "php tests/unit/form-success-panel-metadata-builder.php",
             "php tests/unit/pseudo-form-analyzer.php",

--- a/php-transformer/src/HtmlToBlocks/Elements/QuoteElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/QuoteElementContext.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Closure;
+use DOMElement;
+
+/** Explicit transformer collaborator surface for {@see QuoteElementConverter}. */
+final class QuoteElementContext
+{
+    public function __construct(private readonly Closure $recognizeQuote)
+    {
+    }
+
+    /** @param array<int, array<string, mixed>> $fallbacks @return array<string, mixed>|null */
+    public function recognizeQuote(DOMElement $element, array &$fallbacks): ?array
+    {
+        return ($this->recognizeQuote)($element, $fallbacks);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Elements/QuoteElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/QuoteElementConverter.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use DOMElement;
+
+/** Converts blockquotes through the quote pattern recognizer. */
+final class QuoteElementConverter implements ElementConverter
+{
+    public function __construct(private readonly QuoteElementContext $context)
+    {
+    }
+
+    /** @param array<int, array<string, mixed>> $fallbacks */
+    public function convert(DOMElement $element, string $tagName, array &$fallbacks): ConversionOutcome
+    {
+        if ( 'blockquote' !== $tagName ) {
+            return ConversionOutcome::unhandled();
+        }
+
+        return ConversionOutcome::handled($this->context->recognizeQuote($element, $fallbacks));
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -50,6 +50,8 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ListElementConv
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\MediaDispatchElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\MediaDispatchElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\OrderedElementConverterRegistry;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\QuoteElementContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\QuoteElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\DescriptionListElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\DescriptionListElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\SvgElementContext;
@@ -284,7 +286,7 @@ final class HtmlTransformer
 
     private readonly SvgElementConverter $svgConverter;
 
-    private readonly OrderedElementConverterRegistry $inlineStructureConverters;
+    private readonly OrderedElementConverterRegistry $structuralContentConverters;
 
     private readonly NavigationToggleSuppressor $navigationToggleSuppressor;
 
@@ -317,8 +319,6 @@ final class HtmlTransformer
     private readonly ButtonLinkDispatcher $buttonLinkDispatcher;
 
     private readonly TableElementConverter $tableConverter;
-
-    private readonly FigureElementConverter $figureConverter;
 
     private readonly FlowContainerElementConverter $flowContainerConverter;
 
@@ -595,7 +595,7 @@ final class HtmlTransformer
         ));
         $this->buttonLinkDispatcher = new ButtonLinkDispatcher($this->createButtonLinkDispatchContext());
         $this->tableConverter = new TableElementConverter($this->createTableElementContext());
-        $this->figureConverter = new FigureElementConverter(new FigureElementContext(
+        $figureConverter = new FigureElementConverter(new FigureElementContext(
             function (DOMElement $element, array &$fallbacks): ?array {
                 return $this->mediaGalleryBlockFromElement($element, $fallbacks);
             },
@@ -614,6 +614,11 @@ final class HtmlTransformer
             fn (string $html): bool => '' !== trim($this->runtime->stripAllTags($html)),
             fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
             fn (string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement)
+        ));
+        $quoteConverter = new QuoteElementConverter(new QuoteElementContext(
+            function (DOMElement $element, array &$fallbacks): ?array {
+                return $this->recognizePatterns($element, $fallbacks, array( QuotePattern::class ));
+            }
         ));
         $listConverter = new ListElementConverter(new ListElementContext(
             function (DOMElement $element, array &$fallbacks, array $patterns): ?array {
@@ -651,10 +656,12 @@ final class HtmlTransformer
             fn (string $html): bool => '' !== trim($this->runtime->stripAllTags($html)),
             fn (DOMElement $element): bool => $this->hasBlockContentChildren($element)
         ));
-        $this->inlineStructureConverters = new OrderedElementConverterRegistry(array(
+        $this->structuralContentConverters = new OrderedElementConverterRegistry(array(
             $inlineContentConverter,
             $listConverter,
             $descriptionListConverter,
+            $quoteConverter,
+            $figureConverter,
         ));
         $this->flowContainerConverter = new FlowContainerElementConverter(new FlowContainerElementContext(
             runtimeAppShellBlock: function (DOMElement $element, array &$fallbacks): ?array {
@@ -4541,18 +4548,9 @@ final class HtmlTransformer
             return $this->buttonLinkDispatcher->convertAnchor($element, $fallbacks);
         }
 
-        $inlineStructureDispatch = $this->inlineStructureConverters->convert($element, $tagName, $fallbacks);
-        if ( $inlineStructureDispatch->handled ) {
-            return $inlineStructureDispatch->block;
-        }
-
-        if ( 'blockquote' === $tagName ) {
-            return $this->recognizePatterns($element, $fallbacks, array(QuotePattern::class));
-        }
-
-        $figureDispatch = $this->figureConverter->convert($element, $tagName, $fallbacks);
-        if ( $figureDispatch->handled ) {
-            return $figureDispatch->block;
+        $structuralContentDispatch = $this->structuralContentConverters->convert($element, $tagName, $fallbacks);
+        if ( $structuralContentDispatch->handled ) {
+            return $structuralContentDispatch->block;
         }
 
         if ( 'noscript' === $tagName ) {

--- a/php-transformer/tests/unit/quote-element-converter.php
+++ b/php-transformer/tests/unit/quote-element-converter.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ConversionOutcome;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ElementConverter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\OrderedElementConverterRegistry;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\QuoteElementContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\QuoteElementConverter;
+
+$assertions = 0;
+$failures = array();
+$assert = static function (bool $condition, string $label) use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']';
+    }
+};
+
+$elementFrom = static function (string $html): DOMElement {
+    $document = new DOMDocument();
+    $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+    $element = $document->getElementsByTagName('body')->item(0)?->firstElementChild;
+    if ( $element instanceof DOMElement ) {
+        return $element;
+    }
+    throw new RuntimeException('No element parsed');
+};
+
+$mode = 'quote';
+$converter = new QuoteElementConverter(new QuoteElementContext(
+    static function (DOMElement $element, array &$fallbacks) use (&$mode): ?array {
+        $fallbacks[] = array( 'quote' => true );
+        return 'quote' === $mode ? array( 'blockName' => 'core/quote' ) : null;
+    }
+));
+$fallbacks = array();
+
+$unhandled = $converter->convert($elementFrom('<div></div>'), 'div', $fallbacks);
+$assert(! $unhandled->handled && array() === $fallbacks, 'non-blockquote-unhandled');
+$quote = $converter->convert($elementFrom('<blockquote>Words</blockquote>'), 'blockquote', $fallbacks);
+$assert($quote->handled && 'core/quote' === ($quote->block['blockName'] ?? ''), 'blockquote-recognized');
+$assert(1 === count($fallbacks), 'fallback-reference-forwarded');
+
+$mode = 'declined';
+$declined = $converter->convert($elementFrom('<blockquote></blockquote>'), 'blockquote', $fallbacks);
+$assert($declined->handled && null === $declined->block, 'recognized-family-null-remains-handled');
+
+$lateCalls = 0;
+$lateConverter = new class($lateCalls) implements ElementConverter {
+    private int $calls;
+
+    public function __construct(int &$calls)
+    {
+        $this->calls =& $calls;
+    }
+
+    public function convert(DOMElement $element, string $tagName, array &$fallbacks): ConversionOutcome
+    {
+        ++$this->calls;
+        return 'figure' === $tagName
+            ? ConversionOutcome::handled(array( 'blockName' => 'core/image' ))
+            : ConversionOutcome::unhandled();
+    }
+};
+$registry = new OrderedElementConverterRegistry(array( $converter, $lateConverter ));
+$mode = 'quote';
+$registry->convert($elementFrom('<blockquote>Words</blockquote>'), 'blockquote', $fallbacks);
+$assert(0 === $lateCalls, 'quote-short-circuits-later-structural-converter');
+$figure = $registry->convert($elementFrom('<figure></figure>'), 'figure', $fallbacks);
+$assert(1 === $lateCalls && 'core/image' === ($figure->block['blockName'] ?? ''), 'quote-declines-figure-to-next-converter');
+
+if ( $failures ) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Quote element converter tests: ' . $assertions . " passed\n";


### PR DESCRIPTION
## Summary

- extract blockquote routing into `QuoteElementConverter` with an explicit `QuoteElementContext` collaborator surface
- expand the ordered structural-content registry through quote and figure conversion while preserving declaration order
- cover handled-null semantics and quote-before-figure short-circuit behavior directly

## Verification

- `composer validate --strict`
- `composer test`
- 289 PHP transformer parity fixtures
- exact-base CSS-attached corpus: 383 documents, 87 fixtures, 82 with CSS, 0 throws
- base/candidate SHA-256: `9e6452de69fbe387df3555d5dc029b346264b4695ffaf20261bf381ef4bacf70`

Part of #242.

## AI assistance

OpenAI GPT-5.6-sol via OpenCode was used to inspect the existing converter architecture, implement the extraction, add tests, and run verification. The changes and evidence were reviewed and orchestrated by Chris Huber.