### PR TITLE
Extract button element converter

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -180,7 +180,8 @@
             "php tests/unit/form-success-panel-metadata-builder.php",
             "php tests/unit/pseudo-form-analyzer.php",
             "php tests/unit/runtime-island-analyzer.php",
-            "php tests/unit/button-link-dispatcher.php"
+            "php tests/unit/button-link-dispatcher.php",
+            "php tests/unit/button-element-converter.php"
     ],
     "test:parity": "php tests/parity/run.php",
     "test:migration:examples": "php tests/migration/examples.php",

--- a/php-transformer/src/HtmlToBlocks/Elements/ButtonElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/ButtonElementContext.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Closure;
+use DOMElement;
+
+/** Explicit transformer collaborator surface for {@see ButtonElementConverter}. */
+final class ButtonElementContext
+{
+    public function __construct(
+        private readonly Closure $isReplacedSearchClusterControl,
+        private readonly Closure $isImageCarrierButton,
+        private readonly Closure $convertChildren,
+        private readonly Closure $presentationAttributes,
+        private readonly Closure $createBlock,
+        private readonly Closure $convertButton
+    ) {
+    }
+
+    public function isReplacedSearchClusterControl(DOMElement $element): bool
+    {
+        return ($this->isReplacedSearchClusterControl)($element);
+    }
+
+    public function isImageCarrierButton(DOMElement $element): bool
+    {
+        return ($this->isImageCarrierButton)($element);
+    }
+
+    /** @param array<int, array<string, mixed>> $fallbacks @return array<int, array<string, mixed>> */
+    public function convertChildren(DOMElement $element, array &$fallbacks, bool $captureUnsupported): array
+    {
+        return ($this->convertChildren)($element, $fallbacks, $captureUnsupported);
+    }
+
+    /** @return array<string, mixed> */
+    public function presentationAttributes(DOMElement $element): array
+    {
+        return ($this->presentationAttributes)($element);
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     * @param array<int, array<string, mixed>> $innerBlocks
+     * @return array<string, mixed>
+     */
+    public function createBlock(string $name, array $attributes, array $innerBlocks, DOMElement $element): array
+    {
+        return ($this->createBlock)($name, $attributes, $innerBlocks, $element);
+    }
+
+    /** @return array<string, mixed>|null */
+    public function convertButton(DOMElement $element): ?array
+    {
+        return ($this->convertButton)($element);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Elements/ButtonElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/ButtonElementConverter.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use DOMElement;
+
+/** Converts buttons through search, image-carrier, and generic precedence. */
+final class ButtonElementConverter implements ElementConverter
+{
+    public function __construct(private readonly ButtonElementContext $context)
+    {
+    }
+
+    /** @param array<int, array<string, mixed>> $fallbacks */
+    public function convert(DOMElement $element, string $tagName, array &$fallbacks): ConversionOutcome
+    {
+        if ( 'button' !== $tagName ) {
+            return ConversionOutcome::unhandled();
+        }
+
+        if ( $this->context->isReplacedSearchClusterControl($element) ) {
+            return ConversionOutcome::handled(null);
+        }
+
+        if ( $this->context->isImageCarrierButton($element) ) {
+            $children = $this->context->convertChildren($element, $fallbacks, true);
+            if ( array() !== $children ) {
+                return ConversionOutcome::handled(
+                    $this->context->createBlock(
+                        'core/group',
+                        $this->context->presentationAttributes($element),
+                        $children,
+                        $element
+                    )
+                );
+            }
+        }
+
+        return ConversionOutcome::handled($this->context->convertButton($element));
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -32,6 +32,8 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\ResponsiveMed
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\VisualIframeBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolutionContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolver;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonElementContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispatchContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispatcher;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\AuthoredFormControlBlockConverter;
@@ -321,6 +323,8 @@ final class HtmlTransformer
 
     private readonly ButtonLinkDispatcher $buttonLinkDispatcher;
 
+    private readonly ButtonElementConverter $buttonConverter;
+
     private readonly OrderedElementConverterRegistry $tableConverters;
 
     private readonly DetailsElementConverter $detailsConverter;
@@ -599,6 +603,16 @@ final class HtmlTransformer
             fn (DOMElement $element): bool => $this->pseudoFormAnalyzer->isPseudoForm($element)
         ));
         $this->buttonLinkDispatcher = new ButtonLinkDispatcher($this->createButtonLinkDispatchContext());
+        $this->buttonConverter = new ButtonElementConverter(new ButtonElementContext(
+            fn (DOMElement $element): bool => $this->searchBlockConverter->isReplacedSearchClusterControl($element),
+            fn (DOMElement $element): bool => $this->isImageCarrierButton($element),
+            function (DOMElement $element, array &$fallbacks, bool $captureUnsupported): array {
+                return $this->convertChildren($element, $fallbacks, $captureUnsupported);
+            },
+            fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
+            fn (string $name, array $attributes, array $innerBlocks, DOMElement $element): array => $this->createBlock($name, $attributes, $innerBlocks, $element),
+            fn (DOMElement $element): ?array => $this->buttonLinkDispatcher->convertButton($element)
+        ));
         $this->detailsConverter = new DetailsElementConverter(new DetailsElementContext(
             fn (DOMElement $element): ?DOMElement => $this->capturedDisclosureDialog($element),
             function (DOMElement $element, array &$fallbacks): array {
@@ -4609,24 +4623,12 @@ final class HtmlTransformer
             return $detailsDispatch->block;
         }
 
-        if ( 'a' === $tagName ) {
-            return $this->buttonLinkDispatcher->convertAnchor($element, $fallbacks);
+        $buttonDispatch = $this->buttonConverter->convert($element, $tagName, $fallbacks);
+        if ( $buttonDispatch->handled ) {
+            return $buttonDispatch->block;
         }
 
-        if ( 'button' === $tagName ) {
-            if ( $this->searchBlockConverter->isReplacedSearchClusterControl($element) ) {
-                return null;
-            }
-            if ( $this->isImageCarrierButton($element) ) {
-                $children = $this->convertChildren($element, $fallbacks, true);
-                if ( array() !== $children ) {
-                    return $this->createBlock('core/group', $this->styleResolver->presentationAttributes($element), $children, $element);
-                }
-            }
-            return $this->buttonLinkDispatcher->convertButton($element);
-        }
-
-if ( 'svg' === $tagName ) {
+        if ( 'svg' === $tagName ) {
             return $this->svgConverter->convert($element, $tagName, $fallbacks)->block;
         }
 

--- a/php-transformer/tests/unit/button-element-converter.php
+++ b/php-transformer/tests/unit/button-element-converter.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonElementContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonElementConverter;
+
+$assertions = 0;
+$failures = array();
+$assert = static function (bool $condition, string $label) use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']';
+    }
+};
+
+$document = new DOMDocument();
+$document->loadHTML('<?xml encoding="utf-8" ?><body><button>Go</button><div></div></body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+$button = $document->getElementsByTagName('button')->item(0);
+$div = $document->getElementsByTagName('div')->item(0);
+if ( ! $button instanceof DOMElement || ! $div instanceof DOMElement ) {
+    throw new RuntimeException('Fixture elements not parsed');
+}
+
+$mode = 'generic';
+$imageCalls = 0;
+$genericCalls = 0;
+$captureUnsupported = null;
+$genericBlock = array( 'blockName' => 'core/buttons' );
+$converter = new ButtonElementConverter(new ButtonElementContext(
+    static function (DOMElement $element) use (&$mode): bool {
+        return 'search' === $mode;
+    },
+    static function (DOMElement $element) use (&$mode, &$imageCalls): bool {
+        ++$imageCalls;
+        return in_array($mode, array( 'image', 'empty-image' ), true);
+    },
+    static function (DOMElement $element, array &$fallbacks, bool $capture) use (&$mode, &$captureUnsupported): array {
+        $captureUnsupported = $capture;
+        $fallbacks[] = array( 'image' => true );
+        return 'image' === $mode ? array( array( 'blockName' => 'core/image' ) ) : array();
+    },
+    static fn (DOMElement $element): array => array( 'className' => 'carrier' ),
+    static fn (string $name, array $attributes, array $innerBlocks, DOMElement $element): array => array(
+        'blockName' => $name,
+        'attrs' => $attributes,
+        'innerBlocks' => $innerBlocks,
+    ),
+    static function (DOMElement $element) use (&$genericCalls, &$genericBlock): ?array {
+        ++$genericCalls;
+        return $genericBlock;
+    }
+));
+$fallbacks = array();
+
+$unhandled = $converter->convert($div, 'div', $fallbacks);
+$assert(! $unhandled->handled && 0 === $imageCalls && 0 === $genericCalls, 'non-button-unhandled');
+
+$mode = 'search';
+$search = $converter->convert($button, 'button', $fallbacks);
+$assert($search->handled && null === $search->block, 'replaced-search-control-suppressed');
+$assert(0 === $imageCalls && 0 === $genericCalls, 'search-short-circuits-later-routes');
+
+$mode = 'image';
+$image = $converter->convert($button, 'button', $fallbacks);
+$assert('core/group' === ($image->block['blockName'] ?? ''), 'image-carrier-becomes-group');
+$assert('carrier' === ($image->block['attrs']['className'] ?? '') && 'core/image' === ($image->block['innerBlocks'][0]['blockName'] ?? ''), 'image-carrier-content-preserved');
+$assert(true === $captureUnsupported && 1 === count($fallbacks), 'image-children-forward-fallback-state');
+$assert(0 === $genericCalls, 'image-carrier-short-circuits-generic-button');
+
+$mode = 'empty-image';
+$emptyImage = $converter->convert($button, 'button', $fallbacks);
+$assert('core/buttons' === ($emptyImage->block['blockName'] ?? '') && 1 === $genericCalls, 'empty-image-carrier-falls-through');
+
+$mode = 'generic';
+$generic = $converter->convert($button, 'button', $fallbacks);
+$assert($generic->handled && 'core/buttons' === ($generic->block['blockName'] ?? ''), 'ordinary-button-delegated');
+
+$genericBlock = null;
+$null = $converter->convert($button, 'button', $fallbacks);
+$assert($null->handled && null === $null->block, 'generic-null-remains-handled');
+
+if ( $failures ) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Button element converter tests: ' . $assertions . " passed\n";


### PR DESCRIPTION
## Summary

- extract button routing into `ButtonElementConverter` with an explicit collaborator context
- preserve replaced-search suppression, image-carrier projection, and ordinary button precedence
- remove the unreachable duplicate anchor branch after the earlier unconditional anchor dispatch

## Verification

- `composer validate --strict`
- `composer test`
- 292 PHP transformer parity fixtures
- exact-base CSS-attached corpus: 383 documents, 87 fixtures, 82 with CSS, 0 throws
- base/candidate SHA-256: `6f0fd03d6eaa5b9683919e19a0a44eb652f7517373b91c4de3880ac9055ab04f`

Part of #242.

## AI assistance

OpenAI GPT-5.6-sol via OpenCode was used to inspect button dispatch precedence, implement the extraction, identify and remove unreachable dispatch, add tests, and run verification. The changes and evidence were reviewed and orchestrated by Chris Huber.