### PR TITLE
Extract runtime resource element conversion

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -182,7 +182,8 @@
             "php tests/unit/pseudo-form-analyzer.php",
             "php tests/unit/runtime-island-analyzer.php",
             "php tests/unit/button-link-dispatcher.php",
-            "php tests/unit/button-element-converter.php"
+            "php tests/unit/button-element-converter.php",
+            "php tests/unit/runtime-resource-element-converter.php"
     ],
     "test:parity": "php tests/parity/run.php",
     "test:migration:examples": "php tests/migration/examples.php",

--- a/php-transformer/src/HtmlToBlocks/Elements/RuntimeResourceElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/RuntimeResourceElementConverter.php
@@ -1,0 +1,142 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerSession;
+use Closure;
+use DOMElement;
+
+/** Owns canvas, script, and template conversion and runtime evidence. */
+final class RuntimeResourceElementConverter implements ElementConverter
+{
+    /**
+     * @param Closure(): HtmlTransformerSession $session
+     * @param Closure(DOMElement): array<string, mixed> $htmlPreservationBlock
+     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement): array<string, mixed> $createBlock
+     */
+    public function __construct(
+        private readonly Closure $session,
+        private readonly Closure $htmlPreservationBlock,
+        private readonly Closure $createBlock
+    ) {
+    }
+
+    /** @param array<int, array<string, mixed>> $fallbacks */
+    public function convert(DOMElement $element, string $tagName, array &$fallbacks): ConversionOutcome
+    {
+        return match ($tagName) {
+            'canvas'   => ConversionOutcome::handled($this->convertCanvas($element)),
+            'script'   => ConversionOutcome::handled($this->convertScript($element, $fallbacks)),
+            'template' => ConversionOutcome::handled($this->convertTemplate($element, $fallbacks)),
+            default    => ConversionOutcome::unhandled(),
+        };
+    }
+
+    /** @return array<string, mixed>|null */
+    private function convertCanvas(DOMElement $element): ?array
+    {
+        $session = $this->session();
+        $emitter = $session->fallbackEmitter();
+        if ( ! $emitter->isRuntimeCanvasTarget($element) ) {
+            return null;
+        }
+
+        $emitter->recordRuntimeIsland(
+            $element,
+            'canvas',
+            'canvas_requires_runtime',
+            'canvas_element_and_client_script_execution',
+            array(
+                'script_dependency_hint' => 'Scripts may target this canvas and call canvas APIs such as getContext(); preserving the native element keeps the runtime addressable.',
+                'required_scripts'        => $emitter->requiredScriptsForElement($element),
+            ),
+            $session->runtimeDomState()
+        );
+
+        return ($this->htmlPreservationBlock)($element);
+    }
+
+    /** @param array<int, array<string, mixed>> $fallbacks @return array<string, mixed>|null */
+    private function convertScript(DOMElement $element, array &$fallbacks): ?array
+    {
+        $session = $this->session();
+        $emitter = $session->fallbackEmitter();
+        $metadata = $emitter->staticScriptMetadata($element);
+        if ( null === $metadata ) {
+            $emitter->captureScriptFallback($element, $fallbacks, $session->runtimeDomState());
+            return null;
+        }
+
+        $session->runtimeBehaviorState()->recordScriptMetadata($metadata);
+        if ( ! $this->isAddressableStaticJsonTarget($element, $metadata, $session) ) {
+            return null;
+        }
+
+        $emitter->recordRuntimeIsland(
+            $element,
+            'static_script',
+            'static_script_runtime_target',
+            'client_script_configuration',
+            array(
+                'script_role'      => 'data',
+                'required_scripts' => $emitter->requiredScriptsForElement($element),
+            ),
+            $session->runtimeDomState()
+        );
+
+        return $this->staticJsonTargetBlock($element, $metadata);
+    }
+
+    /** @param array<int, array<string, mixed>> $fallbacks */
+    private function convertTemplate(DOMElement $element, array &$fallbacks): null
+    {
+        $session = $this->session();
+        $session->fallbackEmitter()->captureTemplateFallback($element, $fallbacks, $session->runtimeDomState());
+
+        return null;
+    }
+
+    /** @param array<string, mixed> $metadata */
+    private function isAddressableStaticJsonTarget(DOMElement $element, array $metadata, HtmlTransformerSession $session): bool
+    {
+        $id = trim($element->getAttribute('id'));
+        $type = strtolower(trim($element->getAttribute('type')));
+        if ( '' === $id || ! in_array($type, array( 'application/json', 'application/ld+json' ), true) || ! $session->runtimeSelectorState()->hasDom('#' . $id) ) {
+            return false;
+        }
+
+        if ( ! empty($metadata['body_truncated']) ) {
+            return false;
+        }
+
+        return null !== json_decode((string) ($metadata['body'] ?? ''), true);
+    }
+
+    /** @param array<string, mixed> $metadata @return array<string, mixed> */
+    private function staticJsonTargetBlock(DOMElement $element, array $metadata): array
+    {
+        $attributes = is_array($metadata['attributes'] ?? null) ? $metadata['attributes'] : array();
+        ksort($attributes, SORT_STRING);
+        $attributeHtml = '';
+        foreach ( $attributes as $name => $value ) {
+            if ( ! is_string($name) || ! is_string($value) ) {
+                continue;
+            }
+            $attributeHtml .= ' ' . $name . '="' . htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"';
+        }
+        $body = str_replace('</script', '<\/script', (string) ($metadata['body'] ?? ''));
+
+        return ($this->createBlock)(
+            'core/html',
+            array( 'content' => '<script' . $attributeHtml . '>' . $body . '</script>' ),
+            array(),
+            $element
+        );
+    }
+
+    private function session(): HtmlTransformerSession
+    {
+        return ($this->session)();
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -72,6 +72,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ReadableFormBlo
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\PseudoFormAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeResourceElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TableElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TableElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\UnsupportedElementContext;
@@ -297,6 +298,8 @@ final class HtmlTransformer
 
     private readonly RuntimeIslandAnalyzer $runtimeIslands;
 
+    private readonly RuntimeResourceElementConverter $runtimeResourceConverter;
+
     private readonly FormRuntimeIslandRecorder $formRuntimeIslandRecorder;
 
     private readonly FormControlMetadataBuilder $formControlMetadataBuilder;
@@ -513,6 +516,11 @@ final class HtmlTransformer
         );
         $this->pseudoFormAnalyzer = new PseudoFormAnalyzer($this->formControlMetadataBuilder, fn (DOMElement $element): string => $this->elementSelector($element));
         $this->runtimeIslands = new RuntimeIslandAnalyzer($this->createRuntimeIslandContext(), $this->pseudoFormAnalyzer);
+        $this->runtimeResourceConverter = new RuntimeResourceElementConverter(
+            fn (): HtmlTransformerSession => $this->session,
+            fn (DOMElement $element): array => $this->htmlPreservationBlock($element),
+            fn (string $name, array $attributes, array $innerBlocks, DOMElement $element): array => $this->createBlock($name, $attributes, $innerBlocks, $element)
+        );
         $this->formRuntimeIslandRecorder = new FormRuntimeIslandRecorder(
             $this->formControlMetadataBuilder,
             function (DOMElement $element, string $kind, string $reason, string $capability, array $metadata): void {
@@ -4773,37 +4781,9 @@ final class HtmlTransformer
             return $specializedDispatch->block;
         }
 
-        if ( 'canvas' === $tagName ) {
-            if ( ! $this->runtimeIslands->isRuntimeCanvasTarget($element) ) {
-                return null;
-            }
-
-            $this->runtimeIslands->recordRuntimeIsland($element, 'canvas', 'canvas_requires_runtime', 'canvas_element_and_client_script_execution', array(
-                'script_dependency_hint' => 'Scripts may target this canvas and call canvas APIs such as getContext(); preserving the native element keeps the runtime addressable.',
-                'required_scripts'        => $this->requiredScriptsForElement($element),
-            ));
-            return $this->htmlPreservationBlock($element);
-        }
-
-        if ( 'script' === $tagName ) {
-            if ( $this->captureStaticScriptMetadata($element) ) {
-                if ( $this->isAddressableStaticJsonTarget($element) ) {
-                    $this->runtimeIslands->recordRuntimeIsland($element, 'static_script', 'static_script_runtime_target', 'client_script_configuration', array(
-                        'script_role' => 'data',
-                        'required_scripts' => $this->requiredScriptsForElement($element),
-                    ));
-                    return $this->staticJsonTargetBlock($element);
-                }
-                return null;
-            }
-
-            $this->captureScriptFallback($element, $fallbacks);
-            return null;
-        }
-
-        if ( 'template' === $tagName ) {
-            $this->captureTemplateFallback($element, $fallbacks);
-            return null;
+        $runtimeResourceDispatch = $this->runtimeResourceConverter->convert($element, $tagName, $fallbacks);
+        if ( $runtimeResourceDispatch->handled ) {
+            return $runtimeResourceDispatch->block;
         }
 
         if ( 'form' === $tagName ) {
@@ -11591,72 +11571,6 @@ final class HtmlTransformer
         $namespace = is_scalar($options['generated_block_namespace'] ?? null) ? trim((string) $options['generated_block_namespace']) : '';
 
         return '' !== $namespace ? $namespace : 'custom';
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $fallbacks
-     */
-    private function captureScriptFallback(DOMElement $element, array &$fallbacks): void
-    {
-        $this->fallbackEmitter()->captureScriptFallback($element, $fallbacks, $this->runtimeDom());
-    }
-
-    private function captureStaticScriptMetadata(DOMElement $element): bool
-    {
-        $metadata = $this->fallbackEmitter()->staticScriptMetadata($element);
-        if ( null === $metadata ) {
-            return false;
-        }
-
-        $this->runtimeBehavior()->recordScriptMetadata($metadata);
-
-        return true;
-    }
-
-    /**
-     * Keep a static JSON script in the page only when a carried runtime script
-     * addresses its id. JSON script types never execute, unlike static JavaScript
-     * assignments that remain metadata-only.
-     */
-    private function isAddressableStaticJsonTarget(DOMElement $element): bool
-    {
-        $id = trim($this->attr($element, 'id'));
-        $type = strtolower(trim($this->attr($element, 'type')));
-        if ( '' === $id || ! in_array($type, array('application/json', 'application/ld+json'), true) || ! $this->runtimeSelectors()->hasDom('#' . $id) ) {
-            return false;
-        }
-
-        $metadata = $this->runtimeBehavior()->latestScriptMetadata();
-        if ( null === $metadata || ! empty($metadata['body_truncated']) ) {
-            return false;
-        }
-
-        return null !== json_decode((string) ($metadata['body'] ?? ''), true);
-    }
-
-    private function staticJsonTargetBlock(DOMElement $element): array
-    {
-        $metadata = $this->runtimeBehavior()->latestScriptMetadata() ?? array();
-        $attributes = is_array($metadata['attributes'] ?? null) ? $metadata['attributes'] : array();
-        ksort($attributes, SORT_STRING);
-        $attributeHtml = '';
-        foreach ( $attributes as $name => $value ) {
-            if ( ! is_string($name) || ! is_string($value) ) {
-                continue;
-            }
-            $attributeHtml .= ' ' . $name . '="' . htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"';
-        }
-        $body = str_replace('</script', '<\\/script', (string) ($metadata['body'] ?? ''));
-
-        return $this->createBlock('core/html', array('content' => '<script' . $attributeHtml . '>' . $body . '</script>'), array(), $element);
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $fallbacks
-     */
-    private function captureTemplateFallback(DOMElement $element, array &$fallbacks): void
-    {
-        $this->fallbackEmitter()->captureTemplateFallback($element, $fallbacks, $this->runtimeDom());
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Session/RuntimeBehaviorState.php
+++ b/php-transformer/src/HtmlToBlocks/Session/RuntimeBehaviorState.php
@@ -60,14 +60,6 @@ final class RuntimeBehaviorState
         return $this->scriptMetadata;
     }
 
-    /** @return array<string, mixed>|null */
-    public function latestScriptMetadata(): ?array
-    {
-        $metadata = end($this->scriptMetadata);
-
-        return is_array($metadata) ? $metadata : null;
-    }
-
     public function rememberNativeDisclosureRoot(string $path): void
     {
         $this->nativeDisclosureRootPaths[$path] = true;

--- a/php-transformer/tests/unit/runtime-resource-element-converter.php
+++ b/php-transformer/tests/unit/runtime-resource-element-converter.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeResourceElementConverter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerSession;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeSelectorState;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
+
+$assertions = 0;
+$failures = array();
+$assert = static function (bool $condition, string $label) use (&$assertions, &$failures): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        $failures[] = 'FAIL [' . $label . ']';
+    }
+};
+
+$elementFrom = static function (string $html): DOMElement {
+    $document = new DOMDocument();
+    $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+    $body = $document->getElementsByTagName('body')->item(0);
+    if ( $body instanceof DOMElement ) {
+        foreach ( $body->childNodes as $child ) {
+            if ( $child instanceof DOMElement ) {
+                return $child;
+            }
+        }
+    }
+    throw new RuntimeException('Fixture element not parsed');
+};
+
+$session = new HtmlTransformerSession(new Runtime(), static fn (DOMElement $element): array => array());
+$selectors = new RuntimeSelectorState(
+    array( '#config' => true ),
+    array(),
+    array( '#stage' => true )
+);
+$session->installRuntimeSelectorState($selectors);
+$session->fallbackEmitter()->configure(array(), array(), $selectors);
+
+$preserved = 0;
+$converter = new RuntimeResourceElementConverter(
+    static fn (): HtmlTransformerSession => $session,
+    static function (DOMElement $element) use (&$preserved): array {
+        ++$preserved;
+        return array( 'blockName' => 'core/html', 'attrs' => array( 'content' => 'preserved:' . $element->tagName ) );
+    },
+    static fn (string $name, array $attributes, array $innerBlocks, DOMElement $element): array => array(
+        'blockName' => $name,
+        'attrs' => $attributes,
+        'innerBlocks' => $innerBlocks,
+    )
+);
+$fallbacks = array();
+
+$unhandled = $converter->convert($elementFrom('<div></div>'), 'div', $fallbacks);
+$assert(! $unhandled->handled, 'non-runtime-resource-unhandled');
+
+$plainCanvas = $converter->convert($elementFrom('<canvas></canvas>'), 'canvas', $fallbacks);
+$assert($plainCanvas->handled && null === $plainCanvas->block && 0 === $preserved, 'non-runtime-canvas-dropped');
+
+$runtimeCanvas = $converter->convert($elementFrom('<canvas id="stage"></canvas>'), 'canvas', $fallbacks);
+$assert('core/html' === ($runtimeCanvas->block['blockName'] ?? '') && 1 === $preserved, 'runtime-canvas-preserved');
+$canvasIsland = $session->runtimeDomState()->islands()[0] ?? array();
+$assert('canvas' === ($canvasIsland['kind'] ?? '') && 'canvas_requires_runtime' === ($canvasIsland['preservation_reason'] ?? ''), 'runtime-canvas-island-recorded');
+
+$staticJson = $converter->convert(
+    $elementFrom('<script type="application/json" id="config">{"enabled":true}</script>'),
+    'script',
+    $fallbacks
+);
+$assert('core/html' === ($staticJson->block['blockName'] ?? ''), 'addressable-static-json-preserved');
+$assert(
+    '<script id="config" type="application/json">{"enabled":true}</script>' === ($staticJson->block['attrs']['content'] ?? ''),
+    'static-json-serialized-deterministically'
+);
+$assert(1 === count($session->runtimeBehaviorState()->scriptMetadata()), 'static-script-metadata-recorded');
+$jsonIsland = $session->runtimeDomState()->islands()[1] ?? array();
+$assert('static_script' === ($jsonIsland['kind'] ?? '') && 'data' === ($jsonIsland['script_role'] ?? ''), 'static-json-runtime-island-recorded');
+
+$unaddressed = $converter->convert(
+    $elementFrom('<script type="application/json" id="other">{"enabled":true}</script>'),
+    'script',
+    $fallbacks
+);
+$assert($unaddressed->handled && null === $unaddressed->block, 'unaddressed-static-json-remains-metadata-only');
+$assert(2 === count($session->runtimeBehaviorState()->scriptMetadata()), 'unaddressed-static-metadata-retained');
+
+$invalid = $converter->convert(
+    $elementFrom('<script type="application/json" id="config">not-json</script>'),
+    'script',
+    $fallbacks
+);
+$assert($invalid->handled && null === $invalid->block, 'invalid-addressable-json-not-preserved');
+
+$runtimeScript = $converter->convert($elementFrom('<script src="/app.js"></script>'), 'script', $fallbacks);
+$assert($runtimeScript->handled && null === $runtimeScript->block, 'runtime-script-produces-no-content-block');
+$assert('script_requires_runtime' === ($fallbacks[0]['reason'] ?? ''), 'runtime-script-fallback-captured');
+
+$template = $converter->convert($elementFrom('<template id="card"><p>Card</p></template>'), 'template', $fallbacks);
+$assert($template->handled && null === $template->block, 'template-produces-no-content-block');
+$assert('template' === ($fallbacks[1]['tag'] ?? ''), 'template-fallback-captured');
+
+if ( $failures ) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Runtime resource element converter tests: ' . $assertions . " passed\n";


### PR DESCRIPTION
## Summary

- extract canvas, script, and template routing into one cohesive `RuntimeResourceElementConverter`
- move static-script classification, addressable JSON validation/serialization, runtime-island recording, and fallback capture out of `HtmlTransformer`
- remove five transformer helper methods and the now-unused `latestScriptMetadata()` state API
- reduce `HtmlTransformer` by 86 net lines (97 removed, 11 wiring/dispatch lines added)

## Verification

- 15 direct runtime-resource assertions covering canvas, static JSON, executable script, template, metadata, islands, and handled-null behavior
- HTML transformer session-state contract
- `composer validate --strict`
- `composer test`
- 292 PHP transformer parity fixtures
- exact-base CSS-attached corpus: 383 documents, 87 fixtures, 82 with CSS, 0 throws
- base/candidate SHA-256: `6f0fd03d6eaa5b9683919e19a0a44eb652f7517373b91c4de3880ac9055ab04f`

Part of #242.

## AI assistance

OpenAI GPT-5.6-sol via OpenCode was used to map the runtime-resource subsystem, implement the cohesive extraction, remove obsolete state, add direct tests, and run verification. The changes and evidence were reviewed and orchestrated by Chris Huber.