### PR TITLE
Preserve CSS-responsive visibility states

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
@@ -1633,7 +1633,19 @@ final class StyleResolver
             return $declarations;
         }
 
+        $responsiveDisplay = null;
+        if (
+            'none' === CssValueInspector::comparable((string) ($declarations['display'] ?? ''))
+            && $this->hasConditionalVisibleDisplay($element)
+        ) {
+            $responsiveDisplay = $declarations['display'];
+            unset($declarations['display']);
+        }
+
         $normalized = $this->closedStateNormalizer()->strip($declarations);
+        if ( null !== $responsiveDisplay ) {
+            $normalized['declarations']['display'] = $responsiveDisplay;
+        }
         if ( array() !== $normalized['stripped'] ) {
             $this->context->transformationEvidence()->recordFrozenHiddenState(array(
                 'tag'          => strtolower($element->tagName),
@@ -1644,6 +1656,21 @@ final class StyleResolver
         }
 
         return $normalized['declarations'];
+    }
+
+    private function hasConditionalVisibleDisplay(DOMElement $element): bool
+    {
+        foreach ($this->styleRuleCandidates($element, 'conditional') as $rule) {
+            if (! $this->matchesCssSelector($element, $rule['selector'])) {
+                continue;
+            }
+            $display = CssValueInspector::comparable((string) ($rule['declarations']['display'] ?? ''));
+            if ( '' !== $display && 'none' !== $display ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /** @return list<string> */

--- a/php-transformer/tests/unit/inert-closed-state-interactions.php
+++ b/php-transformer/tests/unit/inert-closed-state-interactions.php
@@ -182,6 +182,26 @@ $assert(
     $hiddenAnswerAfterAuthor
 );
 
+$responsiveDocument = <<<'HTML'
+<style>
+.mobile-document { display: none !important; }
+@media (max-width: 600px) {
+  .desktop-document { display: none !important; }
+  .mobile-document { display: contents !important; }
+}
+</style>
+<div class="desktop-document"><p>Desktop document</p></div>
+<div class="mobile-document"><p>Mobile document</p></div>
+HTML;
+
+$responsiveDocumentResult = ( new HtmlTransformer() )->transform($responsiveDocument)->toArray();
+$responsiveDocumentAfterAuthor = $cssContent($responsiveDocumentResult, 'after-author', 'both');
+$assert(
+    ! str_contains($responsiveDocumentAfterAuthor, '.mobile-document{display:revert'),
+    'a media-revealed responsive document does not receive a global closed-state display repair',
+    $responsiveDocumentAfterAuthor
+);
+
 $products = <<<'HTML'
 <div class="products">
   <div class="item"><h3>Product A</h3><p>Nice chair.</p></div>


### PR DESCRIPTION
## Summary

- preserve baseline `display:none` when a matching conditional rule provides a visible display state
- prevent closed-state normalization from emitting a global after-author reveal for CSS-responsive content
- retain existing repairs for genuinely script-owned hidden content

Fixes #1452.

## Verification

- `composer test`
- regression first failed with `:root .mobile-document{display:revert!important}`, then passed after the fix
- 292 parity fixtures and package installation proof passed

## AI assistance

OpenAI GPT-5.6-sol via OpenCode was used to trace the generated cascade, implement the generic conditional-display classification, add regression coverage, and run verification. Chris Huber directs and reviews the work.