### PR TITLE
Deduplicate speculative selector matching

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -5318,10 +5318,11 @@ final class HtmlTransformer
     }
 
     /** @return list<array{key: string, selector: string, parsed: array<string, mixed>, direct_child_parsed: array<string, mixed>, declarations: array<string, string>, rule_order: int}> */
-    private function authorStyleRuleCandidates(DOMElement $element): array
+    private function authorStyleRuleCandidates(DOMElement $element, ?CssSelectorMatchCache $selectorCache = null): array
     {
         $index = $this->authorStyles()->styleRuleCandidateIndex();
-        return ($this->sourceStyles()->selectorMatchCache ??= new CssSelectorMatchCache())->styleRuleCandidates($element, 'author-rules', $index);
+        $selectorCache ??= $this->sourceStyles()->selectorMatchCache ??= new CssSelectorMatchCache();
+        return $selectorCache->styleRuleCandidates($element, 'author-rules', $index);
     }
 
     private function selectorMatchingSurvivesWrapperCoalescing(DOMElement $element, DOMElement $child, bool $exact = false): bool
@@ -5364,17 +5365,17 @@ final class HtmlTransformer
         $parent->insertBefore($child, $element);
         $parent->removeChild($element);
         $child->setAttribute('class', $this->mergeClassNames(...$chainClasses));
-        $this->styleResolver->invalidateSourceSelectorMatchCache();
 
         $survives = true;
-        $afterCandidates = $this->authorStyleRuleCandidates($child);
+        $temporarySelectorCache = new CssSelectorMatchCache();
+        $afterCandidates = $this->authorStyleRuleCandidates($child, $temporarySelectorCache);
         $candidates = array();
         foreach ( array_merge($beforeCandidates, $afterCandidates) as $selector ) {
             $candidates[$selector['key']] = $selector;
         }
         foreach ( $candidates as $key => $selector ) {
             $matchesAfter = $selector['parsed']['supported']
-                && ($this->sourceStyles()->selectorMatchCache ??= new CssSelectorMatchCache())->matches($child, $selector['selector'], $selector['parsed'], true)['matches'];
+                && $temporarySelectorCache->matches($child, $selector['selector'], $selector['parsed'], true)['matches'];
             if ( ($matchesBefore[$key] ?? false) !== $matchesAfter && ($exact || ! $this->hasOnlyRenderNeutralDeclarations($selector['declarations'])) ) {
                 $survives = false;
                 break;
@@ -5391,8 +5392,6 @@ final class HtmlTransformer
         } else {
             $child->setAttribute('class', $childClass);
         }
-        $this->styleResolver->invalidateSourceSelectorMatchCache();
-
         return $survives;
     }
 

--- a/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatchCache.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatchCache.php
@@ -220,17 +220,17 @@ final class CssSelectorMatchCache
 
     private function elementKey(DOMElement $element): string
     {
+        if ( isset($this->connectedElementKeys[$element]) ) {
+            ++$this->connectedElementKeyHits;
+            return $this->connectedElementKeys[$element];
+        }
+
         // PHP may return a new wrapper each time the same native DOM node is
         // fetched, and it reuses spl_object_id() as soon as an old wrapper is
         // released. A connected node's document path is stable across wrappers
         // and unique within this per-document cache revision.
         for ( $ancestor = $element; $ancestor instanceof DOMNode; $ancestor = $ancestor->parentNode ) {
             if ( $ancestor instanceof \DOMDocument ) {
-                if ( isset($this->connectedElementKeys[$element]) ) {
-                    ++$this->connectedElementKeyHits;
-                    return $this->connectedElementKeys[$element];
-                }
-
                 ++$this->connectedElementKeyBuilds;
                 return $this->connectedElementKeys[$element] = 'path:' . $element->getNodePath();
             }


### PR DESCRIPTION
## Summary

- isolate wrapper-coalescing selector checks in a temporary cache because they run against a temporary DOM shape
- preserve the valid source-DOM selector cache when the speculative mutation is restored
- resolve already-known connected element keys before traversing ancestors

Closes #1044.

## Performance

Measured on the same 10,267-element captured EvolveHealing page and staged page plan used for #1445:

| Metric | #1445 | Candidate | Change |
| --- | ---: | ---: | ---: |
| Selector executions | 5,439,468 | 4,246,539 | -22% |
| Candidate rule checks | 5,459,448 | 4,233,672 | -22% |
| Structural declaration builds | 13,791 | 9,714 | -30% |
| Attribute reads | 49,784 | 24,642 | -51% |

The candidate produced the same canonical receipt hash: `330173e558e16db35ed16ad7ddcc52d3cfef9a652de4206dad15375b9b891572`. Wall time is reported only as observational evidence because concurrent local workload made it noisy; deterministic work counters are the acceptance signal.

## Verification

- `composer test`
- 292 parity fixtures
- packaging install proof
- `git diff --check`
- real staged-page canonical output and deterministic work profile

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode was used to audit selector-cache lifecycle, implement the cache isolation and connected-node lookup simplification, profile the real staged page, and run verification. Chris Huber directed and reviewed the work.