### PR TITLE
Exclude unmatchable source rules from candidate indexes

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/AuthorSelectorSemanticPreparer.php
+++ b/php-transformer/src/HtmlToBlocks/Style/AuthorSelectorSemanticPreparer.php
@@ -60,6 +60,10 @@ final class AuthorSelectorSemanticPreparer
             }
         }
         $authorStyles->installStyleRules($applicableAuthorStyleRules);
+        $sourceStyles->retainMatchableRules(static function (array $rule) use ($sourceStyles, $authorStyles): bool {
+            $parsed = $sourceStyles->parsedSelector((string) ($rule['selector'] ?? ''));
+            return null === $parsed || ! ($parsed['supported'] ?? false) || $authorStyles->selectorCanMatch($parsed);
+        });
         $this->discoverAuthorInlineSemanticPaths($authorSelectors, $authorStyles, $projections);
         $this->discoverInlineLayoutCarrierPaths($authorSelectors, $authorStyles, $projections);
         $this->discoverAuthorAttributePaths($authorSelectors, $authorStyles, $projections);

--- a/php-transformer/src/HtmlToBlocks/Style/SourceStyleResolutionState.php
+++ b/php-transformer/src/HtmlToBlocks/Style/SourceStyleResolutionState.php
@@ -69,6 +69,20 @@ final class SourceStyleResolutionState
         $this->customProperties = $analysis['custom_properties'];
     }
 
+    /**
+     * Retain only the rules whose selectors can match this source document.
+     *
+     * @param callable(array<string, mixed>): bool $isMatchable
+     */
+    public function retainMatchableRules(callable $isMatchable): void
+    {
+        // Rule keys carry source order, so filtering preserves them.
+        $this->staticRules = array_filter($this->staticRules, $isMatchable);
+        $this->conditionalRules = array_filter($this->conditionalRules, $isMatchable);
+        $this->pseudoElementRules = array_filter($this->pseudoElementRules, $isMatchable);
+        $this->ruleCandidateIndexes = array();
+    }
+
     /** @return array<int, string> */
     public function classPromotions(string $className): array
     {

--- a/php-transformer/tests/unit/author-selector-semantics.php
+++ b/php-transformer/tests/unit/author-selector-semantics.php
@@ -607,6 +607,20 @@ $applicableRules = $applicabilitySession->authorStyleAnalysis()?->styleRules() ?
 $applicableSelectors = array_column(array_merge(...array_column($applicableRules, 'selectors')), 'selector');
 $assert(array('.present') === $applicableSelectors, 'the installed page-matching graph omits selectors whose required source signals are absent');
 
+$indexedSelectors = array();
+foreach ( $applicabilitySession->sourceStyleResolutionState()->ruleCandidateIndexes as $index ) {
+    foreach ( array( 'universal', 'ids', 'classes', 'tags', 'attributes' ) as $bucket ) {
+        $entries = 'universal' === $bucket ? $index[$bucket] : array_merge(...array_values($index[$bucket] ?: array(array())));
+        foreach ( $entries as $entry ) {
+            $indexedSelectors[(string) ($entry['rule']['selector'] ?? '')] = true;
+        }
+    }
+}
+$assert(
+    array() !== $indexedSelectors && ! isset($indexedSelectors['.absent *']) && ! isset($indexedSelectors['.missing']),
+    'source-style candidate indexes omit selectors whose required source signals are absent'
+);
+
 $customPropertyCards = $transform('<style>.tour-card{background:linear-gradient(135deg,var(--tone),#fff)}</style><div class="tour-card" style="width:344px;height:430px;--tone:#f06;--unused:discard">First</div><div class="tour-card" style="width:344px;height:430px;--tone:#0af;--unused:discard">Second</div>');
 $customPropertyCardsMarkup = (string) ($customPropertyCards['serialized_blocks'] ?? '');
 $assert(! str_contains($customPropertyCardsMarkup, '--tone:') && ! str_contains($customPropertyCardsMarkup, '--unused:discard') && str_contains($css($customPropertyCards), '--tone:#f06 !important') && str_contains($css($customPropertyCards), '--tone:#0af !important') && str_contains($css($customPropertyCards), 'background:linear-gradient(135deg,var(--tone),#fff)'), 'author-CSS-consumed card custom properties retain distinct gradient values in generated carrier CSS without unused-property or cross-card leakage');

--- a/php-transformer/tests/unit/html-transformer-shared-analysis-cache.php
+++ b/php-transformer/tests/unit/html-transformer-shared-analysis-cache.php
@@ -161,7 +161,7 @@ for ( $index = 0; $index < 100; ++$index ) {
 $candidateHtml = '<style>' . implode('', array_merge($noiseRules, array( '.target{color:red}', 'article{padding:1px}', '.target{color:blue}' ) )) . '</style><section class="target">Indexed target</section>';
 $candidateResult = (new HtmlTransformer(analysisCache: $candidateCache))->transform($candidateHtml)->toArray();
 $assert('blue' === ($candidateResult['blocks'][0]['attrs']['style']['color']['text'] ?? ''), 'Rightmost class candidates preserve duplicate matching-key cascade order.');
-$assert(2 === $candidateCache->sourceStyleCandidateRuleChecks && 204 === $candidateCache->sourceStyleCandidateRulesSkipped, 'Indexed collection checks two relevant rule candidates while deterministically skipping 204 irrelevant candidates.');
+$assert(2 === $candidateCache->sourceStyleCandidateRuleChecks && 2 === $candidateCache->sourceStyleCandidateRulesSkipped, 'Indexed collection checks two relevant rule candidates, and the 100 rules whose classes are absent from the source never enter the index.');
 
 $hiddenStateCache = new HtmlTransformerAnalysisCache();
 $hiddenStateNoise = array();
@@ -174,7 +174,7 @@ $hiddenStateResult = (new HtmlTransformer(analysisCache: $hiddenStateCache))->tr
 )->toArray();
 $hiddenStateFindings = $hiddenStateResult['source_reports']['html']['frozen_hidden_state'] ?? array();
 $assert(array() !== $hiddenStateFindings && in_array('opacity:0', $hiddenStateFindings[0]['declarations'] ?? array(), true), 'Indexed hidden-state collection preserves canonical frozen-state findings.');
-$assert(1001 === $hiddenStateCache->sourceStyleCandidateRulesSkipped && 1 === $hiddenStateCache->sourceSelectorMatchExecutions, 'Hidden-state collection skips irrelevant rightmost-selector candidates instead of matching every rule against every element.');
+$assert(401 === $hiddenStateCache->sourceStyleCandidateRulesSkipped && 1 === $hiddenStateCache->sourceSelectorMatchExecutions, 'Hidden-state collection skips irrelevant rightmost-selector candidates, and rules whose classes are absent from the source never enter the index.');
 
 // One repeated hot rule across 4,097 elements forces both bounded result caches
 // past capacity while later style-resolution passes refresh the same entries.


### PR DESCRIPTION
## Summary
- retain only the source style rules whose selectors can match the document being compiled, at the point where the applicability proof is already established
- rebuild the static, conditional, and pseudo-element candidate indexes from that filtered set
- update candidate-accounting coverage to assert that absent-class rules never enter an index

Follows #1480.

## Problem
#1480 filtered the author rule graph, but the source style collections still indexed every parsed rule. On `free-tour.html` that left 2,068,979 candidate checks and 475,707 selector executions, most of them re-testing selectors whose classes and ids do not exist anywhere in the page.

`AuthorSelectorSemanticPreparer` already proves applicability against the source document, so the source rule streams are filtered there and the candidate indexes are rebuilt from the result.

## Real-corpus evidence
Corpus: 624 files, 34 pages, 287 stylesheets.

`free-tour.html`, paired baseline versus this change:

- canonical receipt SHA-256 unchanged: `e52cc2d4fc9be0c7addb88d1f9616e7c04ebf6c1d3c7995f840d30f6e82d225d`
- selector match executions: 475,707 to 152,857, a 68% reduction
- selector match evictions: 467,515 to 144,665, a 69% reduction
- candidate rule checks: 2,068,979 to 1,487,636, a 28% reduction
- compile CPU: 21.05s to 18.15s
- peak memory: 192.7 MiB to 186.4 MiB

`about.html` independently confirms identical output, receipt `c06054cb00da7001…`, with executions falling from 95,079 to 42,657.

The eviction collapse matters as much as the timing, because the bounded match cache now retains entries that are actually reused.

## Behavior coverage
Two existing candidate-accounting assertions encoded the old totals and were updated to the stronger property:

- indexed collection: 204 skipped candidates becomes 2, because the 100 absent-class rules never enter the index; the duplicate-key cascade result is unchanged
- hidden-state collection: 1001 skipped candidates becomes 401, with the canonical frozen-state finding unchanged

A new assertion fails without the production change.

## Verification
- `composer validate --strict`
- `composer test`, including all 292 parity fixtures
- byte-identical receipts on two independent production pages
- paired baseline/candidate CPU, memory, and counter measurements

## Note
An earlier attempt applied this filter inside `StyleResolver::styleRuleCandidateIndex()`. The suite caught that pattern-level entry points reach the resolver without prepared author styles, so the filter belongs in the preparer that owns the proof.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode implemented the filter, relocated it after the test suite exposed the unprepared-transform path, updated the affected accounting assertions, and ran the paired real-corpus verification. Chris Huber directed the work.