### PR TITLE
Preserve UTF-8 in shared responsive shells

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -4316,10 +4316,7 @@ final class ArtifactCompiler
         foreach ($files as $file) {
             if ('html' !== ($file['kind'] ?? null) || $this->isTemplatePartFile($file) || !is_string($file['content'] ?? null) || '' === trim($file['content'])) continue;
             $dom = new \DOMDocument();
-            $previous = libxml_use_internal_errors(true);
-            $loaded = $dom->loadHTML((string) $file['content']);
-            libxml_clear_errors();
-            libxml_use_internal_errors($previous);
+            $loaded = self::loadUtf8Html($dom, (string) $file['content']);
             if (!$loaded) continue;
             $rows = array('header' => array(), 'footer' => array());
             $body = $dom->getElementsByTagName('body')->item(0);
@@ -4397,9 +4394,7 @@ final class ArtifactCompiler
     private static function normalizeSourceShellIdentity(string $markup): string
     {
         $dom = new \DOMDocument();
-        $previous = libxml_use_internal_errors(true);
-        $loaded = $dom->loadHTML('<body>' . $markup . '</body>');
-        libxml_clear_errors(); libxml_use_internal_errors($previous);
+        $loaded = self::loadUtf8Html($dom, '<body>' . $markup . '</body>');
         if (!$loaded) return $markup;
         $xpath = new \DOMXPath($dom);
         $currentNodes = array();
@@ -4423,6 +4418,14 @@ final class ArtifactCompiler
         $body = $dom->getElementsByTagName('body')->item(0);
         $root = $body instanceof \DOMElement ? $body->firstElementChild : null;
         return $root instanceof \DOMElement ? ($dom->saveHTML($root) ?: $markup) : $markup;
+    }
+
+    private static function loadUtf8Html(\DOMDocument $dom, string $html): bool
+    {
+        $previous = libxml_use_internal_errors(true);
+        $loaded = $dom->loadHTML('<?xml encoding="utf-8" ?>' . $html);
+        libxml_clear_errors(); libxml_use_internal_errors($previous);
+        return $loaded;
     }
 
     /** @param array<int,string> $markups @return array<int,string> */

--- a/php-transformer/tests/contract/shared-shell-plan.php
+++ b/php-transformer/tests/contract/shared-shell-plan.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\ContentRoundTripReporter;
 use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlan;
 
 $assert = static function (bool $condition, string $message): void { if (! $condition) throw new RuntimeException($message); };
@@ -108,6 +109,53 @@ $assert(array() === array_filter($sourceResponsiveArtifacts, static fn(array $ar
 $sourceDivergentResult = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => $sourceResponsiveHtml('Home'), 'about.html' => str_replace('Mobile header', 'Different mobile header', $sourceResponsiveHtml('About')))))->toArray();
 $sourceDivergentArtifacts = $sourceDivergentResult['source_reports']['compiled_site']['inline_shell_artifacts'] ?? array();
 $assert(!array_filter($sourceDivergentArtifacts, static fn(array $artifact): bool => 'header' === ($artifact['area'] ?? null)) && 2 === count(array_filter($sourceDivergentArtifacts, static fn(array $artifact): bool => 'footer' === ($artifact['area'] ?? null))), 'A divergent source variant rejects the complete area bundle while an independently shared area remains canonical.');
+
+$unicodeResponsiveHtml = static function (string $title, string $current): string {
+    $link = static function (string $name, string $label, string $current): string {
+        return '<a class="site-link' . ($name === $current ? ' current" aria-current="page' : '') . '" href="/' . $name . '">' . $label . '</a>';
+    };
+    return '<div class="desktop-document"><header id="κεφαλίδα-🧭" class="desktop-header"><nav>' . $link('home', 'Αρχική σελίδα', $current) . $link('about', 'Σχετικά', $current) . '</nav></header><main><h1>' . $title . '</h1></main><footer id="υποσέλιδο-©" class="desktop-footer"><p>© 2026 Café ☕</p></footer></div>'
+        . '<div class="mobile-document"><header id="μενού-📱" class="mobile-header"><p>Μενού 📱</p></header><main><h1>' . $title . ' mobile</h1></main><footer id="δικαιώματα-😀" class="mobile-footer"><p>Δικαιώματα © 😀</p></footer></div>';
+};
+$unicodeArtifact = array('entrypoint' => 'index.html', 'files' => array('index.html' => $unicodeResponsiveHtml('Home', 'home'), 'about.html' => $unicodeResponsiveHtml('About', 'about')));
+$unicodeResult = (new ArtifactCompiler())->compile($unicodeArtifact)->toArray();
+$unicodeArtifacts = array_column($unicodeResult['source_reports']['compiled_site']['inline_shell_artifacts'] ?? array(), null, 'slug');
+$unicodeRepeatArtifacts = array_column((new ArtifactCompiler())->compile($unicodeArtifact)->toArray()['source_reports']['compiled_site']['inline_shell_artifacts'] ?? array(), null, 'slug');
+$assert(array('header-1', 'header-2', 'footer-1', 'footer-2') === array_keys($unicodeArtifacts) && array_column($unicodeArtifacts, 'source_hash') === array_column($unicodeRepeatArtifacts, 'source_hash'), 'Unicode responsive shells retain deterministic identity across routes and current-navigation variants.');
+$unicodeExpected = array(
+    'header-1' => array('Αρχική σελίδα', 'Σχετικά', '"anchor":"κεφαλίδα-🧭"'),
+    'header-2' => array('Μενού 📱', '"anchor":"μενού-📱"'),
+    'footer-1' => array('© 2026 Café ☕', '"anchor":"υποσέλιδο-©"'),
+    'footer-2' => array('Δικαιώματα © 😀', '"anchor":"δικαιώματα-😀"'),
+);
+$unicodeSource = $unicodeResponsiveHtml('Home', 'home');
+$unicodeRoundTrip = new ContentRoundTripReporter();
+foreach ($unicodeExpected as $slug => $fragments) {
+    $markup = (string) ($unicodeArtifacts[$slug]['block_markup'] ?? '');
+    $roundTrip = $unicodeRoundTrip->report($markup, $unicodeSource);
+    $assert(1 === preg_match('//u', $markup) && 1 === preg_match('/^[a-f0-9]{64}$/', (string) ($unicodeArtifacts[$slug]['source_hash'] ?? '')) && !str_contains($markup, 'Îœ') && !str_contains($markup, 'Â©') && 'pass' === ($roundTrip['status'] ?? null) && array() === array_filter($fragments, static fn(string $fragment): bool => !str_contains($markup, $fragment)), "{$slug} preserves Unicode text, non-breaking spaces, emoji, symbols, and landmark attributes through shared-shell compilation: {$markup}");
+}
+$assert(!str_contains($unicodeArtifacts['header-1']['block_markup'] ?? '', 'aria-current') && !str_contains($unicodeArtifacts['header-1']['block_markup'] ?? '', ' current'), 'Unicode shell identity normalization removes only route-current navigation state.');
+foreach ($unicodeResult['source_reports']['compiled_site']['pages'] ?? array() as $unicodeCompiledPage) {
+    $markup = (string) ($unicodeCompiledPage['block_markup'] ?? '');
+    $assert(1 === preg_match('//u', $markup) && !str_contains($markup, 'Îœ') && !str_contains($markup, 'Â©'), ($unicodeCompiledPage['source_path'] ?? 'page') . ' keeps page-owned UTF-8 after shared-shell extraction.');
+}
+
+foreach ($unicodeResult['source_reports']['compiled_site']['pages'] as &$unicodePage) {
+    $title = 'index.html' === ($unicodePage['source_path'] ?? null) ? 'Home' : 'About';
+    $unicodePage['block_markup'] = '<!-- wp:group {"className":"desktop-document"} --><div class="wp-block-group desktop-document">' . $unicodeArtifacts['header-1']['block_markup'] . '<!-- wp:group {"tagName":"main"} --><main class="wp-block-group"><!-- wp:heading --><h2 class="wp-block-heading">' . $title . '</h2><!-- /wp:heading --></main><!-- /wp:group -->' . $unicodeArtifacts['footer-1']['block_markup'] . '</div><!-- /wp:group -->'
+        . '<!-- wp:group {"className":"mobile-document"} --><div class="wp-block-group mobile-document">' . $unicodeArtifacts['header-2']['block_markup'] . '<!-- wp:group {"tagName":"main"} --><main class="wp-block-group"><!-- wp:heading --><h2 class="wp-block-heading">' . $title . ' mobile</h2><!-- /wp:heading --></main><!-- /wp:group -->' . $unicodeArtifacts['footer-2']['block_markup'] . '</div><!-- /wp:group -->';
+}
+unset($unicodePage);
+$unicodePlan = (new WordPressSitePlan())->fromResult($unicodeResult);
+$unicodeParts = array_column($unicodePlan['template_parts'] ?? array(), null, 'slug');
+$unicodeWrites = $writes($unicodePlan);
+$assert(array_keys($unicodeArtifacts) === array_keys($unicodeParts), 'Every compiled Unicode responsive shell materializes as a template part.');
+foreach ($unicodeParts as $slug => $part) {
+    $content = (string) ($unicodeWrites['parts/' . $slug . '.html']['payload']['data'] ?? '');
+    $assert(1 === preg_match('//u', $content) && !str_contains($content, 'Îœ') && !str_contains($content, 'Â©') && ($part['canonical_block_markup'] ?? null) === $content && hash('sha256', $content) === ($unicodeWrites['parts/' . $slug . '.html']['payload_hash'] ?? null) && 'pass' === ($unicodeRoundTrip->report($content, $unicodeSource)['status'] ?? null), "{$slug} remains byte-identical and valid UTF-8 through template-part materialization.");
+    foreach ($unicodeExpected[$slug] as $fragment) $assert(str_contains($content, $fragment), "{$slug} materialization preserves {$fragment}.");
+}
 
 $styledSvg = '<svg viewBox="0 0 16 16"><path fill="#123456" d="M1 1h14v14H1z"/></svg>';
 $styledSvgDocument = static fn(string $title): string => '<style>.logo svg{width:100%;height:100%}</style><div class="desktop-document"><header class="desktop-header"><div class="logo">' . $styledSvg . '</div></header><main><h1>' . $title . '</h1></main></div><div class="mobile-document"><header class="mobile-header"><div class="logo">' . $styledSvg . '</div></header><main><h1>' . $title . ' mobile</h1></main></div>';


### PR DESCRIPTION
## Summary

- load shared-shell HTML through an explicit UTF-8 DOM boundary
- reuse that boundary for shell extraction and route-current identity normalization
- prove Unicode text, non-breaking spaces, emoji, symbols, IDs, hashes, and template-part materialization remain valid and deterministic

Closes #1420

## Verification

- `composer test` from `php-transformer/`
- 289 parity fixtures passed
- packaging install proof passed
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode traced mojibake to DOM encoding inference, implemented the shared UTF-8 loader, and ran the complete PHP Transformer suite under Chris Huber’s direction.