### PR TITLE
Keep unmatchable selectors out of the author candidate index

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/AuthorStyleAnalysis.php
+++ b/php-transformer/src/HtmlToBlocks/Style/AuthorStyleAnalysis.php
@@ -219,6 +219,12 @@ final class AuthorStyleAnalysis
         foreach ( $this->styleRules as $rule ) {
             foreach ( $rule['selectors'] as $selectorIndex => $selector ) {
                 $parsed = $selector['parsed'];
+                // Candidates exist to be matched. A selector this matcher cannot
+                // evaluate, in either its authored or direct-child form, never
+                // matches an element, so it is not a candidate for one.
+                if ( ! ($parsed['supported'] ?? false) && ! ($selector['direct_child_parsed']['supported'] ?? false) ) {
+                    continue;
+                }
                 $compounds = $parsed['compounds'] ?? array();
                 $rightmost = array() === $compounds ? null : $compounds[array_key_last($compounds)];
                 $target = 'universal';

--- a/php-transformer/tests/unit/author-selector-semantics.php
+++ b/php-transformer/tests/unit/author-selector-semantics.php
@@ -607,6 +607,24 @@ $applicableRules = $applicabilitySession->authorStyleAnalysis()?->styleRules() ?
 $applicableSelectors = array_column(array_merge(...array_column($applicableRules, 'selectors')), 'selector');
 $assert(array('.present') === $applicableSelectors, 'the installed page-matching graph omits selectors whose required source signals are absent');
 
+$unmatchableTransformer = new HtmlTransformer();
+$unmatchableTransformer->transform('<style>.card:before{content:""}.card::after{content:""}.card p::before{content:""}.card{color:red}</style><div class="card"><p>Copy</p></div>');
+$unmatchableSession = (new ReflectionClass($unmatchableTransformer))->getProperty('session')->getValue($unmatchableTransformer);
+$unmatchableIndex = $unmatchableSession->authorStyleAnalysis()?->styleRuleCandidateIndex() ?? array();
+$indexedAuthorSelectors = array();
+foreach ( array( 'universal', 'ids', 'classes', 'tags', 'attributes' ) as $bucket ) {
+    $entries = 'universal' === $bucket ? $unmatchableIndex[$bucket] : array_merge(...array_values($unmatchableIndex[$bucket] ?: array(array())));
+    foreach ( $entries as $entry ) {
+        $indexedAuthorSelectors[(string) ($entry['rule']['selector'] ?? '')] = true;
+    }
+}
+$assert(
+    isset($indexedAuthorSelectors['.card'])
+        && isset($indexedAuthorSelectors['.card p::before'])
+        && ! isset($indexedAuthorSelectors['.card:before']),
+    'author candidate index omits selectors this matcher cannot evaluate while retaining direct-child pseudo-element forms'
+);
+
 $indexedSelectors = array();
 foreach ( $applicabilitySession->sourceStyleResolutionState()->ruleCandidateIndexes as $index ) {
     foreach ( array( 'universal', 'ids', 'classes', 'tags', 'attributes' ) as $bucket ) {


### PR DESCRIPTION
## Summary
- stop indexing author selectors this matcher cannot evaluate, in either their authored or direct-child form
- add coverage that fails without the change

Replaces #1484, which GitHub auto-closed when its base branch was deleted on merge of #1481. Same branch, same commit, retargeted to `trunk`.

## Problem
Profiling the remaining candidate work on `free-tour.html` showed the `author-rules` index dominating with 1,223,228 of 1,487,636 checks. The cause was not selector shape but selector support: 3,448 of the 3,451 universal-bucket entries were selectors the matcher reports as unsupported, such as `.grid *:before`, `.video-js .vjs-control:before`, and `:-ms-fullscreen .grid__cell`.

Every consumer of these candidates already requires `supported` before matching, so those entries could never match anything. They were carried into every element's candidate list purely to be discarded.

Selectors whose authored form is unsupported but whose direct-child form is supported, such as `.card p::before`, are retained, because `hasDirectChildSelectorMatch()` evaluates that form.

## Real-corpus evidence
`free-tour.html`, 624-file corpus:

- canonical receipt SHA-256 unchanged: `e52cc2d4fc9be0c7addb88d1f9616e7c04ebf6c1d3c7995f840d30f6e82d225d`
- candidate rule checks: 1,487,636 to 271,494, an 82% reduction
- candidate cache misses: 7,125 to 6,369, and hits rise from 5,318 to 6,074
- candidate cache evictions: 7,030 to 6,188
- peak memory: 186.4 MiB to 184.3 MiB

`about.html` independently confirms identical output, receipt `c06054cb00da7001…`, with checks falling to 50,136.

## On timing
CPU improvement is small and within run-to-run noise on this host. Five alternating pairs gave a median of 15.97s baseline versus 15.32s candidate, roughly 4%. That is expected: each discarded candidate was cheap to skip, so the win is structural rather than arithmetic. I am reporting the measured result rather than claiming a speedup the data does not support.

The durable benefit is that the bounded candidate cache now retains lists that are actually reused, which is visible in the hit, miss, and eviction counters above.

## Verification
- `composer validate --strict`
- `composer test`, including all 292 parity fixtures
- byte-identical receipts on two independent production pages
- new assertion verified to fail against the unmodified code

## Note
I first tried indexing keyless selectors by an ancestor requirement, expecting the universal bucket to be full of `.menu > *` shapes. Measurement showed it reclassified only 30 of 3,481 entries, so that approach was discarded rather than shipped alongside this one.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode profiled the candidate index per bucket, disproved its own first hypothesis, implemented the support filter with the direct-child carve-out, and ran the paired real-corpus verification. Chris Huber directed the work.
