### PR TITLE
Simplify source selector cache ownership

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -830,10 +830,10 @@ final class HtmlTransformer
     }
 
 
-    /** Source markup changed, so cached selector inputs are no longer valid. */
+    /** Source markup changed after selector analysis, so cached inputs are stale. */
     private function onSourceMarkupMutated(): void
     {
-        $this->styleResolver->invalidateSourceSelectorMatchCache();
+        $this->sourceStyles()->invalidateSelectorMatches();
     }
 
     /**
@@ -1347,7 +1347,7 @@ final class HtmlTransformer
         $this->fallbackEmitter()->configure($this->transformationProvenance()->fallback(), $this->runtimeBehavior()->runtimeScriptMetadata(), $this->runtimeSelectors(), $this->authorSelectorProjections()->tagMarkers());
         // Author-selector preparation marks source nodes for later projection.
         // General style matching begins only after those source mutations settle.
-        $this->styleResolver->invalidateSourceSelectorMatchCache();
+        $this->sourceStyles()->invalidateSelectorMatches();
         $this->styleResolver->collectEditorHiddenStateFindings($body);
         $this->reusableComponents()->installRecognition($this->reusableComponentRecognizer->recognize($body));
 
@@ -1730,15 +1730,15 @@ final class HtmlTransformer
             'diagnostic_count'      => count($diagnostics),
             'transform_duration_ms' => (hrtime(true) - $startedAt) / 1000000,
             'output_bytes'          => strlen($output),
-            'selector_match_cache_hits' => $selectorCache?->matchHits ?? 0,
-            'selector_match_cache_misses' => $selectorCache?->matchMisses ?? 0,
-            'selector_match_cache_evictions' => $selectorCache?->matchEvictions ?? 0,
-            'selector_match_cache_peak_entries' => $selectorCache?->matchPeakEntries ?? 0,
-            'style_rule_candidate_cache_hits' => $selectorCache?->candidateRuleHits ?? 0,
-            'style_rule_candidate_cache_misses' => $selectorCache?->candidateRuleMisses ?? 0,
-            'style_rule_candidate_cache_evictions' => $selectorCache?->candidateRuleEvictions ?? 0,
-            'style_rule_candidate_cache_peak_entries' => $selectorCache?->candidateRulePeakEntries ?? 0,
-            'style_rule_candidate_cache_peak_rule_references' => $selectorCache?->candidateRulePeakRetained ?? 0,
+            'selector_match_cache_hits' => $selectorCache->matchHits,
+            'selector_match_cache_misses' => $selectorCache->matchMisses,
+            'selector_match_cache_evictions' => $selectorCache->matchEvictions,
+            'selector_match_cache_peak_entries' => $selectorCache->matchPeakEntries,
+            'style_rule_candidate_cache_hits' => $selectorCache->candidateRuleHits,
+            'style_rule_candidate_cache_misses' => $selectorCache->candidateRuleMisses,
+            'style_rule_candidate_cache_evictions' => $selectorCache->candidateRuleEvictions,
+            'style_rule_candidate_cache_peak_entries' => $selectorCache->candidateRulePeakEntries,
+            'style_rule_candidate_cache_peak_rule_references' => $selectorCache->candidateRulePeakRetained,
         );
     }
 
@@ -3569,7 +3569,7 @@ final class HtmlTransformer
                 $parsed = $selector['direct_child_parsed'];
                 $last = count($parsed['compounds'] ?? array()) - 1;
                 if ( $parsed['supported'] && $last >= 1 && '>' === ($parsed['combinators'][$last - 1] ?? '')
-                    && ($this->sourceStyles()->selectorMatchCache ??= new CssSelectorMatchCache())->matches($child, $selector['selector'], $parsed, true)['matches'] ) {
+                    && $this->sourceStyles()->selectorMatchCache->matches($child, $selector['selector'], $parsed, true)['matches'] ) {
                     return true;
                 }
             }
@@ -5136,7 +5136,7 @@ final class HtmlTransformer
             if ( isset($matchedRules[$ruleOrder])
                 || ! ($candidate['parsed']['supported'] ?? false)
                 || null !== ($candidate['parsed']['pseudo_state_suffix_span'] ?? null)
-                || ! ($this->sourceStyles()->selectorMatchCache ??= new CssSelectorMatchCache())->matches($element, $candidate['selector'], $candidate['parsed'])['matches']
+                || ! $this->sourceStyles()->selectorMatchCache->matches($element, $candidate['selector'], $candidate['parsed'])['matches']
             ) {
                 continue;
             }
@@ -5309,7 +5309,7 @@ final class HtmlTransformer
             if ( isset($matchedRules[$ruleOrder]) || ! $selector['parsed']['supported'] ) {
                 continue;
             }
-            if ( ($this->sourceStyles()->selectorMatchCache ??= new CssSelectorMatchCache())->matches($element, $selector['selector'], $selector['parsed'], true)['matches'] ) {
+            if ( $this->sourceStyles()->selectorMatchCache->matches($element, $selector['selector'], $selector['parsed'], true)['matches'] ) {
                 $matchedRules[$ruleOrder] = true;
                 $declarations = $this->styleResolver->mergeCssDeclarationMaps($declarations, $selector['declarations']);
             }
@@ -5321,7 +5321,7 @@ final class HtmlTransformer
     private function authorStyleRuleCandidates(DOMElement $element, ?CssSelectorMatchCache $selectorCache = null): array
     {
         $index = $this->authorStyles()->styleRuleCandidateIndex();
-        $selectorCache ??= $this->sourceStyles()->selectorMatchCache ??= new CssSelectorMatchCache();
+        $selectorCache ??= $this->sourceStyles()->selectorMatchCache;
         return $selectorCache->styleRuleCandidates($element, 'author-rules', $index);
     }
 
@@ -5354,7 +5354,7 @@ final class HtmlTransformer
         foreach ( $beforeCandidates as $selector ) {
             $matchesBefore[$selector['key']] = $selector['parsed']['supported'] && (bool) array_filter(
                 $chain,
-                fn (DOMElement $node): bool => ($this->sourceStyles()->selectorMatchCache ??= new CssSelectorMatchCache())->matches($node, $selector['selector'], $selector['parsed'], true)['matches']
+                fn (DOMElement $node): bool => $this->sourceStyles()->selectorMatchCache->matches($node, $selector['selector'], $selector['parsed'], true)['matches']
             );
         }
 

--- a/php-transformer/src/HtmlToBlocks/Style/SourceStyleResolutionState.php
+++ b/php-transformer/src/HtmlToBlocks/Style/SourceStyleResolutionState.php
@@ -6,7 +6,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
 /** Per-transform source stylesheet matching and declaration state. */
 final class SourceStyleResolutionState
 {
-    public ?CssSelectorMatchCache $selectorMatchCache = null;
+    public readonly CssSelectorMatchCache $selectorMatchCache;
 
     /** @var array<string, array<string, mixed>> */
     public array $ruleCandidateIndexes = array();
@@ -42,6 +42,17 @@ final class SourceStyleResolutionState
     private array $parsedSelectors = array();
 
     private string $formLayoutCss = '';
+
+    public function __construct()
+    {
+        $this->selectorMatchCache = new CssSelectorMatchCache();
+    }
+
+    public function invalidateSelectorMatches(): void
+    {
+        $this->selectorMatchCache->clear();
+        $this->structuralDeclarations = array();
+    }
 
     /**
      * @param array<string, array<int, string>> $classPromotions

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
@@ -233,7 +233,6 @@ final class StyleResolver
 
     public function resetPresentationResolutionCache(): void
     {
-        $this->context->sourceStyles()->selectorMatchCache = new CssSelectorMatchCache();
         $this->presentationCacheKeys = null;
     }
 
@@ -2279,23 +2278,13 @@ final class StyleResolver
     public function matchesCssSelector(DOMElement $element, string $selector): bool
     {
         $cache = $this->context->sourceStyles();
-        $match = ($cache->selectorMatchCache ??= new CssSelectorMatchCache())->matches($element, $selector, $this->context->parsedCssSelector($selector));
+        $match = $cache->selectorMatchCache->matches($element, $selector, $this->context->parsedCssSelector($selector));
         return $match['supported'] && $match['matches'];
-    }
-
-    public function invalidateSourceSelectorMatchCache(): void
-    {
-        $cache = $this->context->sourceStyles();
-        $cache->selectorMatchCache?->clear();
-        $cache->structuralDeclarations = array();
     }
 
     public function recordSourceSelectorMatchWork(): void
     {
         $selectorCache = $this->context->sourceStyles()->selectorMatchCache;
-        if ( ! $selectorCache instanceof CssSelectorMatchCache ) {
-            return;
-        }
         $this->analysisCache->sourceSelectorMatchExecutions += $selectorCache->matchExecutions;
         $this->analysisCache->sourceSelectorMatchHits += $selectorCache->matchHits;
         $this->analysisCache->sourceSelectorMatchMisses += $selectorCache->matchMisses;
@@ -2318,7 +2307,7 @@ final class StyleResolver
     {
         $cache = $this->context->sourceStyles();
         $index = $cache->ruleCandidateIndexes[$collection] ??= $this->styleRuleCandidateIndex($collection);
-        return ($cache->selectorMatchCache ??= new CssSelectorMatchCache())->styleRuleCandidates($element, $collection, $index);
+        return $cache->selectorMatchCache->styleRuleCandidates($element, $collection, $index);
     }
 
     /** @return array{universal: list<array{order: int, rule: array<string, mixed>}>, ids: array<string, list<array{order: int, rule: array<string, mixed>}>>, classes: array<string, list<array{order: int, rule: array<string, mixed>}>>, tags: array<string, list<array{order: int, rule: array<string, mixed>}>>, attributes: array<string, list<array{order: int, rule: array<string, mixed>}>>, total: int} */

--- a/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
@@ -25,7 +25,7 @@ trait DomHelpersTrait
 
     private function innerHtml(DOMElement $element): string
     {
-        $this->canonicalizeLinkUrls($element);
+        $element = $this->canonicalizedSerializationClone($element);
         $html = '';
         foreach ( $element->childNodes as $child ) {
             $html .= $element->ownerDocument->saveHTML($child);
@@ -36,7 +36,7 @@ trait DomHelpersTrait
 
     private function innerHtmlPreservingWhitespace(DOMElement $element): string
     {
-        $this->canonicalizeLinkUrls($element);
+        $element = $this->canonicalizedSerializationClone($element);
         $html = '';
         foreach ( $element->childNodes as $child ) {
             $html .= $element->ownerDocument->saveHTML($child);
@@ -47,20 +47,18 @@ trait DomHelpersTrait
 
     private function outerHtml(DOMElement $element): string
     {
-        $this->canonicalizeLinkUrls($element);
+        $element = $this->canonicalizedSerializationClone($element);
         return trim($element->ownerDocument->saveHTML($element) ?: '');
     }
 
-    /**
-     * Signals that link canonicalization rewrote source markup.
-     *
-     * This trait is shared by four classes; only the transformer owns a
-     * selector-match cache that such a rewrite would invalidate. The default is
-     * a no-op and HtmlTransformer overrides it, so the other consumers do not
-     * need a collaborator they have no use for.
-     */
-    private function onSourceMarkupMutated(): void
+    private function canonicalizedSerializationClone(DOMElement $element): DOMElement
     {
+        $clone = $element->cloneNode(true);
+        if ( ! $clone instanceof DOMElement ) {
+            throw new \LogicException('Cloning a DOMElement must produce a DOMElement.');
+        }
+        $this->canonicalizeLinkUrls($clone);
+        return $clone;
     }
 
     private function canonicalizeLinkUrls(DOMElement $element): void
@@ -79,14 +77,12 @@ trait DomHelpersTrait
 
             $href = LinkUrlSanitizer::sanitize($anchor->getAttribute('href'));
             if ( '' === $href ) {
-                $this->onSourceMarkupMutated();
                 $anchor->removeAttribute('href');
                 continue;
             }
             if ( $href !== $anchor->getAttribute('href') ) {
-                $this->onSourceMarkupMutated();
+                $anchor->setAttribute('href', $href);
             }
-            $anchor->setAttribute('href', $href);
         }
     }
 


### PR DESCRIPTION
## Summary

- make per-transform source style state own one non-null selector cache for its full lifetime
- centralize selector and structural-declaration invalidation in that owning state
- remove lazy cache reconstruction branches and the StyleResolver invalidation pass-through
- canonicalize links on serialization clones so `innerHtml()` and `outerHtml()` remain read-only and no longer need a cross-class mutation hook

Follow-up to #1446.

## Evidence

The EvolveHealing 10,267-element staged page produced the same canonical receipt hash and exact deterministic work counters as merged #1446:

- canonical hash: `330173e558e16db35ed16ad7ddcc52d3cfef9a652de4206dad15375b9b891572`
- selector executions: 4,246,539
- candidate rule checks: 4,233,672
- structural declaration builds: 9,714
- attribute reads: 24,642

This is an ownership and mutation-semantics simplification, not a cache-policy change.

## Verification

- `composer test`
- 292 parity fixtures
- packaging install proof
- link canonicalization contract
- selector/session/coalescing focused tests
- real staged-page canonical output and deterministic work profile
- `git diff --check`

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode was used to audit cache ownership and hidden DOM mutation, implement the simplification, compare canonical staged-page evidence, and run verification. Chris Huber directed and reviewed the work.