### PR TITLE
Extract details element converter

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -174,6 +174,7 @@
             "php tests/unit/media-dispatch-element-converter.php",
             "php tests/unit/ordered-element-converter-registry.php",
             "php tests/unit/pattern-element-converter.php",
+            "php tests/unit/details-element-converter.php",
             "php tests/unit/quote-element-converter.php",
             "php tests/unit/form-runtime-requirement-analyzer.php",
             "php tests/unit/form-success-panel-metadata-builder.php",

--- a/php-transformer/src/HtmlToBlocks/Elements/DetailsElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/DetailsElementContext.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Closure;
+use DOMElement;
+
+/** Explicit transformer collaborator surface for {@see DetailsElementConverter}. */
+final class DetailsElementContext
+{
+    public function __construct(
+        private readonly Closure $capturedDisclosureDialog,
+        private readonly Closure $capturedDialogBlock,
+        private readonly Closure $recognizePatterns
+    ) {
+    }
+
+    public function capturedDisclosureDialog(DOMElement $element): ?DOMElement
+    {
+        return ($this->capturedDisclosureDialog)($element);
+    }
+
+    /** @param array<int, array<string, mixed>> $fallbacks @return array<string, mixed> */
+    public function capturedDialogBlock(DOMElement $element, array &$fallbacks): array
+    {
+        return ($this->capturedDialogBlock)($element, $fallbacks);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @param array<int, class-string> $patterns
+     * @return array<string, mixed>|null
+     */
+    public function recognizePatterns(DOMElement $element, array &$fallbacks, array $patterns): ?array
+    {
+        return ($this->recognizePatterns)($element, $fallbacks, $patterns);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Elements/DetailsElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/DetailsElementConverter.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\DetailsPattern;
+use DOMElement;
+
+/** Converts native disclosures while preserving captured-dialog precedence. */
+final class DetailsElementConverter implements ElementConverter
+{
+    public function __construct(private readonly DetailsElementContext $context)
+    {
+    }
+
+    /** @param array<int, array<string, mixed>> $fallbacks */
+    public function convert(DOMElement $element, string $tagName, array &$fallbacks): ConversionOutcome
+    {
+        if ( 'details' !== $tagName ) {
+            return ConversionOutcome::unhandled();
+        }
+
+        $capturedDialog = $this->context->capturedDisclosureDialog($element);
+        if ( $capturedDialog instanceof DOMElement ) {
+            return ConversionOutcome::handled($this->context->capturedDialogBlock($capturedDialog, $fallbacks));
+        }
+
+        return ConversionOutcome::handled(
+            $this->context->recognizePatterns($element, $fallbacks, array( DetailsPattern::class ))
+        );
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -56,6 +56,8 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\QuoteElementCon
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\QuoteElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\DescriptionListElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\DescriptionListElementConverter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\DetailsElementContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\DetailsElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\SvgElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\SvgElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\InlineContentElementContext;
@@ -87,7 +89,6 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\AccordionPatter
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ButtonPatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CodeWindowPatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ColumnsPatternContext;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\DetailsPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\GalleryPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\GalleryPatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\LogoPatternContext;
@@ -321,6 +322,8 @@ final class HtmlTransformer
     private readonly ButtonLinkDispatcher $buttonLinkDispatcher;
 
     private readonly OrderedElementConverterRegistry $tableConverters;
+
+    private readonly DetailsElementConverter $detailsConverter;
 
     private readonly FlowContainerElementConverter $flowContainerConverter;
 
@@ -596,6 +599,15 @@ final class HtmlTransformer
             fn (DOMElement $element): bool => $this->pseudoFormAnalyzer->isPseudoForm($element)
         ));
         $this->buttonLinkDispatcher = new ButtonLinkDispatcher($this->createButtonLinkDispatchContext());
+        $this->detailsConverter = new DetailsElementConverter(new DetailsElementContext(
+            fn (DOMElement $element): ?DOMElement => $this->capturedDisclosureDialog($element),
+            function (DOMElement $element, array &$fallbacks): array {
+                return $this->capturedDialogBlock($element, $fallbacks);
+            },
+            function (DOMElement $element, array &$fallbacks, array $patterns): ?array {
+                return $this->recognizePatterns($element, $fallbacks, $patterns);
+            }
+        ));
         $tableConverter = new TableElementConverter($this->createTableElementContext());
         $parameterTableConverter = new PatternElementConverter(
             new PatternElementContext(
@@ -4592,13 +4604,9 @@ final class HtmlTransformer
             return $this->textLeafConverter->convert($element, $tagName, $fallbacks)->block;
         }
 
-        if ( 'details' === $tagName ) {
-            $capturedDisclosureDialog = $this->capturedDisclosureDialog($element);
-            if ( $capturedDisclosureDialog instanceof DOMElement ) {
-                return $this->capturedDialogBlock($capturedDisclosureDialog, $fallbacks);
-            }
-
-            return $this->recognizePatterns($element, $fallbacks, array(DetailsPattern::class));
+        $detailsDispatch = $this->detailsConverter->convert($element, $tagName, $fallbacks);
+        if ( $detailsDispatch->handled ) {
+            return $detailsDispatch->block;
         }
 
         if ( 'a' === $tagName ) {

--- a/php-transformer/tests/unit/details-element-converter.php
+++ b/php-transformer/tests/unit/details-element-converter.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\DetailsElementContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\DetailsElementConverter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\DetailsPattern;
+
+$assertions = 0;
+$failures = array();
+$assert = static function (bool $condition, string $label) use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']';
+    }
+};
+
+$document = new DOMDocument();
+$document->loadHTML('<?xml encoding="utf-8" ?><body><details><summary>More</summary></details><dialog></dialog><div></div></body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+$details = $document->getElementsByTagName('details')->item(0);
+$dialog = $document->getElementsByTagName('dialog')->item(0);
+$div = $document->getElementsByTagName('div')->item(0);
+if ( ! $details instanceof DOMElement || ! $dialog instanceof DOMElement || ! $div instanceof DOMElement ) {
+    throw new RuntimeException('Fixture elements not parsed');
+}
+
+$captured = false;
+$patternCalls = 0;
+$seenPatterns = array();
+$patternBlock = array( 'blockName' => 'core/details' );
+$converter = new DetailsElementConverter(new DetailsElementContext(
+    static function (DOMElement $element) use (&$captured, $dialog): ?DOMElement {
+        return $captured ? $dialog : null;
+    },
+    static function (DOMElement $element, array &$fallbacks): array {
+        $fallbacks[] = array( 'captured' => true );
+        return array( 'blockName' => 'core/html', 'attrs' => array( 'captured' => $element->tagName ) );
+    },
+    static function (DOMElement $element, array &$fallbacks, array $patterns) use (&$patternCalls, &$seenPatterns, &$patternBlock): ?array {
+        ++$patternCalls;
+        $seenPatterns = $patterns;
+        $fallbacks[] = array( 'pattern' => true );
+        return $patternBlock;
+    }
+));
+$fallbacks = array();
+
+$unhandled = $converter->convert($div, 'div', $fallbacks);
+$assert(! $unhandled->handled && 0 === $patternCalls, 'non-details-unhandled');
+
+$recognized = $converter->convert($details, 'details', $fallbacks);
+$assert($recognized->handled && 'core/details' === ($recognized->block['blockName'] ?? ''), 'details-pattern-recognized');
+$assert(array( DetailsPattern::class ) === $seenPatterns, 'details-pattern-bounded');
+$assert(1 === count($fallbacks), 'pattern-fallback-reference-forwarded');
+
+$captured = true;
+$projected = $converter->convert($details, 'details', $fallbacks);
+$assert('dialog' === ($projected->block['attrs']['captured'] ?? '') && 1 === $patternCalls, 'captured-dialog-precedes-pattern');
+$assert(2 === count($fallbacks), 'captured-fallback-reference-forwarded');
+
+$captured = false;
+$patternBlock = null;
+$declined = $converter->convert($details, 'details', $fallbacks);
+$assert($declined->handled && null === $declined->block, 'details-null-remains-handled');
+
+if ( $failures ) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Details element converter tests: ' . $assertions . " passed\n";


### PR DESCRIPTION
## Summary

- extract native disclosure routing into `DetailsElementConverter` with an explicit collaborator context
- preserve captured-dialog projection before ordinary `DetailsPattern` recognition
- directly cover non-details fallthrough, captured precedence, fallback references, and handled-null semantics

## Verification

- `composer validate --strict`
- `composer test`
- 292 PHP transformer parity fixtures
- exact-base CSS-attached corpus: 383 documents, 87 fixtures, 82 with CSS, 0 throws
- base/candidate SHA-256: `6f0fd03d6eaa5b9683919e19a0a44eb652f7517373b91c4de3880ac9055ab04f`

Part of #242.

## AI assistance

OpenAI GPT-5.6-sol via OpenCode was used to inspect disclosure dispatch semantics, implement the extraction, add tests, and run verification. The changes and evidence were reviewed and orchestrated by Chris Huber.