### PR TITLE
Install only page-applicable author style rules

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/AuthorSelectorSemanticPreparer.php
+++ b/php-transformer/src/HtmlToBlocks/Style/AuthorSelectorSemanticPreparer.php
@@ -49,7 +49,17 @@ final class AuthorSelectorSemanticPreparer
             $projections->ensureTagMarker($tagName);
         }
         $this->discoverAuthorControlPaths($authorSelectors, $authorStyles, $projections);
-        $authorStyles->installStyleRules($authorStyleRules);
+        $applicableAuthorStyleRules = array();
+        foreach ( $authorStyleRules as $rule ) {
+            $rule['selectors'] = array_values(array_filter(
+                $rule['selectors'],
+                static fn (array $selector): bool => $authorStyles->selectorCanMatch($selector['parsed'])
+            ));
+            if ( array() !== $rule['selectors'] ) {
+                $applicableAuthorStyleRules[] = $rule;
+            }
+        }
+        $authorStyles->installStyleRules($applicableAuthorStyleRules);
         $this->discoverAuthorInlineSemanticPaths($authorSelectors, $authorStyles, $projections);
         $this->discoverInlineLayoutCarrierPaths($authorSelectors, $authorStyles, $projections);
         $this->discoverAuthorAttributePaths($authorSelectors, $authorStyles, $projections);

--- a/php-transformer/tests/unit/author-selector-semantics.php
+++ b/php-transformer/tests/unit/author-selector-semantics.php
@@ -600,6 +600,13 @@ $assert(! str_contains($css($second), 'blocks-engine-source-p-') && 1 === substr
 $third = $instance->transform('<style>.cta:hover{color:red}</style><p>Read <span class="cta">this</span>.</p>')->toArray();
 $assert(str_contains($css($third), 'blocks-engine-richtext-') && ! str_contains($css($third), '> :where(.wp-block-button__link)'), 'repeated selector text resolves against each transform source DOM');
 
+$applicabilityTransformer = new HtmlTransformer();
+$applicabilityTransformer->transform('<style>.absent *{color:red}.present,.missing{padding:1rem}</style><div class="present">Present</div>');
+$applicabilitySession = (new ReflectionClass($applicabilityTransformer))->getProperty('session')->getValue($applicabilityTransformer);
+$applicableRules = $applicabilitySession->authorStyleAnalysis()?->styleRules() ?? array();
+$applicableSelectors = array_column(array_merge(...array_column($applicableRules, 'selectors')), 'selector');
+$assert(array('.present') === $applicableSelectors, 'the installed page-matching graph omits selectors whose required source signals are absent');
+
 $customPropertyCards = $transform('<style>.tour-card{background:linear-gradient(135deg,var(--tone),#fff)}</style><div class="tour-card" style="width:344px;height:430px;--tone:#f06;--unused:discard">First</div><div class="tour-card" style="width:344px;height:430px;--tone:#0af;--unused:discard">Second</div>');
 $customPropertyCardsMarkup = (string) ($customPropertyCards['serialized_blocks'] ?? '');
 $assert(! str_contains($customPropertyCardsMarkup, '--tone:') && ! str_contains($customPropertyCardsMarkup, '--unused:discard') && str_contains($css($customPropertyCards), '--tone:#f06 !important') && str_contains($css($customPropertyCards), '--tone:#0af !important') && str_contains($css($customPropertyCards), 'background:linear-gradient(135deg,var(--tone),#fff)'), 'author-CSS-consumed card custom properties retain distinct gradient values in generated carrier CSS without unused-property or cross-card leakage');


### PR DESCRIPTION
## Summary
- install only the author style-rule selectors whose required source signals exist in the page being compiled
- add coverage proving the installed matching graph omits selectors that cannot match the source document

Follows #1467.

## Problem
`AuthorSelectorSemanticPreparer` already proves selector applicability against the source DOM through `AuthorStyleAnalysis::selectorCanMatch()`, then installs every parsed rule regardless. Every later matching pass re-tests selectors whose classes, ids, or tags do not exist on the page.

On the production corpus page `free-tour.html`, the `author-rules` candidate graph alone performed 1,296,146 candidate checks, and broad selectors such as `div.ps-active *` executed 4,853 times each despite their required classes being absent from the document.

## Real-corpus evidence
Corpus: 624 files, 34 pages, 287 stylesheets. Page: `free-tour.html`.

Alternating paired runs, baseline versus this change:

- canonical receipt SHA-256 unchanged: `e52cc2d4fc9be0c7addb88d1f9616e7c04ebf6c1d3c7995f840d30f6e82d225d`
- selector match executions: 511,417 to 475,707
- selector match evictions: 503,225 to 467,515
- candidate rule checks: 2,143,127 to 2,068,979
- compile CPU: 17.56s to 16.19s and 17.77s to 16.14s, about 7.8%
- peak memory: 215.7 MiB to 192.7 MiB, a 23.1 MiB reduction

The reduction in evictions matters as much as the timing: fewer impossible selectors means the bounded match cache retains more useful entries.

## Verification
- `composer validate --strict`
- `composer test`
- byte-identical real-corpus receipt comparison
- alternating baseline/candidate CPU, memory, and counter measurements

## Scope
This is one measured step. Source-selector matching remains the dominant cost, and the full 34-page import is still slower than the target.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode instrumented per-selector and per-collection counters on the real corpus to locate the duplicated work, implemented the applicability filter, reverted a separate table-mutation hypothesis that measurement disproved, and ran the paired verification. Chris Huber directed the work.