### PR TITLE
Materialize filtered inline SVG artwork

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -168,6 +168,7 @@
             "php tests/unit/figure-element-converter.php",
             "php tests/unit/list-element-converters.php",
             "php tests/unit/svg-element-converter.php",
+            "php tests/unit/filtered-svg-materialization.php",
             "php tests/unit/inline-content-element-converter.php",
             "php tests/unit/flow-container-element-converter.php",
             "php tests/unit/media-dispatch-element-converter.php",

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -12831,7 +12831,7 @@ if ( 'svg' === $tagName ) {
             || '' !== trim($this->attr($element, 'aria-labelledby'))
             || '' !== trim($this->attr($element, 'title'))
             || ! $this->hasOnlySvgDefinitions($element)
-            || $this->hiddenSvgStoreHasExternalReference($element) ) {
+            || $this->hiddenSvgStoreHasNonSvgConsumer($element) ) {
             return false;
         }
 
@@ -12874,7 +12874,7 @@ if ( 'svg' === $tagName ) {
         return $hasDefinition;
     }
 
-    private function hiddenSvgStoreHasExternalReference(DOMElement $store): bool
+    private function hiddenSvgStoreHasNonSvgConsumer(DOMElement $store): bool
     {
         $ids = array();
         foreach ( $store->getElementsByTagName('*') as $definition ) {
@@ -12892,7 +12892,9 @@ if ( 'svg' === $tagName ) {
             }
             foreach ( $candidate->attributes as $attribute ) {
                 foreach ( $ids as $id ) {
-                    if ( preg_match('/(?:^|[\\s,(])(?:url\\(\\s*["\']?#' . preg_quote($id, '/') . '["\']?\\s*\\)|#' . preg_quote($id, '/') . '(?:$|[\\s,)]))/', $attribute->value) ) {
+                    if ( preg_match('/(?:^|[\\s,(])(?:url\\(\\s*["\']?#' . preg_quote($id, '/') . '["\']?\\s*\\)|#' . preg_quote($id, '/') . '(?:$|[\\s,)]))/', $attribute->value)
+                        && 'svg' !== strtolower($candidate->tagName)
+                        && null === $this->ancestorElement($candidate, 'svg') ) {
                         return true;
                     }
                 }

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializer.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializer.php
@@ -57,12 +57,10 @@ final class SvgMaterializer implements SvgElementMaterializer
             return null;
         }
 
-        $html = $this->restoreSvgCasing(
-            $this->cssOwnsMediaBox($element)
-                ? $this->ensureInlineSvgBoxStyle($html, $element)
-                : $this->ensureInlineSvgSizing($html, $element)
-        );
-        $html = $this->inlineSvgMaterializationMarkup($this->resolveMaterializedSvgColors($html, $element), $element);
+        $html = $this->cssOwnsMediaBox($element)
+            ? $this->ensureInlineSvgBoxStyle($html, $element)
+            : $this->ensureInlineSvgSizing($html, $element);
+        $html = $this->restoreSvgCasing($this->inlineSvgMaterializationMarkup($this->resolveMaterializedSvgColors($html, $element), $element));
         $imageBlock = $this->inlineSvgImageBlockFromMarkup($element, $html);
         if ( null !== $imageBlock ) {
             return $imageBlock;
@@ -222,12 +220,11 @@ final class SvgMaterializer implements SvgElementMaterializer
             return null;
         }
 
-        $html = $this->restoreSvgCasing(
-            $this->cssOwnsMediaBox($element)
-                ? $this->ensureInlineSvgBoxStyle($html, $element)
-                : $this->ensureInlineSvgSizing($html, $element)
-        );
-        $attrs = $this->inlineSvgImageAttributesFromMarkup($element, $this->inlineSvgMaterializationMarkup($this->resolveMaterializedSvgColors($html, $element), $element), true);
+        $html = $this->cssOwnsMediaBox($element)
+            ? $this->ensureInlineSvgBoxStyle($html, $element)
+            : $this->ensureInlineSvgSizing($html, $element);
+        $html = $this->restoreSvgCasing($this->inlineSvgMaterializationMarkup($this->resolveMaterializedSvgColors($html, $element), $element));
+        $attrs = $this->inlineSvgImageAttributesFromMarkup($element, $html, true);
         if ( null === $attrs ) {
             return null;
         }
@@ -430,21 +427,25 @@ final class SvgMaterializer implements SvgElementMaterializer
      */
     private function inlineSvgMaterializationMarkup(string $html, DOMElement $element): string
     {
-        if ( ! $element->ownerDocument instanceof \DOMDocument || 0 === $element->getElementsByTagName('use')->length ) {
+        if ( ! $element->ownerDocument instanceof \DOMDocument ) {
             return $html;
         }
 
         $references = array();
-        foreach ( $element->getElementsByTagName('use') as $use ) {
-            if ( ! $use instanceof DOMElement ) {
-                continue;
+        if ( preg_match_all('/\burl\(\s*["\']?#([^\s"\')]+)["\']?\s*\)|\b(?:href|xlink:href)\s*=\s*["\']#([^"\']+)["\']/i', $html, $matches, PREG_SET_ORDER) ) {
+            foreach ( $matches as $match ) {
+                $id = trim((string) ('' !== ($match[1] ?? '') ? $match[1] : ($match[2] ?? '')));
+                if ( '' !== $id ) {
+                    $references[$id] = true;
+                }
             }
-            $href = trim($this->context->attr($use, 'href'));
-            if ( '' === $href ) {
-                $href = trim($this->context->attr($use, 'xlink:href'));
-            }
-            if ( preg_match('/^#(.+)$/', $href, $match) ) {
-                $references[$match[1]] = true;
+        }
+        if ( array() === $references ) {
+            return $html;
+        }
+        foreach ( $element->getElementsByTagName('*') as $localDefinition ) {
+            if ( $localDefinition instanceof DOMElement ) {
+                unset($references[trim($this->context->attr($localDefinition, 'id'))]);
             }
         }
         if ( array() === $references ) {
@@ -889,8 +890,8 @@ final class SvgMaterializer implements SvgElementMaterializer
 
     private function isPassiveSvgMarkup(DOMElement $element): bool
     {
-        // Full set of safe SVG structure/presentation/text elements. These carry
-        // only geometry, gradients, and text — no scripting or external embedding
+        // Full set of safe SVG structure/presentation/text/filter elements. These carry
+        // only geometry, gradients, filters, and text — no scripting or external embedding
         // (script/style/foreignObject/image are deliberately excluded and are
         // stripped by the sanitizer). <use>/<symbol> reference handling is gated
         // separately: a <use> carries href/xlink:href which isPassiveSvgElement()
@@ -898,25 +899,38 @@ final class SvgMaterializer implements SvgElementMaterializer
         // inline-preservation path (local refs) or the fallback diagnostic
         // (external sprite refs) rather than this decorative classification.
         $allowedTags = array_flip(array(
-            'circle', 'clippath', 'defs', 'desc', 'ellipse', 'fecolormatrix', 'fegaussianblur',
-            'femerge', 'femergenode', 'feoffset', 'filter', 'g', 'line', 'lineargradient',
+            'circle', 'clippath', 'defs', 'desc', 'ellipse', 'feblend', 'fecolormatrix',
+            'fecomponenttransfer', 'fecomposite', 'feconvolvematrix', 'fediffuselighting',
+            'fedisplacementmap', 'fedistantlight', 'fedropshadow', 'feflood', 'fefunca',
+            'fefuncb', 'fefuncg', 'fefuncr', 'fegaussianblur', 'feimage', 'femerge',
+            'femergenode', 'femorphology', 'feoffset', 'fepointlight', 'fespecularlighting',
+            'fespotlight', 'fetile', 'feturbulence', 'filter', 'g', 'line', 'lineargradient',
             'marker', 'mask', 'path', 'pattern', 'polygon', 'polyline', 'radialgradient',
             'rect', 'stop', 'svg', 'symbol', 'text', 'textpath', 'title', 'tspan', 'use',
         ));
         $allowedAttributes = array_flip(array(
-            'aria-hidden', 'aria-label', 'class', 'clip-path', 'clip-rule', 'cx', 'cy', 'd',
+            'amplitude', 'aria-hidden', 'aria-label', 'azimuth', 'basefrequency', 'bias',
+            'class', 'clip-path', 'clip-rule', 'color-interpolation-filters', 'cx', 'cy', 'd',
             'data-bbox', 'data-color', 'data-testid', 'data-type',
-            'dominant-baseline', 'dx', 'dy', 'enable-background', 'fill', 'fill-opacity', 'fill-rule', 'font-family',
-            'filter', 'focusable', 'font-size', 'font-style', 'font-weight', 'gradienttransform', 'gradientunits',
+            'diffuseconstant', 'divisor', 'dominant-baseline', 'dx', 'dy', 'edgemode',
+            'elevation', 'enable-background', 'exponent', 'fill', 'fill-opacity', 'fill-rule', 'flood-color',
+            'flood-opacity', 'font-family',
+            'filter', 'filterunits', 'focusable', 'font-size', 'font-style', 'font-weight', 'gradienttransform', 'gradientunits',
             'height', 'id', 'letter-spacing', 'marker-end', 'marker-mid', 'marker-start',
-            'markerheight', 'markerunits', 'markerwidth', 'mask', 'offset', 'opacity', 'orient',
+            'intercept', 'k1', 'k2', 'k3', 'k4', 'kernelmatrix', 'kernelunitlength',
+            'lighting-color', 'markerheight', 'markerunits', 'markerwidth', 'mask', 'mode',
+            'numoctaves', 'offset', 'opacity', 'operator', 'order', 'orient',
             'href', 'patterncontentunits', 'patterntransform', 'patternunits', 'points',
-            'preserveaspectratio', 'r', 'refx', 'refy', 'result', 'role', 'rotate', 'rx', 'ry',
+            'preservealpha', 'preserveaspectratio', 'primitiveunits', 'r', 'radius', 'refx', 'refy',
+            'result', 'role', 'rotate', 'rx', 'ry', 'scale', 'seed', 'slope',
+            'specularconstant', 'specularexponent',
             'spreadmethod', 'stop-color', 'stop-opacity', 'stroke', 'stroke-dasharray',
             'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit',
-            'stroke-opacity', 'stroke-width', 'stddeviation', 'style', 'text-anchor', 'transform',
-            'values', 'vector-effect', 'version', 'viewbox', 'width', 'x', 'x1', 'x2', 'xlink:href', 'xml:space',
-            'xmlns', 'xmlns:xlink', 'y', 'y1', 'y2', 'in', 'title',
+            'stitchtiles', 'stroke-opacity', 'stroke-width', 'stddeviation', 'style', 'surfacescale',
+            'tablevalues', 'targetx', 'targety', 'text-anchor', 'transform', 'type',
+            'values', 'vector-effect', 'version', 'viewbox', 'width', 'x', 'x1', 'x2',
+            'xchannelselector', 'xlink:href', 'xml:space', 'y', 'y1', 'y2', 'ychannelselector', 'in', 'in2', 'title',
+            'xmlns', 'xmlns:xlink',
         ));
 
         foreach ( $element->getElementsByTagName('*') as $child ) {

--- a/php-transformer/tests/fixtures/parity/html-filtered-svg-responsive-artwork.json
+++ b/php-transformer/tests/fixtures/parity/html-filtered-svg-responsive-artwork.json
@@ -1,0 +1,31 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-filtered-svg-responsive-artwork",
+  "description": "Materializes repeated self-contained filtered SVG artwork as portable core/image assets inside a CSS-owned responsive layout without raw HTML fallbacks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-filtered-svg-responsive-artwork.json",
+    "notes": "Generic repeated portrait artwork covering standard component-transfer filter primitives and responsive selector ownership."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<style>.portrait-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:1rem}.portrait-art{width:100%;height:auto}@media(max-width:600px){.portrait-grid{grid-template-columns:1fr}}</style><main><div class=\"portrait-grid\"><svg class=\"portrait-art\" role=\"img\" aria-label=\"First portrait\" viewBox=\"0 0 100 80\"><defs><filter id=\"portrait-tone\"><feComponentTransfer result=\"srcRGB\"></feComponentTransfer><feColorMatrix in=\"srcRGB\" type=\"saturate\" values=\"0\"></feColorMatrix><feComponentTransfer><feFuncR type=\"linear\" slope=\"1.1\" intercept=\"-0.05\"></feFuncR><feFuncG type=\"linear\" slope=\"1.1\" intercept=\"-0.05\"></feFuncG><feFuncB type=\"linear\" slope=\"1.1\" intercept=\"-0.05\"></feFuncB></feComponentTransfer></filter></defs><rect width=\"100\" height=\"80\" filter=\"url(#portrait-tone)\"></rect></svg><svg class=\"portrait-art\" role=\"img\" aria-label=\"Second portrait\" viewBox=\"0 0 100 80\"><defs><filter id=\"portrait-tone\"><feComponentTransfer result=\"srcRGB\"></feComponentTransfer><feColorMatrix in=\"srcRGB\" type=\"saturate\" values=\"0\"></feColorMatrix><feComponentTransfer><feFuncR type=\"linear\" slope=\"1.1\" intercept=\"-0.05\"></feFuncR><feFuncG type=\"linear\" slope=\"1.1\" intercept=\"-0.05\"></feFuncG><feFuncB type=\"linear\" slope=\"1.1\" intercept=\"-0.05\"></feFuncB></feComponentTransfer></filter></defs><rect width=\"100\" height=\"80\" filter=\"url(#portrait-tone)\"></rect></svg></div></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0.innerBlocks.0", "name": "core/image", "attrs": { "alt": "First portrait" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/image", "attrs": { "alt": "Second portrait" } }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:html" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "portrait-grid" },
+    { "path": "assets.0.content", "assert": "contains", "value": "<feComponentTransfer" },
+    { "path": "assets.0.content", "assert": "contains", "value": "type=\"saturate\"" },
+    { "path": "assets.0.mime_type", "assert": "equals", "value": "image/svg+xml" },
+    { "path": "source_reports.wp_block_validity.status", "assert": "equals", "value": "pass" }
+  ]
+}

--- a/php-transformer/tests/unit/filtered-svg-materialization.php
+++ b/php-transformer/tests/unit/filtered-svg-materialization.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$assertions = 0;
+$assert = static function (bool $condition, string $message) use (&$assertions): void {
+    ++$assertions;
+    if (!$condition) {
+        fwrite(STDERR, 'FAIL: ' . $message . PHP_EOL);
+        exit(1);
+    }
+};
+
+$filter = '<filter id="portrait-tone" filterUnits="objectBoundingBox"><feComponentTransfer result="srcRGB"></feComponentTransfer><feColorMatrix in="srcRGB" type="saturate" values="0"></feColorMatrix><feComponentTransfer><feFuncR type="linear" slope="1.1" intercept="-0.05"></feFuncR><feFuncG type="linear" slope="1.1" intercept="-0.05"></feFuncG><feFuncB type="linear" slope="1.1" intercept="-0.05"></feFuncB></feComponentTransfer></filter>';
+$artwork = static fn(string $label, bool $includeFilter = true): string => '<svg class="portrait-art" role="img" aria-label="' . $label . '" viewBox="0 0 100 80"><defs>' . ($includeFilter ? $filter : '') . '</defs><rect width="100" height="80" filter="url(#portrait-tone)"></rect></svg>';
+
+$filtered = (new HtmlTransformer())->transform('<style>.portrait-grid{display:grid;grid-template-columns:repeat(2,1fr)}.portrait-art{width:100%;height:auto}@media(max-width:600px){.portrait-grid{grid-template-columns:1fr}}</style><main><div class="portrait-grid">' . $artwork('First portrait') . $artwork('Second portrait') . '</div></main>')->toArray();
+$filteredMarkup = (string) ($filtered['serialized_blocks'] ?? '');
+$filteredAssets = array_values(array_filter($filtered['assets'] ?? array(), static fn(array $asset): bool => 'inline-svg' === ($asset['source'] ?? null)));
+$assert(!str_contains($filteredMarkup, '<!-- wp:html'), 'Repeated filtered artwork uses typed blocks without raw HTML.');
+$assert(2 === substr_count($filteredMarkup, '<!-- wp:image'), 'Each filtered artwork instance remains an editable image block.');
+$assert(1 === count($filteredAssets), 'Equivalent filtered artwork shares one portable SVG asset.');
+$assert(str_contains((string) ($filteredAssets[0]['content'] ?? ''), '<feComponentTransfer') && str_contains((string) ($filteredAssets[0]['content'] ?? ''), 'filterUnits="objectBoundingBox"'), 'Filter primitives and canonical casing survive asset materialization.');
+$assert(str_contains($filteredMarkup, 'portrait-art') && str_contains($filteredMarkup, 'First portrait') && str_contains($filteredMarkup, 'Second portrait'), 'Selectors and per-instance accessibility labels survive typed conversion.');
+$assert('pass' === ($filtered['source_reports']['wp_block_validity']['status'] ?? null), 'Filtered image blocks are Gutenberg-valid.');
+
+$documentFilter = (new HtmlTransformer())->transform('<main><svg data-dom-store style="display:none"><defs id="document-definitions">' . $filter . '</defs></svg>' . $artwork('Document portrait', false) . '</main>')->toArray();
+$documentMarkup = (string) ($documentFilter['serialized_blocks'] ?? '');
+$documentAsset = (string) ($documentFilter['assets'][0]['content'] ?? '');
+$assert(!str_contains($documentMarkup, '<!-- wp:html') && 1 === substr_count($documentMarkup, '<!-- wp:image'), 'An SVG-only document definition store is replaced by its typed image consumer.');
+$assert(str_contains($documentAsset, '<defs id="document-definitions">') && str_contains($documentAsset, '<feFuncR'), 'Document-level filter definitions are hydrated into the standalone SVG document.');
+$assert(!str_contains($documentAsset, 'data-dom-store'), 'The hidden document store is not retained in the portable asset.');
+
+$cssConsumer = (new HtmlTransformer())->transform('<style>.filtered-panel{filter:url(#portrait-tone)}</style><svg data-dom-store style="display:none"><defs>' . $filter . '</defs></svg><div class="filtered-panel">Panel</div>')->toArray();
+$assert(str_contains((string) ($cssConsumer['serialized_blocks'] ?? ''), '<!-- wp:html'), 'A definition store with a non-SVG CSS consumer remains in document context.');
+
+$external = (new HtmlTransformer())->transform('<svg viewBox="0 0 10 10"><use href="sprite.svg#mark"></use></svg>')->toArray();
+$assert(!str_contains((string) ($external['serialized_blocks'] ?? ''), '<!-- wp:image') && 'html_inline_svg_fallback' === ($external['fallbacks'][0]['diagnostic_code'] ?? null), 'External-document SVG references still fail closed with an explicit diagnostic.');
+
+$scriptOnly = (new HtmlTransformer())->transform('<main><svg><script>alert(1)</script></svg></main>')->toArray();
+$assert('html_unsafe_inline_svg' === ($scriptOnly['fallbacks'][0]['diagnostic_code'] ?? null) && !str_contains((string) ($scriptOnly['serialized_blocks'] ?? ''), '<!-- wp:image'), 'Script-only SVG fails closed without a typed image.');
+
+$javascriptHref = (new HtmlTransformer())->transform('<main><svg><use href="javascript:alert(1)"></use></svg></main>')->toArray();
+$assert('html_unsafe_inline_svg' === ($javascriptHref['fallbacks'][0]['diagnostic_code'] ?? null) && !str_contains((string) ($javascriptHref['serialized_blocks'] ?? ''), 'javascript:'), 'javascript: SVG references fail closed and do not leak into markup.');
+
+$eventHandler = (new HtmlTransformer())->transform('<main><svg onload="alert(1)"></svg></main>')->toArray();
+$assert('html_unsafe_inline_svg' === ($eventHandler['fallbacks'][0]['diagnostic_code'] ?? null) && !str_contains((string) ($eventHandler['serialized_blocks'] ?? ''), 'onload='), 'Event-handler SVG fails closed without leaking handlers.');
+
+fwrite(STDOUT, 'Filtered SVG materialization tests: ' . $assertions . " passed\n");

--- a/php-transformer/tests/unit/inert-capture-scaffolding.php
+++ b/php-transformer/tests/unit/inert-capture-scaffolding.php
@@ -25,7 +25,7 @@ $assert(array() === ($unreferencedStore['fallbacks'] ?? array()), 'hidden unrefe
 $assert(! str_contains((string) ($unreferencedStore['serialized_blocks'] ?? ''), 'unused'), 'hidden unreferenced SVG store emits no raw HTML');
 
 $referencedStore = $transform('<main><svg data-dom-store style="display:none"><defs><symbol id="mark"><path d="M0 0h1v1z"/></symbol></defs></svg><svg viewBox="0 0 1 1"><use href="#mark"/></svg></main>');
-$assert(str_contains((string) ($referencedStore['serialized_blocks'] ?? ''), 'id="mark"'), 'referenced SVG store remains available');
+$assert(! str_contains((string) ($referencedStore['serialized_blocks'] ?? ''), '<!-- wp:html') && str_contains((string) ($referencedStore['serialized_blocks'] ?? ''), 'assets/materialized-svg/'), 'referenced SVG store hydrates a typed image instead of remaining raw HTML');
 $materializedSvg = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), array_filter($referencedStore['assets'] ?? array(), static fn (array $asset): bool => 'inline-svg' === ($asset['source'] ?? ''))));
 $assert(str_contains($materializedSvg, 'id="mark"') && str_contains($materializedSvg, 'href="#mark"'), 'referenced SVG symbols remain available to materialized images');
 
@@ -34,7 +34,8 @@ $conditionalStore = $transform($conditionalStyles . '<main><svg data-dom-store s
 $assert(! str_contains((string) ($conditionalStore['serialized_blocks'] ?? ''), 'conditional-unused'), 'unreferenced data DOM store stays inert under conditional SVG styles');
 
 $conditionalReferencedStore = $transform($conditionalStyles . '<main><svg data-dom-store style="display:none"><defs><symbol id="conditional-mark"><path d="M0 0h1v1z"/></symbol></defs></svg><svg viewBox="0 0 1 1"><use href="#conditional-mark"/></svg></main>');
-$assert(str_contains((string) ($conditionalReferencedStore['serialized_blocks'] ?? ''), 'conditional-mark'), 'referenced data DOM store survives conditional SVG styles');
+$conditionalReferencedSvg = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), array_filter($conditionalReferencedStore['assets'] ?? array(), static fn (array $asset): bool => 'inline-svg' === ($asset['source'] ?? ''))));
+$assert(str_contains($conditionalReferencedSvg, 'conditional-mark') && ! str_contains((string) ($conditionalReferencedStore['serialized_blocks'] ?? ''), '<!-- wp:html'), 'referenced data DOM store hydrates its consumer image under conditional SVG styles');
 
 $conditionalOrdinaryStore = $transform($conditionalStyles . '<main><svg style="display:none"><defs><symbol id="ordinary-store"><path d="M0 0h1v1z"/></symbol></defs></svg><p>Visible copy</p></main>');
 $conditionalOrdinarySvg = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), array_filter($conditionalOrdinaryStore['assets'] ?? array(), static fn (array $asset): bool => 'inline-svg' === ($asset['source'] ?? ''))));


### PR DESCRIPTION
## Summary

- hydrate local SVG filter and definition references into self-contained typed image assets
- expand passive filter primitive support while rejecting scripts, external references, event handlers, and unsafe URLs
- remove hidden definition stores and `core/html` fallback after typed consumer materialization

Closes #1421

## Verification

- `composer test` from `php-transformer/`
- filtered SVG materialization: 14 assertions passed
- 290 parity fixtures passed
- packaging install proof passed
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode traced filtered SVG fallback boundaries, implemented safe local-definition hydration and typed materialization, and ran the complete PHP Transformer suite under Chris Huber’s direction.