### PR TITLE
Extract block materialization

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -7,9 +7,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleAttributeMapp
 use Automattic\BlocksEngine\PhpTransformer\WordPress\GeneratedGutenbergClassPolicy;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
-/**
- * @internal Block construction is owned by HtmlTransformer.
- */
+/** Canonical block shape and saved-markup construction. */
 final class BlockFactory
 {
     /**

--- a/php-transformer/src/HtmlToBlocks/BlockMaterializer.php
+++ b/php-transformer/src/HtmlToBlocks/BlockMaterializer.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandAnalyzer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\TransformationProvenanceState;
+
+/** Records source ownership and builds the final canonical block representation. */
+final class BlockMaterializer
+{
+    public function __construct(
+        private readonly BlockFactory $blockFactory,
+        private readonly RuntimeIslandAnalyzer $runtimeIslands
+    ) {}
+
+    /**
+     * @param array<string, mixed>              $attrs
+     * @param array<int, array<string, mixed>> $innerBlocks
+     * @return array<string, mixed>
+     */
+    public function materialize(
+        string $name,
+        array $attrs,
+        array $innerBlocks,
+        ?SourceBlockMaterializationFacts $sourceFacts,
+        TransformationProvenanceState $provenance
+    ): array {
+        $provenanceId = null;
+        $runtimeOwned = false;
+        if ( $sourceFacts instanceof SourceBlockMaterializationFacts ) {
+            $this->recordPresentationSignal($name, $attrs, $sourceFacts, $provenance);
+            $this->recordStructureSignal($name, $sourceFacts, $provenance);
+            $runtimeOwned = $this->runtimeIslands->recordBlockRuntimeDomContract($sourceFacts->sourceElement, $name);
+            $provenanceId = $provenance->registerSource($sourceFacts->sourceEntry, $sourceFacts->startsHidden);
+        }
+
+        $block = $this->blockFactory->create($name, $attrs, $innerBlocks);
+        if ( null !== $provenanceId ) {
+            $block['_source_provenance_id'] = $provenanceId;
+        }
+        if ( $runtimeOwned ) {
+            $block['_editability_runtime_owned'] = true;
+        }
+        if ( null !== $provenanceId
+            && $sourceFacts instanceof SourceBlockMaterializationFacts
+            && array() !== $sourceFacts->visualTopologyEvidence
+        ) {
+            $block['_editability_visual_owned'] = true;
+            $provenance->addSourceEvidence($provenanceId, array( 'visual_topology_evidence' => $sourceFacts->visualTopologyEvidence ));
+        }
+
+        return $block;
+    }
+
+    /** @param array<string, mixed> $attrs */
+    private function recordPresentationSignal(
+        string $blockName,
+        array $attrs,
+        SourceBlockMaterializationFacts $facts,
+        TransformationProvenanceState $provenance
+    ): void {
+        $signals = array_intersect_key($attrs, array_flip(array( 'className', 'style', 'layout' )));
+        $signals = array_filter($signals, static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value));
+        if ( array() === $signals ) {
+            return;
+        }
+
+        $provenance->recordPresentationSignal(array(
+            'block_name'        => $blockName,
+            'tag'               => $facts->sourceTag,
+            'selector'          => $facts->sourceSelector,
+            'signals'           => $signals,
+            'source_attributes' => array_intersect_key($facts->sourceAttributes, array_flip(array( 'class', 'style', 'data-layout', 'data-wp-layout' ))),
+        ));
+    }
+
+    private function recordStructureSignal(
+        string $blockName,
+        SourceBlockMaterializationFacts $facts,
+        TransformationProvenanceState $provenance
+    ): void {
+        if ( array() === $facts->structureSignals ) {
+            return;
+        }
+
+        $provenance->recordStructureSignal(array(
+            'block_name'        => $blockName,
+            'tag'               => $facts->sourceTag,
+            'selector'          => $facts->sourceSelector,
+            'signals'           => $facts->structureSignals,
+            'source_attributes' => array_intersect_key($facts->sourceAttributes, array_flip(array( 'class', 'id', 'role', 'style', 'data-layout', 'data-wp-layout' ))),
+        ));
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Elements/RuntimeIslandAnalyzer.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/RuntimeIslandAnalyzer.php
@@ -363,6 +363,29 @@ final class RuntimeIslandAnalyzer
         }
     }
 
+    public function recordBlockRuntimeDomContract(DOMElement $element, string $blockName): bool
+    {
+        $tagName = strtolower($element->tagName);
+        if ( ! $this->isRuntimeDomTarget($element)
+            || FormControlClassifier::isControlElement($element)
+            || in_array($tagName, array( 'canvas', 'form', 'script' ), true)
+        ) {
+            return false;
+        }
+
+        if ( ! $this->canRetainRuntimeDomContractNatively($element, $blockName) ) {
+            $this->recordRuntimeIsland($element, 'dom', 'runtime_dom_target', 'client_script_execution', array(
+                'events'           => $this->context->eventMetadata($element),
+                'required_scripts' => $this->context->requiredScriptsForElement($element),
+            ));
+            $this->recordRuntimeDomFallback($element, $blockName);
+        } else {
+            $this->recordNativeRuntimeDomPreservation($element, $blockName, in_array($blockName, array( 'core/paragraph', 'core/heading' ), true));
+        }
+
+        return true;
+    }
+
     public function canRetainRuntimeDomContractNatively(DOMElement $element, string $blockName): bool
     {
         if ( ! in_array($blockName, array('core/group', 'core/paragraph', 'core/heading'), true) ) {

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -284,6 +284,8 @@ final class HtmlTransformer
 
     private readonly BlockFactory $blockFactory;
 
+    private readonly BlockMaterializer $blockMaterializer;
+
     private readonly BackgroundImageExtractor $backgroundImageExtractor;
 
     private readonly TableClassificationPolicy $tableClassificationPolicy;
@@ -556,6 +558,7 @@ final class HtmlTransformer
         );
         $this->pseudoFormAnalyzer = new PseudoFormAnalyzer($this->formControlMetadataBuilder, fn (DOMElement $element): string => $this->elementSelector($element));
         $this->runtimeIslands = new RuntimeIslandAnalyzer($this->createRuntimeIslandContext(), $this->pseudoFormAnalyzer);
+        $this->blockMaterializer = new BlockMaterializer($this->blockFactory, $this->runtimeIslands);
         $this->runtimeResourceConverter = new RuntimeResourceElementConverter(
             fn (): HtmlTransformerSession => $this->session,
             fn (DOMElement $element): array => $this->htmlPreservationBlock($element),
@@ -3327,7 +3330,7 @@ final class HtmlTransformer
             }
         }
 
-        $runtimeOwned = false;
+        $sourceMaterializationFacts = null;
         if ( $sourceElement instanceof DOMElement ) {
             $sourceTagName = strtolower($sourceElement->tagName);
             if ( in_array($name, array( 'core/group', 'core/column', 'core/columns' ), true) ) {
@@ -3361,40 +3364,27 @@ final class HtmlTransformer
                 ),
                 $this->sourceBlockAttributeProjectionContext()
             );
-            $this->recordPresentationProvenance($name, $attrs, $sourceElement);
-            $this->recordStructureProvenance($name, $attrs, $sourceElement);
-            if ( $this->runtimeIslands->isRuntimeDomTarget($sourceElement) && ! FormControlClassifier::isControlElement($sourceElement) && ! in_array($sourceTagName, array( 'canvas', 'form', 'script' ), true) ) {
-                $runtimeOwned = true;
-                if ( ! $this->runtimeIslands->canRetainRuntimeDomContractNatively($sourceElement, $name) ) {
-                    $this->runtimeIslands->recordRuntimeIsland($sourceElement, 'dom', 'runtime_dom_target', 'client_script_execution', array(
-                        'events'          => $this->eventMetadata($sourceElement),
-                        'required_scripts' => $this->requiredScriptsForElement($sourceElement),
-                    ));
-                    $this->runtimeIslands->recordRuntimeDomFallback($sourceElement, $name);
-                } else {
-                    $this->runtimeIslands->recordNativeRuntimeDomPreservation($sourceElement, $name, in_array($name, array('core/paragraph', 'core/heading'), true));
-                }
-            }
-            $provenanceId = $this->transformationProvenance()->registerSource(
+            $sourceMaterializationFacts = new SourceBlockMaterializationFacts(
+                $sourceElement,
+                $sourceTagName,
+                $this->elementSelector($sourceElement),
                 $this->sourceProvenanceEntry($name, $sourceElement),
-                $this->sourceElementStartsHidden($sourceElement)
+                $this->sourceElementStartsHidden($sourceElement),
+                $this->htmlAttributes($sourceElement),
+                $this->structureSignals($sourceElement, $attrs),
+                array() === $innerBlocks && 'core/group' === $name
+                    ? $this->emptyVisualTopologyEvidence($sourceElement)
+                    : array()
             );
         }
 
-        $block = $this->blockFactory->create($name, $attrs, $innerBlocks);
-        if ( isset($provenanceId) ) {
-            $block['_source_provenance_id'] = $provenanceId;
-        }
-        if ($runtimeOwned) $block['_editability_runtime_owned'] = true;
-        if ( $sourceElement instanceof DOMElement && array() === $innerBlocks && 'core/group' === $name ) {
-            $visualTopologyEvidence = $this->emptyVisualTopologyEvidence($sourceElement);
-            if ( array() !== $visualTopologyEvidence ) {
-                $block['_editability_visual_owned'] = true;
-                $this->transformationProvenance()->addSourceEvidence($provenanceId, array( 'visual_topology_evidence' => $visualTopologyEvidence ));
-            }
-        }
-
-        return $block;
+        return $this->blockMaterializer->materialize(
+            $name,
+            $attrs,
+            $innerBlocks,
+            $sourceMaterializationFacts,
+            $this->transformationProvenance()
+        );
     }
 
     private function sourceElementStartsHidden(DOMElement $element): bool
@@ -4922,45 +4912,6 @@ final class HtmlTransformer
         }
 
         return $this->styleResolver->presentationClassName(implode(' ', $classes));
-    }
-
-    /**
-     * @param array<string, mixed> $attrs
-     */
-    private function recordPresentationProvenance(string $blockName, array $attrs, DOMElement $element): void
-    {
-        $signals = array_intersect_key($attrs, array_flip(array( 'className', 'style', 'layout' )));
-        $signals = array_filter($signals, static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value));
-        if ( array() === $signals ) {
-            return;
-        }
-
-        $this->transformationProvenance()->recordPresentationSignal(array(
-            'block_name'        => $blockName,
-            'tag'               => strtolower($element->tagName),
-            'selector'          => $this->elementSelector($element),
-            'signals'           => $signals,
-            'source_attributes' => array_intersect_key($this->htmlAttributes($element), array_flip(array( 'class', 'style', 'data-layout', 'data-wp-layout' ))),
-        ));
-    }
-
-    /**
-     * @param array<string, mixed> $attrs
-     */
-    private function recordStructureProvenance(string $blockName, array $attrs, DOMElement $element): void
-    {
-        $signals = $this->structureSignals($element, $attrs);
-        if ( array() === $signals ) {
-            return;
-        }
-
-        $this->transformationProvenance()->recordStructureSignal(array(
-            'block_name'        => $blockName,
-            'tag'               => strtolower($element->tagName),
-            'selector'          => $this->elementSelector($element),
-            'signals'           => $signals,
-            'source_attributes' => array_intersect_key($this->htmlAttributes($element), array_flip(array( 'class', 'id', 'role', 'style', 'data-layout', 'data-wp-layout' ))),
-        ));
     }
 
     private function shouldPreserveWrapper(DOMElement $element): bool

--- a/php-transformer/src/HtmlToBlocks/SourceBlockMaterializationFacts.php
+++ b/php-transformer/src/HtmlToBlocks/SourceBlockMaterializationFacts.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+
+use DOMElement;
+
+/** Source evidence computed before a canonical block is materialized. */
+final class SourceBlockMaterializationFacts
+{
+    /**
+     * @param array<string, mixed>                                                        $sourceEntry
+     * @param array<string, string>                                                       $sourceAttributes
+     * @param array<string, mixed>                                                        $structureSignals
+     * @param list<array{selector: string, declarations: array<string, string>, specificity: int, order: int, source_path: string, source_hash: string}> $visualTopologyEvidence
+     */
+    public function __construct(
+        public readonly DOMElement $sourceElement,
+        public readonly string $sourceTag,
+        public readonly string $sourceSelector,
+        public readonly array $sourceEntry,
+        public readonly bool $startsHidden,
+        public readonly array $sourceAttributes,
+        public readonly array $structureSignals,
+        public readonly array $visualTopologyEvidence
+    ) {}
+}

--- a/php-transformer/tests/unit/runtime-island-analyzer.php
+++ b/php-transformer/tests/unit/runtime-island-analyzer.php
@@ -172,6 +172,15 @@ $assert(! $retain->canRetainRuntimeDomContractNatively($elementFrom('<div><p>tex
 $assert(! $retain->canRetainRuntimeDomContractNatively($elementFrom('<section><button>go</button></section>'), 'core/group'), 'interactive-descendant-blocks-native-retention');
 $assert(! $retain->canRetainRuntimeDomContractNatively($elementFrom('<section><p>t</p></section>'), 'core/image'), 'unsupported-block-name-does-not-retain');
 
+// Block materialization delegates the complete runtime DOM recording decision.
+$runtimeDom = new RuntimeDomState();
+$blockRuntime = $makeAnalyzer(array('#mount'), array(), array(
+    'runtimeDom' => static fn (): RuntimeDomState => $runtimeDom,
+));
+$assert($blockRuntime->recordBlockRuntimeDomContract($elementFrom('<section id="mount"><p>text</p></section>'), 'core/group'), 'runtime-block-contract-recorded');
+$assert(array(array('block_name' => 'core/group', 'tag' => 'section', 'selector' => '#mount')) === $runtimeDom->preservations(), 'runtime-block-native-preservation-recorded');
+$assert(! $blockRuntime->recordBlockRuntimeDomContract($elementFrom('<input id="mount">'), 'core/group'), 'runtime-form-control-block-contract-excluded');
+
 if ($failures) {
     fwrite(STDERR, implode("\n", $failures) . "\n");
     exit(1);


### PR DESCRIPTION
## Summary
- add a typed `BlockMaterializer` boundary for final `BlockFactory` assembly, source registration, provenance signals, and editability annotations
- move complete block runtime DOM recording into `RuntimeIslandAnalyzer`, where runtime target policy already lives
- pass source evidence through callback-free `SourceBlockMaterializationFacts` and reduce `HtmlTransformer::createBlock()` from 102 to 87 lines

## Verification
- `composer validate --strict`
- `composer test` (includes 292 PHP transformer parity fixtures)
- runtime island analyzer: 35 direct assertions
- CSS-attached corpus: 383 documents across 87 fixtures, 82 with CSS, 0 throws
- corpus SHA-256: `6f0fd03d6eaa5b9683919e19a0a44eb652f7517373b91c4de3880ac9055ab04f` (exact clean-base match)

Part of #242.

## AI Assistance
AI assistance: OpenAI `gpt-5.6-sol` via OpenCode was used to map the materialization boundary, implement the typed extraction, and run and interpret verification.