### PR TITLE
Apply a repeated stylesheet reference once

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -2543,6 +2543,7 @@ final class ArtifactCompiler
             $reserved[$path] = true;
         }
         $occurrences = array();
+        $variants = array();
         if ( ! preg_match_all('/<link\b[^>]*>/i', $html, $matches) ) {
             return $files;
         }
@@ -2563,8 +2564,16 @@ final class ArtifactCompiler
                 $files[$byPath[$originalPath]]['type'] = $type;
                 $files[$byPath[$originalPath]]['stylesheet_source_path'] = $originalPath;
                 $files[$byPath[$originalPath]]['stylesheet_occurrence'] = 1;
+                $variants[$originalPath][$media . "\0" . $type] = true;
                 continue;
             }
+            // Repeating one stylesheet under the same conditions applies it
+            // once, exactly as a browser resolves it. Only a differing media or
+            // type makes a later reference its own participant in the cascade.
+            if ( isset($variants[$originalPath][$media . "\0" . $type]) ) {
+                continue;
+            }
+            $variants[$originalPath][$media . "\0" . $type] = true;
             $alias = $this->allocateStylesheetOccurrencePath($this->stylesheetOccurrencePath($originalPath, $occurrence), $reserved);
             $aliasFile = $files[$byPath[$originalPath]];
             $aliasFile['path'] = $alias;

--- a/php-transformer/src/HtmlToBlocks/Style/AuthorStyleAnalysis.php
+++ b/php-transformer/src/HtmlToBlocks/Style/AuthorStyleAnalysis.php
@@ -219,6 +219,12 @@ final class AuthorStyleAnalysis
         foreach ( $this->styleRules as $rule ) {
             foreach ( $rule['selectors'] as $selectorIndex => $selector ) {
                 $parsed = $selector['parsed'];
+                // Candidates exist to be matched. A selector this matcher cannot
+                // evaluate, in either its authored or direct-child form, never
+                // matches an element, so it is not a candidate for one.
+                if ( ! ($parsed['supported'] ?? false) && ! ($selector['direct_child_parsed']['supported'] ?? false) ) {
+                    continue;
+                }
                 $compounds = $parsed['compounds'] ?? array();
                 $rightmost = array() === $compounds ? null : $compounds[array_key_last($compounds)];
                 $target = 'universal';

--- a/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
+++ b/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
@@ -30,8 +30,8 @@ $assets = $result['assets'] ?? array();
 $assetPaths = array_column($assets, 'path');
 $assetsByPath = array_column($assets, null, 'path');
 $assert(1 === preg_match('#^assets/css/engine-support-before-author-[a-f0-9]{16}\.css$#', $assetPaths[0] ?? '')
-    && array( 'index.inline-1.css', 'a.css', 'index.inline-2.css', 'b.css', 'a.occurrence-2-generated-1.css', 'a.occurrence-2.css' ) === array_slice($assetPaths, 1, 6)
-    && 1 === preg_match('#^assets/css/engine-support-after-author-[a-f0-9]{16}\.css$#', $assetPaths[7] ?? ''), 'allocated repeated-link alias preserves source occurrence order around before- and after-author support assets');
+    && array( 'index.inline-1.css', 'a.css', 'index.inline-2.css', 'b.css', 'a.occurrence-2.css' ) === array_slice($assetPaths, 1, 5)
+    && 1 === preg_match('#^assets/css/engine-support-after-author-[a-f0-9]{16}\.css$#', $assetPaths[6] ?? ''), 'source stylesheet order is preserved around before- and after-author support assets, and a repeated identical link adds no second copy');
 foreach ( $assets as $asset ) {
     $content = (string) ($asset['content'] ?? '');
     $hash = hash('sha256', $content);
@@ -47,7 +47,27 @@ $assert(hash('sha256', base64_encode('a.cta:hover{padding:1rem}')) === ($assetsB
 $assert('text' === ($assetsByPath['a.css']['content_encoding'] ?? '') && ! isset($assetsByPath['a.css']['content_base64']), 'projected linked CSS invalidates the stale source payload encoding');
 $assert(! str_contains((string) ($assetsByPath['a.css']['content'] ?? ''), 'a.cta:hover') && str_contains((string) ($assetsByPath['a.css']['content'] ?? ''), '> :where(.wp-block-button__link):hover'), 'linked button CSS is rewritten in place');
 $assert(hash('sha256', '.hero p{color:green}') === ($assetsByPath['index.inline-2.css']['source_hash'] ?? null) && ! str_contains((string) ($assetsByPath['index.inline-2.css']['content'] ?? ''), '.hero p') && str_contains((string) ($assetsByPath['index.inline-2.css']['content'] ?? ''), ':where(.blocks-engine-source-p-'), 'inline CSS is rewritten in place with original source provenance');
-$assert(str_contains((string) ($assetsByPath['a.occurrence-2-generated-1.css']['content'] ?? ''), '> :where(.wp-block-button__link):hover') && '.authored-collision{color:purple}' === ($assetsByPath['a.occurrence-2.css']['content'] ?? ''), 'allocated occurrence alias is referenced while authored collision CSS remains a deterministic orphan asset');
+$assert(! isset($assetsByPath['a.occurrence-2-generated-1.css']) && '.authored-collision{color:purple}' === ($assetsByPath['a.occurrence-2.css']['content'] ?? ''), 'a repeated identical link materializes no alias while authored collision CSS remains a deterministic orphan asset');
+
+// A repeat under a different media condition is a distinct cascade
+// participant, so it still earns its own asset, allocated around the authored
+// path collision.
+$mediaVariant = ( new ArtifactCompiler() )->compile(array(
+    'files' => array(
+        array( 'path' => 'index.html', 'kind' => 'html', 'content' => '<!doctype html><html><head><link rel="stylesheet" href="a.css"><link rel="stylesheet" href="a.css" media="print"><link rel="stylesheet" href="a.css"></head><body><p class="copy">Copy</p></body></html>' ),
+        array( 'path' => 'a.css', 'kind' => 'css', 'content' => '.copy{color:red}' ),
+        array( 'path' => 'a.occurrence-2.css', 'kind' => 'css', 'content' => '.authored-collision{color:purple}' ),
+    ),
+) )->toArray();
+$mediaVariantPaths = array_column($mediaVariant['assets'] ?? array(), 'path');
+$mediaVariantAssets = array_column($mediaVariant['assets'] ?? array(), null, 'path');
+$assert(
+    in_array('a.css', $mediaVariantPaths, true)
+        && in_array('a.occurrence-2-generated-1.css', $mediaVariantPaths, true)
+        && 'print' === ($mediaVariantAssets['a.occurrence-2-generated-1.css']['media'] ?? null)
+        && 1 === count(array_filter($mediaVariantPaths, static fn (string $path): bool => str_contains($path, 'occurrence-2-generated'))),
+    'a repeated link under a different media condition still materializes its own asset, and the third identical link adds no further copy'
+);
 
 $runtimeReveal = ( new ArtifactCompiler() )->compile(array( 'files' => array(
     array( 'path' => 'index.html', 'kind' => 'html', 'content' => <<<'HTML'

--- a/php-transformer/tests/unit/author-selector-semantics.php
+++ b/php-transformer/tests/unit/author-selector-semantics.php
@@ -607,6 +607,24 @@ $applicableRules = $applicabilitySession->authorStyleAnalysis()?->styleRules() ?
 $applicableSelectors = array_column(array_merge(...array_column($applicableRules, 'selectors')), 'selector');
 $assert(array('.present') === $applicableSelectors, 'the installed page-matching graph omits selectors whose required source signals are absent');
 
+$unmatchableTransformer = new HtmlTransformer();
+$unmatchableTransformer->transform('<style>.card:before{content:""}.card::after{content:""}.card p::before{content:""}.card{color:red}</style><div class="card"><p>Copy</p></div>');
+$unmatchableSession = (new ReflectionClass($unmatchableTransformer))->getProperty('session')->getValue($unmatchableTransformer);
+$unmatchableIndex = $unmatchableSession->authorStyleAnalysis()?->styleRuleCandidateIndex() ?? array();
+$indexedAuthorSelectors = array();
+foreach ( array( 'universal', 'ids', 'classes', 'tags', 'attributes' ) as $bucket ) {
+    $entries = 'universal' === $bucket ? $unmatchableIndex[$bucket] : array_merge(...array_values($unmatchableIndex[$bucket] ?: array(array())));
+    foreach ( $entries as $entry ) {
+        $indexedAuthorSelectors[(string) ($entry['rule']['selector'] ?? '')] = true;
+    }
+}
+$assert(
+    isset($indexedAuthorSelectors['.card'])
+        && isset($indexedAuthorSelectors['.card p::before'])
+        && ! isset($indexedAuthorSelectors['.card:before']),
+    'author candidate index omits selectors this matcher cannot evaluate while retaining direct-child pseudo-element forms'
+);
+
 $indexedSelectors = array();
 foreach ( $applicabilitySession->sourceStyleResolutionState()->ruleCandidateIndexes as $index ) {
     foreach ( array( 'universal', 'ids', 'classes', 'tags', 'attributes' ) as $bucket ) {


### PR DESCRIPTION
## Summary
- materialize one asset per stylesheet reference that actually participates in the cascade, instead of one per link tag
- retain a separate asset when a repeat carries a different `media` or `type`
- cover both cases, including the authored path-collision fallback

Stacked on #1484. Base retargets as the chain merges.

## Problem
The Taste and Travel source pages link the same stylesheet many times, because each marketplace widget instance inlines its own tag inside `<body>`:

```
<div id="element-141ad901…" data-platform-element-id="318202189592020009-1.0.5">
  <link rel="stylesheet" href="…/assets/animate.css">
```

`free-tour.html` has 69 stylesheet links across 47 distinct hrefs, with `animate.css` linked 16 times. A browser fetches and applies that stylesheet once. `withStylesheetOccurrenceAssets()` instead cloned the file for every repeat, so the compiler carried 71 payloads and emitted 71 CSS files where 48 exist.

The generated site was therefore heavier than the site it liberated: 16 distinct URLs for one stylesheet, all enqueued.

The occurrence-alias mechanism still matters, because the same stylesheet can legitimately appear twice under different media conditions. That case is preserved; only conditionless repeats collapse.

## Ownership
The duplication is genuine in the captured source, so this is not an upstream capture defect. The liberation artifact already content-addresses assets correctly. Modelling repeated identical references as one stylesheet is CSS semantics, so it belongs here rather than being delegated to whatever produced the artifact.

## Real-corpus evidence
624-file corpus, per page emitted author CSS:

| page | files | bytes | editor stylesheet |
| --- | --- | --- | --- |
| `free-tour.html` | 71 to 49 | 2,534,588 to 1,176,806 (-53.6%) | 1,609,374 to 587,002 (-63.5%) |
| `about.html` | 44 to 38 | 1,150,865 to 729,092 (-36.7%) | 697,493 to 328,327 (-52.9%) |
| `contact.html` | 39 to 35 | 913,674 to 674,597 (-26.2%) | 499,966 to 290,412 (-41.9%) |

Compile cost on `free-tour.html`, paired runs: 9,358 ms to 6,097 ms and 9,550 ms to 5,736 ms CPU, with peak memory 184.3 MiB to 175.7 MiB. Combined author CSS for that page falls from 2,363,666 to 1,002,211 bytes.

## Functional equivalence
Emitted assets change by design, so byte-identical receipts are not the gate here. Three independent checks:

1. **Block markup is byte-identical.** Serialized blocks for `free-tour.html` are 345,231 bytes before and after, and compare exactly equal once deterministic marker seeds and content-addressed generated block names are normalized. Those identifiers are derived from a hash of the combined CSS, so they shift when duplicate payloads are removed while the structure they name does not.
2. **The cascade resolves identically.** Resolving 35 properties through `StaticCssCascade` over a strided sample of 239 elements from the real page, comparing full duplicated CSS against deduplicated CSS, produced zero differing computed values.
3. **No new fallbacks.** Fallback counts are unchanged per page: 0, 0, and 2.

## Verification
- `composer validate --strict`
- `composer test`, including all 292 parity fixtures
- cascade-equivalence and block-markup comparisons described above

A browser parity pass on a rebuilt site is still the acceptance gate for the import itself; this PR carries the offline evidence.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode traced the duplication from emitted assets back to the captured source, confirmed it originates in the source site rather than in capture, implemented the media-aware collapse, and produced the cascade-equivalence and markup-equivalence evidence. Chris Huber directed the work and identified duplicate operations and unnecessary output as the target.