### PR TITLE
Compose parameter table element conversion

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -173,6 +173,7 @@
             "php tests/unit/flow-container-element-converter.php",
             "php tests/unit/media-dispatch-element-converter.php",
             "php tests/unit/ordered-element-converter-registry.php",
+            "php tests/unit/pattern-element-converter.php",
             "php tests/unit/quote-element-converter.php",
             "php tests/unit/form-runtime-requirement-analyzer.php",
             "php tests/unit/form-success-panel-metadata-builder.php",

--- a/php-transformer/src/HtmlToBlocks/Elements/PatternElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/PatternElementContext.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Closure;
+use DOMElement;
+
+/** Explicit transformer collaborator surface for {@see PatternElementConverter}. */
+final class PatternElementContext
+{
+    public function __construct(private readonly Closure $recognizePatterns)
+    {
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @param array<int, class-string> $patterns
+     * @return array<string, mixed>|null
+     */
+    public function recognizePatterns(DOMElement $element, array &$fallbacks, array $patterns): ?array
+    {
+        return ($this->recognizePatterns)($element, $fallbacks, $patterns);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Elements/PatternElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/PatternElementConverter.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use DOMElement;
+use InvalidArgumentException;
+
+/** Offers elements to a bounded set of pattern recognizers. */
+final class PatternElementConverter implements ElementConverter
+{
+    /** @param array<int, class-string> $patterns */
+    public function __construct(
+        private readonly PatternElementContext $context,
+        private readonly array $patterns
+    ) {
+        if ( array() === $patterns ) {
+            throw new InvalidArgumentException('PatternElementConverter requires at least one pattern.');
+        }
+    }
+
+    /** @param array<int, array<string, mixed>> $fallbacks */
+    public function convert(DOMElement $element, string $tagName, array &$fallbacks): ConversionOutcome
+    {
+        $block = $this->context->recognizePatterns($element, $fallbacks, $this->patterns);
+
+        return null === $block
+            ? ConversionOutcome::unhandled()
+            : ConversionOutcome::handled($block);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -50,6 +50,8 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ListElementConv
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\MediaDispatchElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\MediaDispatchElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\OrderedElementConverterRegistry;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\PatternElementContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\PatternElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\QuoteElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\QuoteElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\DescriptionListElementContext;
@@ -318,7 +320,7 @@ final class HtmlTransformer
 
     private readonly ButtonLinkDispatcher $buttonLinkDispatcher;
 
-    private readonly TableElementConverter $tableConverter;
+    private readonly OrderedElementConverterRegistry $tableConverters;
 
     private readonly FlowContainerElementConverter $flowContainerConverter;
 
@@ -594,7 +596,19 @@ final class HtmlTransformer
             fn (DOMElement $element): bool => $this->pseudoFormAnalyzer->isPseudoForm($element)
         ));
         $this->buttonLinkDispatcher = new ButtonLinkDispatcher($this->createButtonLinkDispatchContext());
-        $this->tableConverter = new TableElementConverter($this->createTableElementContext());
+        $tableConverter = new TableElementConverter($this->createTableElementContext());
+        $parameterTableConverter = new PatternElementConverter(
+            new PatternElementContext(
+                function (DOMElement $element, array &$fallbacks, array $patterns): ?array {
+                    return $this->recognizePatterns($element, $fallbacks, $patterns);
+                }
+            ),
+            array( ParameterTablePattern::class )
+        );
+        $this->tableConverters = new OrderedElementConverterRegistry(array(
+            $tableConverter,
+            $parameterTableConverter,
+        ));
         $figureConverter = new FigureElementConverter(new FigureElementContext(
             function (DOMElement $element, array &$fallbacks): ?array {
                 return $this->mediaGalleryBlockFromElement($element, $fallbacks);
@@ -4569,13 +4583,9 @@ final class HtmlTransformer
             return $this->textLeafConverter->convert($element, $tagName, $fallbacks)->block;
         }
 
-        if ( $this->tableConverter->handles($tagName) ) {
-            return $this->tableConverter->convert($element, $tagName, $fallbacks)->block;
-        }
-
-        $parameterTable = $this->recognizePatterns($element, $fallbacks, array(ParameterTablePattern::class));
-        if ( null !== $parameterTable ) {
-            return $parameterTable;
+        $tableDispatch = $this->tableConverters->convert($element, $tagName, $fallbacks);
+        if ( $tableDispatch->handled ) {
+            return $tableDispatch->block;
         }
 
         if ( 'hr' === $tagName || 'br' === $tagName ) {

--- a/php-transformer/tests/unit/pattern-element-converter.php
+++ b/php-transformer/tests/unit/pattern-element-converter.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ConversionOutcome;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ElementConverter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\OrderedElementConverterRegistry;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\PatternElementContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\PatternElementConverter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ParameterTablePattern;
+
+$assertions = 0;
+$failures = array();
+$assert = static function (bool $condition, string $label) use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']';
+    }
+};
+
+$document = new DOMDocument();
+$document->loadHTML('<?xml encoding="utf-8" ?><body><div class="param-table"></div><table></table></body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+$div = $document->getElementsByTagName('div')->item(0);
+$table = $document->getElementsByTagName('table')->item(0);
+if ( ! $div instanceof DOMElement || ! $table instanceof DOMElement ) {
+    throw new RuntimeException('Fixture elements not parsed');
+}
+
+$mode = 'match';
+$seenPatterns = array();
+$converter = new PatternElementConverter(
+    new PatternElementContext(
+        static function (DOMElement $element, array &$fallbacks, array $patterns) use (&$mode, &$seenPatterns): ?array {
+            $seenPatterns = $patterns;
+            $fallbacks[] = array( 'pattern' => true );
+            return 'match' === $mode ? array( 'blockName' => 'core/table' ) : null;
+        }
+    ),
+    array( ParameterTablePattern::class )
+);
+$fallbacks = array();
+$matched = $converter->convert($div, 'div', $fallbacks);
+$assert($matched->handled && 'core/table' === ($matched->block['blockName'] ?? ''), 'recognized-pattern-handled');
+$assert(array( ParameterTablePattern::class ) === $seenPatterns, 'bounded-pattern-list-forwarded');
+$assert(1 === count($fallbacks), 'fallback-reference-forwarded');
+
+$mode = 'decline';
+$assert(! $converter->convert($div, 'div', $fallbacks)->handled, 'declined-pattern-unhandled');
+
+$nativeCalls = 0;
+$nativeTable = new class($nativeCalls) implements ElementConverter {
+    private int $calls;
+
+    public function __construct(int &$calls)
+    {
+        $this->calls =& $calls;
+    }
+
+    public function convert(DOMElement $element, string $tagName, array &$fallbacks): ConversionOutcome
+    {
+        if ( 'table' !== $tagName ) {
+            return ConversionOutcome::unhandled();
+        }
+        ++$this->calls;
+        return ConversionOutcome::handled(array( 'blockName' => 'core/table', 'attrs' => array( 'native' => true ) ));
+    }
+};
+$mode = 'match';
+$registry = new OrderedElementConverterRegistry(array( $nativeTable, $converter ));
+$native = $registry->convert($table, 'table', $fallbacks);
+$assert(1 === $nativeCalls && true === ($native->block['attrs']['native'] ?? false), 'native-table-precedes-pattern');
+$pattern = $registry->convert($div, 'div', $fallbacks);
+$assert($pattern->handled && 'core/table' === ($pattern->block['blockName'] ?? ''), 'non-table-reaches-pattern');
+
+try {
+    new PatternElementConverter(new PatternElementContext(static fn (): ?array => null), array());
+    $assert(false, 'empty-pattern-list-rejected');
+} catch (InvalidArgumentException) {
+    $assert(true, 'empty-pattern-list-rejected');
+}
+
+if ( $failures ) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Pattern element converter tests: ' . $assertions . " passed\n";


### PR DESCRIPTION
## Summary

- add a reusable `PatternElementConverter` with an explicit pattern-recognition context
- compose native/layout table conversion before `.param-table` recognition in an ordered table registry
- preserve declined-pattern fallthrough and directly cover native-table precedence

## Verification

- `composer validate --strict`
- `composer test`
- 292 PHP transformer parity fixtures
- exact-base CSS-attached corpus: 383 documents, 87 fixtures, 82 with CSS, 0 throws
- base/candidate SHA-256: `6f0fd03d6eaa5b9683919e19a0a44eb652f7517373b91c4de3880ac9055ab04f`

Part of #242.

## AI assistance

OpenAI GPT-5.6-sol via OpenCode was used to inspect pattern dispatch semantics, implement the reusable converter and ordered table lane, add tests, and run verification. The changes and evidence were reviewed and orchestrated by Chris Huber.