### PR TITLE
Optimize large artifact CSS compilation

### DIFF
--- a/php-transformer/src/ArtifactCompiler/RuntimeDeclarations.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeDeclarations.php
@@ -196,29 +196,22 @@ final class RuntimeDeclarations
     /** @param resource $context */
     private static function updateCanonicalStringHash($context, string $value): void
     {
-        if (1 !== preg_match('//u', $value)) throw new InvalidArgumentException('Runtime declaration payload is not serializable.');
         hash_update($context, '"');
         $length = strlen($value);
-        $start = 0;
-        $escapes = array(8 => '\\b', 9 => '\\t', 10 => '\\n', 12 => '\\f', 13 => '\\r', 34 => '\\"', 92 => '\\\\');
-        for ($index = 0; $index < $length; ++$index) {
-            $byte = ord($value[$index]);
-            $lineTerminator = 0xE2 === $byte && $index + 2 < $length && 0x80 === ord($value[$index + 1]) && in_array(ord($value[$index + 2]), array(0xA8, 0xA9), true);
-            if ($lineTerminator || $byte < 32 || isset($escapes[$byte])) {
-                if ($index > $start) hash_update($context, substr($value, $start, $index - $start));
-                if ($lineTerminator) {
-                    hash_update($context, 0xA8 === ord($value[$index + 2]) ? '\\u2028' : '\\u2029');
-                    $index += 2;
-                } else {
-                    hash_update($context, $escapes[$byte] ?? sprintf('\\u%04x', $byte));
-                }
-                $start = $index + 1;
-            } elseif ($index - $start >= 8191) {
-                hash_update($context, substr($value, $start, $index - $start + 1));
-                $start = $index + 1;
+        $offset = 0;
+        while ($offset < $length) {
+            $available = min(65536, $length - $offset);
+            $chunkLength = $available;
+            while ($offset + $chunkLength < $length && 0x80 === (ord($value[$offset + $chunkLength]) & 0xC0)) --$chunkLength;
+            if (0 === $chunkLength) $chunkLength = $available;
+            try {
+                $encoded = json_encode(substr($value, $offset, $chunkLength), JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+            } catch (JsonException) {
+                throw new InvalidArgumentException('Runtime declaration payload is not serializable.');
             }
+            hash_update($context, substr($encoded, 1, -1));
+            $offset += $chunkLength;
         }
-        if ($length > $start) hash_update($context, substr($value, $start));
         hash_update($context, '"');
     }
 

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -356,6 +356,8 @@ final class HtmlTransformer
 
     private HtmlTransformerSession $session;
 
+    private ?bool $authorStylesUseUniversalBorderBoxReset = null;
+
     private const SYNTHETIC_PARAGRAPH_CLASS = 'blocks-engine-synthetic-paragraph';
 
     private const SYNTHETIC_ANCHOR_UNDECORATED_CLASS = 'blocks-engine-synthetic-anchor-undecorated';
@@ -1195,6 +1197,7 @@ final class HtmlTransformer
             $this->runtime,
             fn (DOMElement $element): array => $this->sourceContext($element)
         );
+        $this->authorStylesUseUniversalBorderBoxReset = null;
         $context = TransformationOptions::context($options);
         $startedAt = hrtime(true);
         $this->transformationProvenance()->installFallback(TransformationOptions::provenance($options));
@@ -2564,6 +2567,9 @@ final class HtmlTransformer
 
     private function authorStylesUseUniversalBorderBoxReset(): bool
     {
+        if (null !== $this->authorStylesUseUniversalBorderBoxReset) {
+            return $this->authorStylesUseUniversalBorderBoxReset;
+        }
         $usesBorderBox = false;
         ( new CssStylesheetTransformer() )->visitStyleRules(
             $this->authorStyles()->combinedCss(),
@@ -2583,7 +2589,7 @@ final class HtmlTransformer
                 }
             }
         );
-        return $usesBorderBox;
+        return $this->authorStylesUseUniversalBorderBoxReset = $usesBorderBox;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1244,7 +1244,6 @@ final class HtmlTransformer
             $this->runtime,
             fn (DOMElement $element): array => $this->sourceContext($element)
         );
-        $this->authorStylesUseUniversalBorderBoxReset = null;
         $context = TransformationOptions::context($options);
         $startedAt = hrtime(true);
         $this->transformationProvenance()->installFallback(TransformationOptions::provenance($options));

--- a/php-transformer/src/HtmlToBlocks/Style/AuthorStyleAnalysis.php
+++ b/php-transformer/src/HtmlToBlocks/Style/AuthorStyleAnalysis.php
@@ -18,6 +18,8 @@ final class AuthorStyleAnalysis
     private array $sourceElementsById = array();
     /** @var array<string, list<DOMElement>> */
     private array $sourceElementsByClass = array();
+    /** @var array<string, list<DOMElement>> */
+    private array $sourceElementsByAttribute = array();
     /** @var array<string, true> */
     private array $sourceTags = array();
     /** @var array<string, true> */
@@ -153,11 +155,30 @@ final class AuthorStyleAnalysis
         if ( is_string($rightmost['type'] ?? null) && '' !== $rightmost['type'] ) {
             $candidates[] = $this->sourceElementsByTag[strtolower($rightmost['type'])] ?? array();
         }
+        foreach ( $rightmost['attributes'] ?? array() as $attribute ) {
+            $name = strtolower((string) ($attribute['name'] ?? ''));
+            if ( '' !== $name ) {
+                $candidates[] = $this->sourceElementsByAttribute($name);
+            }
+        }
         if ( array() === $candidates ) {
             return $this->sourceElements;
         }
         usort($candidates, static fn (array $left, array $right): int => count($left) <=> count($right));
         return $candidates[0];
+    }
+
+    /** @return list<DOMElement> */
+    private function sourceElementsByAttribute(string $name): array
+    {
+        if ( isset($this->sourceElementsByAttribute[$name]) ) {
+            return $this->sourceElementsByAttribute[$name];
+        }
+
+        return $this->sourceElementsByAttribute[$name] = array_values(array_filter(
+            $this->sourceElements,
+            static fn (DOMElement $element): bool => $element->hasAttribute($name)
+        ));
     }
 
     /** @param array<string, mixed> $parsed */

--- a/php-transformer/src/HtmlToBlocks/Style/AuthorStyleRuleProjector.php
+++ b/php-transformer/src/HtmlToBlocks/Style/AuthorStyleRuleProjector.php
@@ -6,16 +6,22 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\TransformationEvidenceState;
 use DOMElement;
+use WeakMap;
 
 /** Projects authored rule bodies whose source geometry changes under block wrappers. */
 final class AuthorStyleRuleProjector
 {
     private const ROOT_FONT_SIZE_PX = 16;
 
+    /** @var WeakMap<AuthorStyleAnalysis, bool> */
+    private WeakMap $universalBorderBoxResets;
+
     public function __construct(
         private readonly StyleResolver $styleResolver,
         private readonly AuthorSelectorSemanticPreparer $semanticPreparer
-    ) {}
+    ) {
+        $this->universalBorderBoxResets = new WeakMap();
+    }
 
     public function project(
         string $prelude,
@@ -86,6 +92,10 @@ final class AuthorStyleRuleProjector
 
     private function authorStylesUseUniversalBorderBoxReset(AuthorStyleAnalysis $authorStyles): bool
     {
+        if ( isset($this->universalBorderBoxResets[$authorStyles]) ) {
+            return $this->universalBorderBoxResets[$authorStyles];
+        }
+
         $usesBorderBox = false;
         ( new CssStylesheetTransformer() )->visitStyleRules(
             $authorStyles->combinedCss(),
@@ -105,7 +115,7 @@ final class AuthorStyleRuleProjector
                 }
             }
         );
-        return $usesBorderBox;
+        return $this->universalBorderBoxResets[$authorStyles] = $usesBorderBox;
     }
 
     private function projectResponsiveCanvasMinimumWidth(

--- a/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatchCache.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatchCache.php
@@ -34,6 +34,9 @@ final class CssSelectorMatchCache
     /** @var WeakMap<DOMElement, int> */
     private WeakMap $detachedElementKeys;
 
+    /** @var WeakMap<DOMElement, string> */
+    private WeakMap $connectedElementKeys;
+
     private int $nextDetachedElementKey = 0;
 
     public int $classTokenBuilds = 0;
@@ -68,9 +71,14 @@ final class CssSelectorMatchCache
 
     public int $candidateRulePeakRetained = 0;
 
+    public int $connectedElementKeyBuilds = 0;
+
+    public int $connectedElementKeyHits = 0;
+
     public function __construct()
     {
         $this->detachedElementKeys = new WeakMap();
+        $this->connectedElementKeys = new WeakMap();
     }
 
     /** @return list<string> */
@@ -206,6 +214,7 @@ final class CssSelectorMatchCache
         $this->ruleCandidates = array();
         $this->candidateRulesRetained = 0;
         $this->detachedElementKeys = new WeakMap();
+        $this->connectedElementKeys = new WeakMap();
         $this->nextDetachedElementKey = 0;
     }
 
@@ -217,7 +226,13 @@ final class CssSelectorMatchCache
         // and unique within this per-document cache revision.
         for ( $ancestor = $element; $ancestor instanceof DOMNode; $ancestor = $ancestor->parentNode ) {
             if ( $ancestor instanceof \DOMDocument ) {
-                return 'path:' . $element->getNodePath();
+                if ( isset($this->connectedElementKeys[$element]) ) {
+                    ++$this->connectedElementKeyHits;
+                    return $this->connectedElementKeys[$element];
+                }
+
+                ++$this->connectedElementKeyBuilds;
+                return $this->connectedElementKeys[$element] = 'path:' . $element->getNodePath();
             }
         }
 

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
@@ -7,6 +7,7 @@ use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\CssUrlRewriter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformerAnalysisCache;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\GeneratedGutenbergClassPolicy;
 use DOMElement;
+use WeakMap;
 
 /**
  * Resolves source CSS into native block presentation attributes.
@@ -33,6 +34,9 @@ final class StyleResolver
     private ?HighValueStyleBoundaryPolicy $highValueStyleBoundaryPolicy = null;
 
     private ?ClosedStateNormalizer $closedStateNormalizer = null;
+
+    /** @var WeakMap<DOMElement, string>|null */
+    private ?WeakMap $presentationCacheKeys = null;
 
     /**
      * Resolved presentation attributes for the active transform, keyed by the
@@ -230,6 +234,7 @@ final class StyleResolver
     public function resetPresentationResolutionCache(): void
     {
         $this->context->sourceStyles()->selectorMatchCache = new CssSelectorMatchCache();
+        $this->presentationCacheKeys = null;
     }
 
     public function styleAttributeMapper(): StyleAttributeMapper
@@ -1991,7 +1996,9 @@ final class StyleResolver
 
     private function presentationCacheKey(DOMElement $element): string
     {
-        return spl_object_id($element) . ':' . $element->getNodePath();
+        $this->presentationCacheKeys ??= new WeakMap();
+        return $this->presentationCacheKeys[$element]
+            ??= spl_object_id($element) . ':' . $element->getNodePath();
     }
 
     private function isHighValueStyledElement(DOMElement $element): bool

--- a/php-transformer/tests/unit/author-selector-semantics.php
+++ b/php-transformer/tests/unit/author-selector-semantics.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AuthorStyleAnalysis;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssSelectorMatcher;
 
 $failures = 0;
 $passes = 0;
@@ -25,6 +27,22 @@ $css = static function (array $result): string {
     }
     return implode("\n", $parts);
 };
+
+$candidateDom = new DOMDocument();
+$candidateDom->loadHTML('<!doctype html><body><div data-color="1"></div><p data-color="1"></p><p></p><p></p><span></span></body>');
+$candidateBody = $candidateDom->getElementsByTagName('body')->item(0);
+if (! $candidateBody instanceof DOMElement) {
+    throw new RuntimeException('Attribute candidate fixture did not produce a body element.');
+}
+$candidateAnalysis = new AuthorStyleAnalysis('', '', array(), $candidateBody);
+$attributeCandidates = $candidateAnalysis->selectorCandidates(CssSelectorMatcher::parse('[data-color="1"]'));
+$typedAttributeCandidates = $candidateAnalysis->selectorCandidates(CssSelectorMatcher::parse('p[data-color="1"]'));
+$assert(
+    2 === count($attributeCandidates)
+        && 2 === count($typedAttributeCandidates)
+        && array_reduce($attributeCandidates, static fn (bool $matched, DOMElement $element): bool => $matched && $element->hasAttribute('data-color'), true),
+    'rightmost attributes lazily narrow selector candidates instead of scanning the full source document'
+);
 
 $paragraph = $transform('<style>p{color:red}span{color:blue}</style><span>Loose text</span><p>Paragraph</p>');
 $paragraphClass = (string) ($paragraph['blocks'][1]['attrs']['className'] ?? '');

--- a/php-transformer/tests/unit/css-selector-matcher.php
+++ b/php-transformer/tests/unit/css-selector-matcher.php
@@ -104,6 +104,13 @@ $candidateIndex = array(
 );
 $candidateSelectors = array_column($candidateCache->styleRuleCandidates($byId('target'), 'test', $candidateIndex), 'selector');
 $assert(array( '#target', '.final', 'span', ':not(.excluded)', 'span[data-value]' ) === $candidateSelectors, 'candidate index merges id, class, tag, and universal rules in source order while type wins over direct attributes');
+$pathCache = new CssSelectorMatchCache();
+$pathCachedElement = $byId('target');
+$pathCache->attribute($pathCachedElement, 'id');
+$pathCache->attribute($pathCachedElement, 'id');
+$pathCache->classTokens($pathCachedElement);
+$pathCache->attributeNames($pathCachedElement);
+$assert(1 === $pathCache->connectedElementKeyBuilds && 4 === $pathCache->connectedElementKeyHits, 'connected element wrappers compute their document path once per immutable cache revision');
 $candidateSelectors = array_column($candidateCache->styleRuleCandidates($byId('one'), 'test-attributes', $candidateIndex), 'selector');
 $assert(array( '[data-value]', ':not(.excluded)' ) === $candidateSelectors, 'direct attribute-presence buckets select only elements carrying the attribute');
 $assert($candidateCache->matches($byId('target'), '.final', CssSelectorMatcher::parse('.final'))['matches'], 'selector result cache matches the initial class');

--- a/php-transformer/tests/unit/html-transformer-session-state.php
+++ b/php-transformer/tests/unit/html-transformer-session-state.php
@@ -29,6 +29,8 @@ $tiles = '<my-pricing><div class="tier"><h3>Basic</h3><p>$9</p></div><div class=
 $svg = '<main><svg viewBox="0 0 10 10" role="img" aria-label="Map"><path d="M0 0h10v10z"/></svg></main>';
 $script = '<main><script src="widget.js"></script><canvas id="map">Map</canvas></main>';
 $styled = '<style>.card{display:grid;gap:1rem;color:#123}.card .title{font-weight:700}</style><main class="card" style="display:flex;gap:2rem"><h2 class="title">Styled</h2></main>';
+$borderBox = '<style>*,*::before,*::after{box-sizing:border-box}.card{width:640px;padding:48px;border:2px solid}</style><main class="card">Border box</main>';
+$contentBox = '<style>.card{width:640px;padding:48px;border:2px solid}</style><main class="card">Content box</main>';
 $accordion = static fn (string $label, string $answer): string => '<section class="faq"><div class="faq-item"><button aria-controls="a">' . $label . ' A?</button><div id="a"><p>' . $answer . ' A.</p></div></div><div class="faq-item"><button aria-controls="b">' . $label . ' B?</button><div id="b"><p>' . $answer . ' B.</p></div></div></section>';
 
 $families = array(
@@ -58,6 +60,14 @@ $families = array(
         'assertion' => static fn (array $result): bool => str_contains(
             implode('', array_column(array_filter($result['assets'] ?? array(), static fn (array $asset): bool => 'author-css' === ($asset['source'] ?? '')), 'content')),
             '#0a0'
+        ),
+    ),
+    'author border-box reset' => array(
+        'seed' => array($borderBox, array()),
+        'target' => array($contentBox, array()),
+        'assertion' => static fn (array $result): bool => str_contains(
+            implode('', array_column(array_filter($result['assets'] ?? array(), static fn (array $asset): bool => 'author-css' === ($asset['source'] ?? '')), 'content')),
+            'box-sizing:content-box'
         ),
     ),
     'reused pattern execution context' => array(

--- a/php-transformer/tests/unit/runtime-declarations-streaming-hash.php
+++ b/php-transformer/tests/unit/runtime-declarations-streaming-hash.php
@@ -16,6 +16,7 @@ $values = array(
     array(2 => 'x', 0 => 'a', 1 => 'b'),
     array(0 => 'a', 2 => 'b'),
     array(array('nested' => array('b' => 2, 'a' => 1))),
+    str_repeat('x', 65535) . 'é' . str_repeat('y', 65535),
 );
 
 foreach ($values as $value) {

--- a/php-transformer/tools/benchmarks/staged-page-compilation.php
+++ b/php-transformer/tools/benchmarks/staged-page-compilation.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
+
+if ( $argc < 3 ) {
+    fwrite(STDERR, "Usage: php staged-page-compilation.php <artifact.json> <page-id> [...]\n");
+    exit(1);
+}
+
+$artifact = json_decode((string) file_get_contents($argv[1]), true, 512, JSON_THROW_ON_ERROR);
+$compiler = new ArtifactCompiler();
+$sharedPlan = $compiler->prepareShared($artifact);
+$preparedPages = $compiler->preparePages($artifact, $sharedPlan);
+$pagePlans = array();
+foreach ( array_slice($argv, 2) as $pageId ) {
+    if ( ! isset($preparedPages[$pageId]) ) {
+        throw new RuntimeException(sprintf('Artifact does not contain page %s.', $pageId));
+    }
+    $pagePlans[] = $preparedPages[$pageId];
+}
+
+$startedAt = hrtime(true);
+$receipts = $compiler->compilePreparedPages($sharedPlan, $pagePlans);
+
+fwrite(STDOUT, json_encode(array(
+    'elapsed_ms' => (hrtime(true) - $startedAt) / 1000000,
+    'peak_memory_bytes' => memory_get_peak_usage(true),
+    'pages' => array_map(static fn (array $receipt): array => array(
+        'page_id' => $receipt['page_id'],
+        'compile_duration_ms' => $receipt['work']['compile_duration_ms'] ?? null,
+    ), array_values($receipts)),
+), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");


### PR DESCRIPTION
## Summary

- narrow rightmost attribute selectors through a lazy per-attribute source-element index instead of scanning the full document
- cache stable connected-node and presentation keys for the lifetime of an immutable DOM revision
- preserve universal border-box detection memoization in the extracted stylesheet rule projector
- stream large canonical runtime-declaration strings through bounded JSON-encoding chunks
- add a staged page compilation benchmark for repeatable real-artifact measurements

## Root cause and result

A 1.1 MB captured page with 5,628 elements and five selectors ending in `[data-color="1"]` compiled in 414,322.9 ms. Attribute selectors were omitted from `AuthorStyleAnalysis::selectorCandidates()`, so each selector scanned the full document instead of the 20 elements carrying `data-color`; those scans then repeatedly generated libxml node paths for cache keys.

With this branch on current `trunk`, the same unmodified page compiles in 27,650.6 ms: a 93.3% reduction and 15.0x speedup. This remains a useful target for further optimization, but removes the nonlinear selector-candidate cliff.

Reproduction command:

```sh
php php-transformer/tools/benchmarks/staged-page-compilation.php <artifact.json> <page-id>
```

## Verification

- `composer test:unit`
- `php tests/contract/staged-artifact-compilation.php`
- exact full-page benchmark: 414,322.9 ms -> 27,650.6 ms

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode was used to inspect the PHP process profile, bisect the real captured page and stylesheet inputs, identify the attribute-candidate full-document scan, implement the generic caches and candidate index, run tests and benchmarks, and prepare this pull request. I reviewed the resulting code, evidence, and repository state.