### PR TITLE
Give the DOM reading vocabulary a shape collaborators can reach

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -86,6 +86,7 @@
       "php tests/unit/artifact-normalizer-source-budget.php",
       "php tests/unit/subtree-classifier.php",
       "php tests/unit/source-element-classifier.php",
+      "php tests/unit/source-dom.php",
       "php tests/unit/custom-block-generator.php",
       "php tests/unit/description-list-block.php",
       "php tests/unit/css-value-splitter.php",

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -6,24 +6,25 @@ namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
 use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\CssUrlRewriter;
 use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\ReferenceAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionReportProjection;
-use Automattic\BlocksEngine\PhpTransformer\Contract\EditabilityReport;
-use Automattic\BlocksEngine\PhpTransformer\Contract\EditabilityPolicy;
 use Automattic\BlocksEngine\PhpTransformer\Contract\CoreHtmlFallbackEvidence;
+use Automattic\BlocksEngine\PhpTransformer\Contract\EditabilityPolicy;
+use Automattic\BlocksEngine\PhpTransformer\Contract\EditabilityReport;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
 use Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatBridge;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformerAnalysisCache;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\ShellLandmarkPolicy;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AdminBarAccommodation;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssStylesheetTransformer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\FormLayoutGraphBuilder;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\ShellLandmarkPolicy;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
 use Automattic\BlocksEngine\PhpTransformer\Support\DeterministicRowDeduplicator;
 use Automattic\BlocksEngine\PhpTransformer\Support\StyleTagScanner;
-use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlan;
-use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanInput;
 use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\DocumentIdentityException;
 use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\ValidationException;
+use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlan;
+use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanInput;
 use DOMDocument;
 use DOMElement;
 
@@ -2109,7 +2110,7 @@ final class ArtifactCompiler
                     'attributes'         => $this->inlineScriptAttributes($file),
                 ), static fn (mixed $value): bool => null !== $value && '' !== $value && array() !== $value);
             }
-            $runtimeIsland['required_scripts'] = $this->dedupeArrayRows($requiredScripts);
+            $runtimeIsland['required_scripts'] = SourceDom::dedupeArrayRows($requiredScripts);
         }
         unset($runtimeIsland);
 
@@ -2215,15 +2216,6 @@ final class ArtifactCompiler
         }
 
         return $attributes;
-    }
-
-    /**
-     * @param array<int, mixed> $rows
-     * @return array<int, mixed>
-     */
-    private function dedupeArrayRows(array $rows): array
-    {
-        return DeterministicRowDeduplicator::dedupe($rows);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleAttributeMapper;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\GeneratedGutenbergClassPolicy;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
@@ -299,7 +300,7 @@ final class BlockFactory
         }
 
         if ( 'core/accordion-item' === $name ) {
-            $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), ! empty($attrs['openByDefault']) ? 'is-open' : '');
+            $attrs['className'] = SourceDom::mergeClassNames((string) ($attrs['className'] ?? ''), ! empty($attrs['openByDefault']) ? 'is-open' : '');
             return array( 'opening' => '<div' . $this->blockSupportAttrs($attrs, 'wp-block-accordion-item') . '>', 'closing' => '</div>' );
         }
 
@@ -620,12 +621,12 @@ final class BlockFactory
 
         $wrapperAttrs = array(
             'id'    => (string) ($attrs['anchor'] ?? ''),
-            'class' => $this->mergeClassNames('wp-block-button', (string) ($attrs['className'] ?? '')),
+            'class' => SourceDom::mergeClassNames('wp-block-button', (string) ($attrs['className'] ?? '')),
             'style' => (string) ($attrs['inlineGeometryStyle'] ?? ''),
         );
 
         $controlAttrs = array(
-            'class' => $this->mergeClassNames('wp-block-button__link', $support['classes'], 'wp-element-button'),
+            'class' => SourceDom::mergeClassNames('wp-block-button__link', $support['classes'], 'wp-element-button'),
             'style' => $support['style'],
             'title' => (string) ($attrs['title'] ?? ''),
         );
@@ -685,24 +686,24 @@ final class BlockFactory
         $border = is_array($attrs['style']['border'] ?? null) ? $attrs['style']['border'] : array();
         $borderSupport = $this->styleSupport(array( 'border' => $border ));
         if ( array() !== $border ) {
-            $baseClass = $this->mergeClassNames('wp-block-image has-custom-border', $borderSupport['classes']);
+            $baseClass = SourceDom::mergeClassNames('wp-block-image has-custom-border', $borderSupport['classes']);
             unset($figureAttrs['style']['border']);
             if ( empty($figureAttrs['style']) ) {
                 unset($figureAttrs['style']);
             }
         }
         if ( ! empty($attrs['sizeSlug']) ) {
-            $figureAttrs['className'] = $this->mergeClassNames((string) ($figureAttrs['className'] ?? ''), 'size-' . (string) $attrs['sizeSlug']);
+            $figureAttrs['className'] = SourceDom::mergeClassNames((string) ($figureAttrs['className'] ?? ''), 'size-' . (string) $attrs['sizeSlug']);
         }
         if ( '' !== (string) ($attrs['width'] ?? '') || '' !== (string) ($attrs['height'] ?? '') ) {
-            $figureAttrs['className'] = $this->mergeClassNames('is-resized', (string) ($figureAttrs['className'] ?? ''));
+            $figureAttrs['className'] = SourceDom::mergeClassNames('is-resized', (string) ($figureAttrs['className'] ?? ''));
         }
 
         $imageAttrs = array(
             'src'   => $attrs['url'] ?? '',
             'alt'   => $attrs['alt'] ?? '',
             'title' => $attrs['title'] ?? '',
-            'class' => $this->mergeClassNames(! empty($attrs['id']) ? 'wp-image-' . (string) $attrs['id'] : '', $borderSupport['classes']),
+            'class' => SourceDom::mergeClassNames(! empty($attrs['id']) ? 'wp-image-' . (string) $attrs['id'] : '', $borderSupport['classes']),
             'style' => trim($this->imageDimensionStyle($attrs) . ';' . $borderSupport['style'], ';'),
         );
 
@@ -810,7 +811,7 @@ final class BlockFactory
         }
 
         $figureAttrs = $attrs;
-        $figureAttrs['className'] = $this->mergeClassNames(implode(' ', $classes), (string) ($attrs['className'] ?? ''));
+        $figureAttrs['className'] = SourceDom::mergeClassNames(implode(' ', $classes), (string) ($attrs['className'] ?? ''));
 
         return '<figure' . $this->blockSupportAttrs($figureAttrs) . '><div class="wp-block-embed__wrapper">' . $url . '</div></figure>';
     }
@@ -978,21 +979,6 @@ final class BlockFactory
             'style'   => implode(';', $declarations),
         );
     }
-
-    private function mergeClassNames(string ...$classNames): string
-    {
-        $classes = array();
-        foreach ( $classNames as $className ) {
-            foreach ( preg_split('/\s+/', trim($className)) ?: array() as $class ) {
-                if ( '' !== $class && ! in_array($class, $classes, true) ) {
-                    $classes[] = $class;
-                }
-            }
-        }
-
-        return implode(' ', $classes);
-    }
-
     /**
      * @param array<string, mixed> $attrs
      */
@@ -1002,7 +988,7 @@ final class BlockFactory
         $presetClasses = $this->presetColorClasses($attrs);
         $layoutClasses = $this->layoutClasses($attrs['layout'] ?? null, $baseClass);
         $alignmentClasses = $this->textAlignmentClasses($attrs);
-        $classes = $this->mergeClassNames($baseClass, $presetClasses, $support['classes'], $layoutClasses, $alignmentClasses, (string) ($attrs['className'] ?? ''));
+        $classes = SourceDom::mergeClassNames($baseClass, $presetClasses, $support['classes'], $layoutClasses, $alignmentClasses, (string) ($attrs['className'] ?? ''));
         $style = trim(
             (string) $support['style'] . ';' . (null === $styleOverride
                 ? (string) ($attrs['inlineGeometryStyle'] ?? '')
@@ -1077,7 +1063,7 @@ final class BlockFactory
             return '';
         }
 
-        return $this->mergeClassNames(
+        return SourceDom::mergeClassNames(
             'is-layout-' . $type,
             '' !== $baseClass ? $baseClass . '-is-layout-' . $type : ''
         );

--- a/php-transformer/src/HtmlToBlocks/Classification/SourceElementClassifier.php
+++ b/php-transformer/src/HtmlToBlocks/Classification/SourceElementClassifier.php
@@ -5,6 +5,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\InlineContentElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\ShellLandmarkPolicy;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use DOMElement;
 
 /**
@@ -57,8 +58,8 @@ final class SourceElementClassifier
 
     public function isDependentRuntimeMediaMask(DOMElement $element): bool
     {
-        if ( '' !== trim($this->attr($element, 'aria-label'))
-            || in_array(strtolower(trim($this->attr($element, 'role'))), array( 'img', 'graphics-document', 'graphics-symbol' ), true)
+        if ( '' !== trim(SourceDom::attr($element, 'aria-label'))
+            || in_array(strtolower(trim(SourceDom::attr($element, 'role'))), array( 'img', 'graphics-document', 'graphics-symbol' ), true)
             || 0 < $element->getElementsByTagName('title')->length
             || 0 < $element->getElementsByTagName('desc')->length
         ) {
@@ -66,9 +67,9 @@ final class SourceElementClassifier
         }
 
         $identity = strtolower(implode(' ', array(
-            $this->attr($element, 'id'),
-            $this->attr($element, 'class'),
-            $this->attr($element, 'data-role'),
+            SourceDom::attr($element, 'id'),
+            SourceDom::attr($element, 'class'),
+            SourceDom::attr($element, 'data-role'),
         )));
         if ( 1 === preg_match('/\b(?:clip|mask|overlay)\b/', $identity) ) {
             return true;
@@ -78,11 +79,11 @@ final class SourceElementClassifier
         $path = 1 === $paths->length ? $paths->item(0) : null;
         return $path instanceof DOMElement
             && 1 === $element->getElementsByTagName('*')->length
-            && '' !== trim($this->attr($path, 'd'))
-            && '' === trim($this->attr($element, 'fill'))
-            && '' === trim($this->attr($element, 'stroke'))
-            && '' === trim($this->attr($path, 'fill'))
-            && '' === trim($this->attr($path, 'stroke'));
+            && '' !== trim(SourceDom::attr($path, 'd'))
+            && '' === trim(SourceDom::attr($element, 'fill'))
+            && '' === trim(SourceDom::attr($element, 'stroke'))
+            && '' === trim(SourceDom::attr($path, 'fill'))
+            && '' === trim(SourceDom::attr($path, 'stroke'));
     }
 
     public function isStructuralTransparentCustomWrapperChild(DOMElement $element): bool
@@ -161,7 +162,7 @@ final class SourceElementClassifier
 
     public function hasMotionStructureToken(DOMElement $element): bool
     {
-        $identity = strtolower($this->attr($element, 'class') . ' ' . $this->attr($element, 'id'));
+        $identity = strtolower(SourceDom::attr($element, 'class') . ' ' . SourceDom::attr($element, 'id'));
         return (bool) preg_match('/(?:^|[^a-z0-9])(?:band|carousel|loop|marquee|mask|rail|scroller|slider|ticker|track|viewport)(?:[^a-z0-9]|$)/', $identity);
     }
 
@@ -230,7 +231,7 @@ final class SourceElementClassifier
     public function hasLogoBrandSignal(DOMElement $element): bool
     {
         foreach ( array( 'class', 'id' ) as $attribute ) {
-            foreach ( preg_split('/[^a-z0-9]+/', strtolower($this->attr($element, $attribute))) ?: array() as $token ) {
+            foreach ( preg_split('/[^a-z0-9]+/', strtolower(SourceDom::attr($element, $attribute))) ?: array() as $token ) {
                 if ( in_array($token, array( 'logo', 'brand', 'branding' ), true) ) {
                     return true;
                 }
@@ -269,11 +270,11 @@ final class SourceElementClassifier
     public function hasInlineTokenSignal(DOMElement $element): bool
     {
         $tokens = strtolower(trim(implode(' ', array(
-            $this->attr($element, 'class'),
-            $this->attr($element, 'id'),
-            $this->attr($element, 'role'),
-            $this->attr($element, 'data-filter'),
-            $this->attr($element, 'data-tag'),
+            SourceDom::attr($element, 'class'),
+            SourceDom::attr($element, 'id'),
+            SourceDom::attr($element, 'role'),
+            SourceDom::attr($element, 'data-filter'),
+            SourceDom::attr($element, 'data-tag'),
         ))));
 
         return 1 === preg_match('/(?:^|[^a-z0-9])(?:chips?|pills?|badges?|tags?|filters?|facets?)(?:[^a-z0-9]|$)/', $tokens);
@@ -318,23 +319,23 @@ final class SourceElementClassifier
             return false;
         }
 
-        return '' !== trim($this->attr($element, 'class')) || '' !== trim($this->attr($element, 'style'));
+        return '' !== trim(SourceDom::attr($element, 'class')) || '' !== trim(SourceDom::attr($element, 'style'));
     }
 
     public function isCardLikeElement(DOMElement $element): bool
     {
-        $className = strtolower($this->attr($element, 'class'));
+        $className = strtolower(SourceDom::attr($element, 'class'));
         return 'article' === strtolower($element->tagName) || (bool) preg_match('/(?:^|[\s_-])(?:card|feature|service|provider|resource|post|project|stat|badge|tile|panel|item)(?:$|[\s_-])/', $className);
     }
 
     public function isVisualLayerElement(DOMElement $element): bool
     {
         $context = strtolower(trim(implode(' ', array(
-            $this->attr($element, 'class'),
-            $this->attr($element, 'id'),
-            $this->attr($element, 'aria-label'),
+            SourceDom::attr($element, 'class'),
+            SourceDom::attr($element, 'id'),
+            SourceDom::attr($element, 'aria-label'),
         ))));
-        $style = strtolower($this->attr($element, 'style'));
+        $style = strtolower(SourceDom::attr($element, 'style'));
 
         if ( preg_match('/(?:^|[\s_-])(?:hero|decor|decorative|layer|overlay|grain|noise|texture|glow|atmosphere|ambient|aura|orb|blob|backdrop|background|bg)(?:$|[\s_-])/', $context) ) {
             return true;
@@ -350,7 +351,7 @@ final class SourceElementClassifier
     public function hasCommerceToken(DOMElement $element, array $tokens): bool
     {
         foreach ( array( 'class', 'id', 'itemprop' ) as $attribute ) {
-            $value = strtolower($this->attr($element, $attribute));
+            $value = strtolower(SourceDom::attr($element, $attribute));
             foreach ( preg_split('/[^a-z0-9]+/', $value) ?: array() as $token ) {
                 if ( in_array($token, $tokens, true) ) {
                     return true;
@@ -447,7 +448,7 @@ final class SourceElementClassifier
             return false;
         }
 
-        $name = strtolower(trim($this->attr($element, 'class') . ' ' . $this->attr($element, 'id') . ' ' . $this->attr($element, 'role') . ' ' . $this->attr($element, 'aria-label')));
+        $name = strtolower(trim(SourceDom::attr($element, 'class') . ' ' . SourceDom::attr($element, 'id') . ' ' . SourceDom::attr($element, 'role') . ' ' . SourceDom::attr($element, 'aria-label')));
         return (bool) preg_match('/(?:^|[\s_-])(?:heading|label|title)(?:$|[\s_-])/', $name);
     }
 
@@ -458,11 +459,11 @@ final class SourceElementClassifier
 
     public function hasNavigationContainerSignal(DOMElement $element): bool
     {
-        if ( 'navigation' === strtolower($this->attr($element, 'role')) ) {
+        if ( 'navigation' === strtolower(SourceDom::attr($element, 'role')) ) {
             return true;
         }
 
-        $name = strtolower(trim($this->attr($element, 'class') . ' ' . $this->attr($element, 'id')));
+        $name = strtolower(trim(SourceDom::attr($element, 'class') . ' ' . SourceDom::attr($element, 'id')));
         return (bool) preg_match('/(?:^|[\s_-])(?:nav|navbar|navigation|menu|links)(?:$|[\s_-])/', $name);
     }
 
@@ -480,7 +481,7 @@ final class SourceElementClassifier
     public function hasPictureSourceSelection(DOMElement $element): bool
     {
         foreach ( $element->getElementsByTagName('source') as $source ) {
-            if ( $source instanceof DOMElement && '' !== $this->attr($source, 'srcset') ) {
+            if ( $source instanceof DOMElement && '' !== SourceDom::attr($source, 'srcset') ) {
                 return true;
             }
         }
@@ -490,7 +491,7 @@ final class SourceElementClassifier
 
     public function isImageCarrierButton(DOMElement $element): bool
     {
-        if ( '' !== trim($element->textContent ?? '') || 'submit' === strtolower($this->attr($element, 'type')) ) {
+        if ( '' !== trim($element->textContent ?? '') || 'submit' === strtolower(SourceDom::attr($element, 'type')) ) {
             return false;
         }
 
@@ -500,7 +501,7 @@ final class SourceElementClassifier
     public function hasResponsiveImageSources(DOMElement $element): bool
     {
         if ( 'img' === strtolower($element->tagName) ) {
-            return '' !== $this->attr($element, 'srcset') || '' !== $this->attr($element, 'sizes');
+            return '' !== SourceDom::attr($element, 'srcset') || '' !== SourceDom::attr($element, 'sizes');
         }
 
         if ( $this->hasPictureSourceSelection($element) ) {
@@ -508,7 +509,7 @@ final class SourceElementClassifier
         }
 
         foreach ( $element->getElementsByTagName('img') as $image ) {
-            if ( $image instanceof DOMElement && ( '' !== $this->attr($image, 'srcset') || '' !== $this->attr($image, 'sizes') ) ) {
+            if ( $image instanceof DOMElement && ( '' !== SourceDom::attr($image, 'srcset') || '' !== SourceDom::attr($image, 'sizes') ) ) {
                 return true;
             }
         }
@@ -527,11 +528,11 @@ final class SourceElementClassifier
     {
         $identity = strtolower(implode(' ', array(
             $element->tagName,
-            $this->attr($element, 'id'),
-            $this->attr($element, 'class'),
-            $this->attr($element, 'role'),
-            $this->attr($element, 'data-hook'),
-            $this->attr($element, 'data-testid'),
+            SourceDom::attr($element, 'id'),
+            SourceDom::attr($element, 'class'),
+            SourceDom::attr($element, 'role'),
+            SourceDom::attr($element, 'data-hook'),
+            SourceDom::attr($element, 'data-testid'),
         )));
 
         return 1 === preg_match('/(?:^|[^a-z0-9])(?:carousel|gallery|slider|slideshow)(?:[^a-z0-9]|$)/', $identity);
@@ -539,7 +540,7 @@ final class SourceElementClassifier
 
     public function isCarouselList(DOMElement $element): bool
     {
-        return 'list' === strtolower(trim($this->attr($element, 'role')))
+        return 'list' === strtolower(trim(SourceDom::attr($element, 'role')))
             || in_array(strtolower($element->tagName), array('ol', 'ul'), true);
     }
 
@@ -548,9 +549,9 @@ final class SourceElementClassifier
         for ( $ancestor = $element->parentNode; $ancestor instanceof DOMElement && $ancestor !== $root; $ancestor = $ancestor->parentNode ) {
             $identity = strtolower(implode(' ', array(
                 $ancestor->tagName,
-                $this->attr($ancestor, 'class'),
-                $this->attr($ancestor, 'role'),
-                $this->attr($ancestor, 'data-hook'),
+                SourceDom::attr($ancestor, 'class'),
+                SourceDom::attr($ancestor, 'role'),
+                SourceDom::attr($ancestor, 'data-hook'),
             )));
             if ( 1 === preg_match('/(?:^|[^a-z0-9])(?:dialog|expanded|lightbox|modal)(?:[^a-z0-9]|$)/', $identity) ) {
                 return true;
@@ -615,22 +616,5 @@ final class SourceElementClassifier
     {
         return (bool) preg_match('/^(?:\d+|\d*\.\d+)%$/', $value)
             && (float) $value > 0;
-    }
-
-    private function attr(DOMElement $element, string $name): string
-    {
-        return $element->hasAttribute($name) ? $element->getAttribute($name) : '';
-    }
-
-    private function childElementCount(DOMElement $element): int
-    {
-        $count = 0;
-        foreach ( $element->childNodes as $child ) {
-            if ( $child instanceof DOMElement ) {
-                ++$count;
-            }
-        }
-
-        return $count;
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Elements/AuthoredFormControlBlockConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/AuthoredFormControlBlockConverter.php
@@ -6,6 +6,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredInputBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredSelectBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use Closure;
 use DOMElement;
 
@@ -68,12 +69,12 @@ final class AuthoredFormControlBlockConverter
         $generator = new AuthoredSelectBlockGenerator();
         ($this->registerGeneratedBlock)(AuthoredSelectBlockGenerator::class, $generator->definition());
         $attrs = array_filter(array(
-            'id' => $this->attr($select, 'id'),
-            'name' => $this->attr($select, 'name'),
-            'ariaLabel' => $this->attr($select, 'aria-label'),
-            'placeholder' => $this->attr($select, 'placeholder'),
-            'className' => $this->attr($select, 'class'),
-            'style' => $this->attr($select, 'style'),
+            'id' => SourceDom::attr($select, 'id'),
+            'name' => SourceDom::attr($select, 'name'),
+            'ariaLabel' => SourceDom::attr($select, 'aria-label'),
+            'placeholder' => SourceDom::attr($select, 'placeholder'),
+            'className' => SourceDom::attr($select, 'class'),
+            'style' => SourceDom::attr($select, 'style'),
             'options' => $options,
             'selectedSummary' => $this->selectedOptionSummary($options),
         ), static fn (mixed $value): bool => is_array($value) ? array() !== $value : '' !== $value);
@@ -89,7 +90,7 @@ final class AuthoredFormControlBlockConverter
         // Preserve the established structural address while source identity and
         // authored selectors remain on the native control inside this shell.
         return ($this->createBlock)('core/group', array_filter(array(
-            'anchor' => ($this->safeAnchor)($this->attr($select, 'id')),
+            'anchor' => ($this->safeAnchor)(SourceDom::attr($select, 'id')),
             'className' => 'blocks-engine-authored-select-wrapper',
         )), array( $controlBlock ), null);
     }
@@ -110,16 +111,16 @@ final class AuthoredFormControlBlockConverter
         ($this->registerGeneratedBlock)(AuthoredInputBlockGenerator::class, $generator->definition());
         $attrs = array_filter(array(
             'type' => FormControlClassifier::controlType($input),
-            'id' => $this->attr($input, 'id'),
-            'name' => $this->attr($input, 'name'),
-            'value' => $this->attr($input, 'value'),
-            'placeholder' => $this->attr($input, 'placeholder'),
-            'ariaLabel' => $this->attr($input, 'aria-label'),
-            'className' => $this->attr($input, 'class'),
-            'style' => $this->attr($input, 'style'),
-            'min' => $this->attr($input, 'min'),
-            'max' => $this->attr($input, 'max'),
-            'step' => $this->attr($input, 'step'),
+            'id' => SourceDom::attr($input, 'id'),
+            'name' => SourceDom::attr($input, 'name'),
+            'value' => SourceDom::attr($input, 'value'),
+            'placeholder' => SourceDom::attr($input, 'placeholder'),
+            'ariaLabel' => SourceDom::attr($input, 'aria-label'),
+            'className' => SourceDom::attr($input, 'class'),
+            'style' => SourceDom::attr($input, 'style'),
+            'min' => SourceDom::attr($input, 'min'),
+            'max' => SourceDom::attr($input, 'max'),
+            'step' => SourceDom::attr($input, 'step'),
             'required' => $input->hasAttribute('required'),
             'disabled' => $input->hasAttribute('disabled'),
             'readOnly' => $input->hasAttribute('readonly'),
@@ -149,10 +150,5 @@ final class AuthoredFormControlBlockConverter
         }
 
         return array() === $selected ? '' : implode(', ', $selected) . ' (selected)';
-    }
-
-    private function attr(DOMElement $element, string $name): string
-    {
-        return $element->hasAttribute($name) ? $element->getAttribute($name) : '';
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Elements/FormControlMetadataBuilder.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FormControlMetadataBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use Closure;
 use DOMDocument;
 use DOMElement;
@@ -40,15 +41,15 @@ final class FormControlMetadataBuilder
     public function form(DOMElement $form): array
     {
         $metadata = array_filter(array(
-            'id'           => $this->attr($form, 'id'),
-            'name'         => $this->attr($form, 'name'),
-            'class'        => $this->attr($form, 'class'),
-            'aria_label'   => $this->attr($form, 'aria-label'),
-            'action'       => $this->attr($form, 'action'),
-            'method'       => strtolower($this->attr($form, 'method')),
-            'enctype'      => $this->attr($form, 'enctype'),
-            'target'       => $this->attr($form, 'target'),
-            'autocomplete' => $this->attr($form, 'autocomplete'),
+            'id'           => SourceDom::attr($form, 'id'),
+            'name'         => SourceDom::attr($form, 'name'),
+            'class'        => SourceDom::attr($form, 'class'),
+            'aria_label'   => SourceDom::attr($form, 'aria-label'),
+            'action'       => SourceDom::attr($form, 'action'),
+            'method'       => strtolower(SourceDom::attr($form, 'method')),
+            'enctype'      => SourceDom::attr($form, 'enctype'),
+            'target'       => SourceDom::attr($form, 'target'),
+            'autocomplete' => SourceDom::attr($form, 'autocomplete'),
         ), static fn (string $value): bool => '' !== $value);
 
         if ( $form->hasAttribute('novalidate') ) {
@@ -74,20 +75,20 @@ final class FormControlMetadataBuilder
         $metadata = array_filter(array(
             'tag'          => $tagName,
             'selector'     => ($this->elementSelector)($control),
-            'id'           => $this->attr($control, 'id'),
+            'id'           => SourceDom::attr($control, 'id'),
             'class'        => $this->classNames($control),
             'label_class'  => $labelElement instanceof DOMElement ? $this->classNames($labelElement) : '',
-            'name'         => $this->attr($control, 'name'),
+            'name'         => SourceDom::attr($control, 'name'),
             'type'         => $type,
             'label'        => $this->label($control),
-            'placeholder'  => $this->attr($control, 'placeholder'),
-            'autocomplete' => $this->attr($control, 'autocomplete'),
-            'pattern'      => $this->attr($control, 'pattern'),
-            'min'          => $this->attr($control, 'min'),
-            'max'          => $this->attr($control, 'max'),
-            'step'         => $this->attr($control, 'step'),
-            'maxlength'    => $this->attr($control, 'maxlength'),
-            'rows'         => $this->attr($control, 'rows'),
+            'placeholder'  => SourceDom::attr($control, 'placeholder'),
+            'autocomplete' => SourceDom::attr($control, 'autocomplete'),
+            'pattern'      => SourceDom::attr($control, 'pattern'),
+            'min'          => SourceDom::attr($control, 'min'),
+            'max'          => SourceDom::attr($control, 'max'),
+            'step'         => SourceDom::attr($control, 'step'),
+            'maxlength'    => SourceDom::attr($control, 'maxlength'),
+            'rows'         => SourceDom::attr($control, 'rows'),
         ), static fn (string $value): bool => '' !== $value);
 
         if ( in_array($type, array( 'button', 'reset', 'submit' ), true) ) {
@@ -103,7 +104,7 @@ final class FormControlMetadataBuilder
             }
         }
 
-        if ( $control->hasAttribute('required') || 'true' === strtolower(trim($this->attr($control, 'aria-required'))) ) {
+        if ( $control->hasAttribute('required') || 'true' === strtolower(trim(SourceDom::attr($control, 'aria-required'))) ) {
             $metadata['required'] = true;
         }
         foreach ( array( 'disabled', 'readonly', 'checked', 'multiple' ) as $attribute ) {
@@ -112,7 +113,7 @@ final class FormControlMetadataBuilder
             }
         }
 
-        $value = $this->attr($control, 'value');
+        $value = SourceDom::attr($control, 'value');
         if ( '' !== $value && 'select' !== $tagName ) {
             $metadata['value'] = $value;
         }
@@ -129,7 +130,7 @@ final class FormControlMetadataBuilder
 
     public function label(DOMElement $control): string
     {
-        $ariaLabel = trim($this->attr($control, 'aria-label'));
+        $ariaLabel = trim(SourceDom::attr($control, 'aria-label'));
         if ( '' !== $ariaLabel ) {
             return $ariaLabel;
         }
@@ -146,11 +147,11 @@ final class FormControlMetadataBuilder
     {
         $label = $this->label($control);
         if ( '' === $label ) {
-            $label = $this->attr($control, 'aria-label');
+            $label = SourceDom::attr($control, 'aria-label');
         }
         foreach ( array( 'placeholder', 'name' ) as $attribute ) {
             if ( '' === $label ) {
-                $label = $this->attr($control, $attribute);
+                $label = SourceDom::attr($control, $attribute);
             }
         }
 
@@ -165,13 +166,13 @@ final class FormControlMetadataBuilder
     /** Label associated by `for`; wrapping labels are handled with their control. */
     public function associatedLabel(DOMElement $control): ?DOMElement
     {
-        $id = $this->attr($control, 'id');
+        $id = SourceDom::attr($control, 'id');
         if ( '' === $id || ! $control->ownerDocument instanceof DOMDocument ) {
             return null;
         }
 
         foreach ( $control->ownerDocument->getElementsByTagName('label') as $label ) {
-            if ( $label instanceof DOMElement && $id === $this->attr($label, 'for') ) {
+            if ( $label instanceof DOMElement && $id === SourceDom::attr($label, 'for') ) {
                 return $label;
             }
         }
@@ -196,7 +197,7 @@ final class FormControlMetadataBuilder
     private function classNames(DOMElement $element): string
     {
         $classes = array();
-        foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $className ) {
+        foreach ( preg_split('/\s+/', trim(SourceDom::attr($element, 'class'))) ?: array() as $className ) {
             if ( count($classes) >= 16 ) {
                 break;
             }
@@ -214,7 +215,7 @@ final class FormControlMetadataBuilder
             return $text;
         }
 
-        $value = trim($this->attr($control, 'value'));
+        $value = trim(SourceDom::attr($control, 'value'));
         return '' !== $value ? $value : $fallback;
     }
 
@@ -227,7 +228,7 @@ final class FormControlMetadataBuilder
                 continue;
             }
 
-            $value = $this->attr($option, 'value');
+            $value = SourceDom::attr($option, 'value');
             $optionMetadata = array(
                 'label' => trim(preg_replace('/\s+/', ' ', $option->textContent ?? '') ?? ''),
                 // An explicit empty value is a placeholder semantic, not a missing value.
@@ -259,7 +260,7 @@ final class FormControlMetadataBuilder
         if ( XML_TEXT_NODE === $node->nodeType ) {
             return $node->textContent ?? '';
         }
-        if ( $node instanceof DOMElement && 'true' === strtolower($this->attr($node, 'aria-hidden')) ) {
+        if ( $node instanceof DOMElement && 'true' === strtolower(SourceDom::attr($node, 'aria-hidden')) ) {
             return '';
         }
         if ( $node instanceof DOMElement && FormControlClassifier::isControlElement($node) ) {
@@ -277,18 +278,13 @@ final class FormControlMetadataBuilder
     private function buttonText(DOMElement $control): string
     {
         foreach ( array( 'aria-label', 'title' ) as $attribute ) {
-            $label = trim($this->attr($control, $attribute));
+            $label = trim(SourceDom::attr($control, $attribute));
             if ( '' !== $label ) {
                 return $label;
             }
         }
 
         $text = trim(preg_replace('/\s+/', ' ', $control->textContent ?? '') ?? '');
-        return '' !== $text ? $text : trim($this->attr($control, 'value'));
-    }
-
-    private function attr(DOMElement $element, string $name): string
-    {
-        return $element->hasAttribute($name) ? $element->getAttribute($name) : '';
+        return '' !== $text ? $text : trim(SourceDom::attr($control, 'value'));
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Elements/FormRuntimeRequirementAnalyzer.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FormRuntimeRequirementAnalyzer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use Closure;
 use DOMElement;
 
@@ -31,17 +32,17 @@ final class FormRuntimeRequirementAnalyzer
 
     private function hasSubmissionMetadata(DOMElement $form): bool
     {
-        $action = trim($this->attr($form, 'action'));
+        $action = trim(SourceDom::attr($form, 'action'));
         if ( '' !== $action && '#' !== $action ) {
             return true;
         }
 
-        if ( '' === $action && '' !== trim($this->attr($form, 'method')) ) {
+        if ( '' === $action && '' !== trim(SourceDom::attr($form, 'method')) ) {
             return true;
         }
 
         foreach ( array( 'enctype', 'target' ) as $attribute ) {
-            if ( '' !== trim($this->attr($form, $attribute)) ) {
+            if ( '' !== trim(SourceDom::attr($form, $attribute)) ) {
                 return true;
             }
         }
@@ -58,12 +59,12 @@ final class FormRuntimeRequirementAnalyzer
 
             $haystack = strtolower(implode(' ', array(
                 $control->textContent ?? '',
-                $this->attr($control, 'value'),
-                $this->attr($control, 'class'),
-                $this->attr($control, 'id'),
-                $this->attr($control, 'name'),
-                $this->attr($control, 'aria-label'),
-                $this->attr($control, 'title'),
+                SourceDom::attr($control, 'value'),
+                SourceDom::attr($control, 'class'),
+                SourceDom::attr($control, 'id'),
+                SourceDom::attr($control, 'name'),
+                SourceDom::attr($control, 'aria-label'),
+                SourceDom::attr($control, 'title'),
             )));
 
             if ( preg_match('/(?:^|[^a-z0-9])(?:add to cart|cart|checkout|payment|purchase|buy|order|register|registration|ticket)(?:[^a-z0-9]|$)/', $haystack) ) {
@@ -91,17 +92,12 @@ final class FormRuntimeRequirementAnalyzer
 
     private function hasRuntimeClassSignal(DOMElement $element): bool
     {
-        foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) {
+        foreach ( preg_split('/\s+/', trim(SourceDom::attr($element, 'class'))) ?: array() as $class ) {
             if ( preg_match('/^js-[A-Za-z0-9_-]+$/', $class) ) {
                 return true;
             }
         }
 
         return false;
-    }
-
-    private function attr(DOMElement $element, string $name): string
-    {
-        return $element->hasAttribute($name) ? $element->getAttribute($name) : '';
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Elements/FormSuccessPanelMetadataBuilder.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FormSuccessPanelMetadataBuilder.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use Closure;
 use DOMElement;
 use DOMNode;
@@ -56,10 +57,10 @@ final class FormSuccessPanelMetadataBuilder
         $boundedHtml = ($this->fallbackHtmlMetadata)($element);
         return array_filter(array(
             'selector'       => ($this->elementSelector)($element),
-            'id'             => $this->attr($element, 'id'),
-            'class'          => $this->attr($element, 'class'),
-            'role'           => $this->attr($element, 'role'),
-            'aria_live'      => $this->attr($element, 'aria-live'),
+            'id'             => SourceDom::attr($element, 'id'),
+            'class'          => SourceDom::attr($element, 'class'),
+            'role'           => SourceDom::attr($element, 'role'),
+            'aria_live'      => SourceDom::attr($element, 'aria-live'),
             'text'           => $this->normalizedText($element),
             'html'           => $boundedHtml['html'],
             'html_bytes'     => $boundedHtml['bytes'],
@@ -75,17 +76,12 @@ final class FormSuccessPanelMetadataBuilder
 
     private function hasSignal(DOMElement $element): bool
     {
-        $role = strtolower($this->attr($element, 'role'));
+        $role = strtolower(SourceDom::attr($element, 'role'));
         if ( in_array($role, array( 'status', 'alert' ), true) ) {
             return true;
         }
 
-        $tokens = strtolower(trim($this->attr($element, 'id') . ' ' . $this->attr($element, 'class') . ' ' . $this->attr($element, 'aria-live')));
+        $tokens = strtolower(trim(SourceDom::attr($element, 'id') . ' ' . SourceDom::attr($element, 'class') . ' ' . SourceDom::attr($element, 'aria-live')));
         return (bool) preg_match('/(?:^|[^a-z0-9])(?:success|sent|submitted|thank|thanks|confirmation|confirmed)(?:[^a-z0-9]|$)/', $tokens);
-    }
-
-    private function attr(DOMElement $element, string $name): string
-    {
-        return $element->hasAttribute($name) ? $element->getAttribute($name) : '';
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Elements/PseudoFormAnalyzer.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/PseudoFormAnalyzer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use Closure;
 use DOMElement;
 
@@ -68,19 +69,19 @@ final class PseudoFormAnalyzer
 
     public function hasStandaloneSearchSignal(DOMElement $element, DOMElement $input): bool
     {
-        if ( 'search' === FormControlClassifier::controlType($input) || 'search' === strtolower(trim($this->attr($element, 'role'))) ) {
+        if ( 'search' === FormControlClassifier::controlType($input) || 'search' === strtolower(trim(SourceDom::attr($element, 'role'))) ) {
             return true;
         }
 
         $haystack = strtolower(implode(' ', array(
-            $this->attr($element, 'aria-label'),
-            $this->attr($element, 'id'),
-            $this->attr($element, 'class'),
-            $this->attr($input, 'aria-label'),
-            $this->attr($input, 'id'),
-            $this->attr($input, 'class'),
-            $this->attr($input, 'name'),
-            $this->attr($input, 'placeholder'),
+            SourceDom::attr($element, 'aria-label'),
+            SourceDom::attr($element, 'id'),
+            SourceDom::attr($element, 'class'),
+            SourceDom::attr($input, 'aria-label'),
+            SourceDom::attr($input, 'id'),
+            SourceDom::attr($input, 'class'),
+            SourceDom::attr($input, 'name'),
+            SourceDom::attr($input, 'placeholder'),
         )));
 
         return str_contains($haystack, 'search');
@@ -92,12 +93,12 @@ final class PseudoFormAnalyzer
         $hasFieldLabel = false;
         $hasSubmit = false;
         $hasActionControl = false;
-        $hasContainerAction = '' !== trim($this->attr($element, 'action')) || '' !== trim($this->attr($element, 'method')) || '' !== trim($this->attr($element, 'data-action'));
+        $hasContainerAction = '' !== trim(SourceDom::attr($element, 'action')) || '' !== trim(SourceDom::attr($element, 'method')) || '' !== trim(SourceDom::attr($element, 'data-action'));
 
         foreach ( FormControlClassifier::controlElements($element) as $control ) {
             if ( FormControlClassifier::isPseudoFormDataEntryControl($control) && ! $this->hasStandaloneSearchSignal($element, $control) ) {
                 $hasDataEntry = true;
-                $hasFieldLabel = $hasFieldLabel || '' !== trim($this->formControlMetadataBuilder->label($control)) || '' !== trim($this->attr($control, 'aria-label')) || '' !== trim($this->attr($control, 'name'));
+                $hasFieldLabel = $hasFieldLabel || '' !== trim($this->formControlMetadataBuilder->label($control)) || '' !== trim(SourceDom::attr($control, 'aria-label')) || '' !== trim(SourceDom::attr($control, 'name'));
             } elseif ( 'button' === strtolower($control->tagName) || ( 'input' === strtolower($control->tagName) && ! in_array(FormControlClassifier::controlType($control), array( 'reset', 'button' ), true) ) ) {
                 $hasActionControl = true;
                 $hasSubmit = $hasSubmit || FormControlClassifier::isPseudoFormSubmitControl($control);
@@ -119,7 +120,7 @@ final class PseudoFormAnalyzer
             }
 
             $tagName = strtolower($descendant->tagName);
-            $role = strtolower($this->attr($descendant, 'role'));
+            $role = strtolower(SourceDom::attr($descendant, 'role'));
             if ( in_array($tagName, array( 'article', 'nav', 'header', 'footer', 'main' ), true)
                 || in_array($role, array( 'article', 'navigation', 'banner', 'contentinfo', 'main' ), true) ) {
                 return true;
@@ -127,10 +128,5 @@ final class PseudoFormAnalyzer
         }
 
         return false;
-    }
-
-    private function attr(DOMElement $element, string $name): string
-    {
-        return $element->hasAttribute($name) ? $element->getAttribute($name) : '';
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Elements/ReadableFormControlBlockConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/ReadableFormControlBlockConverter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use Closure;
 use DOMElement;
@@ -51,7 +52,7 @@ final class ReadableFormControlBlockConverter
         if ( 'input' === $tagName && 'search' === FormControlClassifier::controlType($element) ) {
             $label = $this->metadataBuilder->label($element);
             if ( '' === $label ) {
-                $label = $this->attr($element, 'aria-label');
+                $label = SourceDom::attr($element, 'aria-label');
             }
             if ( '' === $label ) {
                 $label = 'Search';
@@ -157,14 +158,14 @@ final class ReadableFormControlBlockConverter
                 $details[] = 'selected: ' . implode(', ', $selected);
             }
         } elseif ( 'range' === $type ) {
-            $value = trim($this->attr($control, 'value'));
+            $value = trim(SourceDom::attr($control, 'value'));
             if ( '' !== $value ) {
                 $details[] = $value;
             }
 
             $bounds = array();
             foreach ( array( 'min', 'max', 'step' ) as $attribute ) {
-                $value = trim($this->attr($control, $attribute));
+                $value = trim(SourceDom::attr($control, $attribute));
                 if ( '' !== $value ) {
                     $bounds[] = $attribute . ' ' . $value;
                 }
@@ -174,7 +175,7 @@ final class ReadableFormControlBlockConverter
             }
         } else {
             foreach ( array( 'value', 'placeholder' ) as $attribute ) {
-                $value = trim($this->attr($control, $attribute));
+                $value = trim(SourceDom::attr($control, $attribute));
                 if ( '' !== $value ) {
                     $details[] = $value;
                     break;
@@ -192,10 +193,5 @@ final class ReadableFormControlBlockConverter
 
         ($this->registerEcho)($text);
         return $this->runtime->escapeHtml($text);
-    }
-
-    private function attr(DOMElement $element, string $name): string
-    {
-        return $element->hasAttribute($name) ? $element->getAttribute($name) : '';
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use DOMElement;
 
 final class ButtonsPattern
@@ -323,7 +324,7 @@ final class ButtonsPattern
         unset($attrs['layout']);
         $isOutline     = $this->hasOutlineSignal($element, $resolvedStyle, $native);
         if ( $isOutline ) {
-            $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), 'is-style-outline');
+            $attrs['className'] = SourceDom::mergeClassNames((string) ($attrs['className'] ?? ''), 'is-style-outline');
         }
 
         // Translate the resolved source CSS (inline style merged with the matched
@@ -348,21 +349,6 @@ final class ButtonsPattern
 
         return $attrs;
     }
-
-    private function mergeClassNames(string ...$classNames): string
-    {
-        $classes = array();
-        foreach ( $classNames as $className ) {
-            foreach ( preg_split('/\s+/', trim($className)) ?: array() as $class ) {
-                if ( '' !== $class && ! in_array($class, $classes, true) ) {
-                    $classes[] = $class;
-                }
-            }
-        }
-
-        return implode(' ', $classes);
-    }
-
 	private function buttonWidth(string $style): ?int
 	{
 		if ( ! preg_match('/(?:^|;)\s*width\s*:\s*(25|50|75|100)%\s*(?:;|$)/i', $style, $matches) ) {

--- a/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
@@ -3,8 +3,9 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
-use DOMElement;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\ShellLandmarkPolicy;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
+use DOMElement;
 
 /**
  * Recognizes column / split-layout / documentation-sidebar containers and
@@ -165,7 +166,7 @@ final class ColumnsPattern implements PatternRecognizerInterface
         // Split-layout names describe two-pane structures. Multi-child content
         // stacks such as hero copy must stay groups so source CSS controls flow.
         return (bool) preg_match('/(?:^|[\s_-])columns?(?:$|[\s_-])/', $className)
-            || ( $this->looksLikeSplitLayout($element) && 2 === $this->directElementChildCount($element) )
+            || ( $this->looksLikeSplitLayout($element) && 2 === SourceDom::directElementChildCount($element) )
             || ( $this->looksLikeDocumentationLayout($element) && $this->hasSidebarAndContentChildren($element) )
             || $this->hasSidebarAndContentChildren($element)
             || preg_match('/(?:^|;)\s*display\s*:\s*(?:inline-)?flex/', $inlineStyle);
@@ -177,19 +178,6 @@ final class ColumnsPattern implements PatternRecognizerInterface
 
         return (bool) preg_match('/(?:^|[\s_-])(?:split|two[\s_-]?col|media[\s_-]?text|text[\s_-]?media|feature[\s_-]?row|hero[\s_-]?(?:inner|grid|content|layout)|content[\s_-]?grid)(?:$|[\s_-])/', $name);
     }
-
-    private function directElementChildCount(DOMElement $element): int
-    {
-        $count = 0;
-        foreach ( $element->childNodes as $child ) {
-            if ( $child instanceof DOMElement ) {
-                ++$count;
-            }
-        }
-
-        return $count;
-    }
-
     private function looksLikeDocumentationLayout(DOMElement $element): bool
     {
         $name = strtolower(trim($this->attr($element, 'class') . ' ' . $this->attr($element, 'id')));

--- a/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
@@ -3,8 +3,9 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\BackgroundImageExtractor;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssValueSplitter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\BackgroundImageExtractor;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use DOMElement;
 use Throwable;
 
@@ -241,7 +242,7 @@ final class CoverPattern implements PatternRecognizerInterface
 
     private function columnsRejectionGate(DOMElement $element, string $style): ?string
     {
-        if ( $this->directElementChildCount($element) < 2 ) {
+        if ( SourceDom::directElementChildCount($element) < 2 ) {
             return null;
         }
 
@@ -270,19 +271,6 @@ final class CoverPattern implements PatternRecognizerInterface
     {
         return $hasTextBearingChildren ? null : 'no_text_content';
     }
-
-    private function directElementChildCount(DOMElement $element): int
-    {
-        $count = 0;
-        foreach ( $element->childNodes as $child ) {
-            if ( $child instanceof DOMElement ) {
-                ++$count;
-            }
-        }
-
-        return $count;
-    }
-
     /**
      * @param array<int, array<string, mixed>> $blocks
      */

--- a/php-transformer/src/HtmlToBlocks/Patterns/LogoPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/LogoPattern.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\LinkUrlSanitizer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use DOMDocument;
 use DOMElement;
 
@@ -51,7 +52,7 @@ final class LogoPattern implements PatternRecognizerInterface
             $content = $materializeSvgImages($element, $innerHtml($element)) ?? (preg_replace('/<svg\b[^>]*>.*?<\/svg>/is', '', $innerHtml($element)) ?? $innerHtml($element));
             $attrs = array_filter(array(
                 'text'  => trim($content),
-                'url'   => $this->safeNavigationUrl($element->hasAttribute('href') ? $element->getAttribute('href') : ''),
+                'url'   => SourceDom::safeNavigationUrl($element->hasAttribute('href') ? $element->getAttribute('href') : ''),
                 'title' => trim($element->hasAttribute('aria-label') ? $element->getAttribute('aria-label') : ''),
 				'style' => array(
                     'color' => array( 'background' => 'transparent' ),
@@ -103,7 +104,7 @@ final class LogoPattern implements PatternRecognizerInterface
             return '';
         }
 
-        $href = $this->safeNavigationUrl($anchor->hasAttribute('href') ? $anchor->getAttribute('href') : '');
+        $href = SourceDom::safeNavigationUrl($anchor->hasAttribute('href') ? $anchor->getAttribute('href') : '');
         if ( '' === $href ) {
             return $label;
         }
@@ -115,7 +116,7 @@ final class LogoPattern implements PatternRecognizerInterface
             }
         }
 
-        return '<a' . $this->htmlAttributeString($attrs) . '>' . $label . '</a>';
+        return '<a' . SourceDom::htmlAttributeString($attrs) . '>' . $label . '</a>';
     }
 
     /** @param callable(DOMElement, string): ?string $materializeSvgImages */
@@ -237,24 +238,6 @@ final class LogoPattern implements PatternRecognizerInterface
 
         return '';
     }
-
-    private function safeNavigationUrl(string $url): string
-    {
-        return LinkUrlSanitizer::sanitize($url);
-    }
-
-    /**
-     * @param array<string, string> $attrs
-     */
-    private function htmlAttributeString(array $attrs): string
-    {
-        $html = '';
-        foreach ( $attrs as $name => $value ) {
-            $html .= ' ' . $name . '="' . htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"';
-        }
-        return $html;
-    }
-
     private function hasLogoSignal(DOMElement $element): bool
     {
         foreach ( array( 'class', 'id' ) as $attribute ) {

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -3,9 +3,10 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\LinkUrlSanitizer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssValueSplitter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleAttributeMapper;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\LinkUrlSanitizer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use DOMElement;
 
 final class NavigationPattern implements PatternRecognizerInterface
@@ -716,12 +717,6 @@ final class NavigationPattern implements PatternRecognizerInterface
 
         return true;
     }
-
-    private function safeNavigationUrl(string $url): string
-    {
-        return LinkUrlSanitizer::sanitize($url);
-    }
-
     private function hasDirectBrandingAnchorBesideListNavigation(DOMElement $element, callable $innerHtml): bool
     {
         if ( 'nav' !== strtolower($element->tagName) && ! $this->hasNavigationSignal($element) ) {
@@ -1010,7 +1005,7 @@ final class NavigationPattern implements PatternRecognizerInterface
 
             $submenuAttrs = array(
                 'label' => $this->anchorLabel($anchor, $innerHtml),
-                'url'   => $this->safeNavigationUrl($anchor->hasAttribute('href') ? $anchor->getAttribute('href') : ''),
+                'url'   => SourceDom::safeNavigationUrl($anchor->hasAttribute('href') ? $anchor->getAttribute('href') : ''),
                 'kind'  => 'custom',
             );
             $submenuContainer = $this->submenuContainers($element, $anchor)[0] ?? null;
@@ -1028,7 +1023,7 @@ final class NavigationPattern implements PatternRecognizerInterface
     {
         $linkAttrs = $this->navigationItemAttributes($item ?? $anchor, $anchor, null, array(
             'label' => $this->anchorLabel($anchor, $innerHtml),
-            'url'   => $this->safeNavigationUrl($anchor->hasAttribute('href') ? $anchor->getAttribute('href') : ''),
+            'url'   => SourceDom::safeNavigationUrl($anchor->hasAttribute('href') ? $anchor->getAttribute('href') : ''),
             'kind'  => 'custom',
         ), $presentationAttributes, $navigationContext);
         // An icon-only anchor keeps its accessible name as the saved label, but

--- a/php-transformer/src/HtmlToBlocks/Patterns/PlaceholderMediaPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PlaceholderMediaPattern.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use DOMElement;
 
 /** @internal Pattern recognizers are implementation details of HtmlTransformer. */
@@ -25,7 +26,7 @@ final class PlaceholderMediaPattern implements PatternRecognizerInterface
         // The aspect ratio rides on the preserved placeholder/ratio classNames and
         // companion-plugin CSS; a raw inline `style` string would invalidate the
         // core/group block, so it is intentionally not emitted here (#261).
-        $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), 'blocks-engine-placeholder-media');
+        $attrs['className'] = SourceDom::mergeClassNames((string) ($attrs['className'] ?? ''), 'blocks-engine-placeholder-media');
         unset($attrs['style']);
 
         $label = $this->placeholderLabel($element);
@@ -75,19 +76,5 @@ final class PlaceholderMediaPattern implements PatternRecognizerInterface
 
         $directText = trim(preg_replace('/\s+/', ' ', $element->textContent ?? '') ?? '');
         return strlen($directText) <= 80 ? $directText : '';
-    }
-
-    private function mergeClassNames(string ...$classNames): string
-    {
-        $classes = array();
-        foreach ( $classNames as $className ) {
-            foreach ( preg_split('/\s+/', trim($className)) ?: array() as $class ) {
-                if ( '' !== $class && ! in_array($class, $classes, true) ) {
-                    $classes[] = $class;
-                }
-            }
-        }
-
-        return implode(' ', $classes);
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Patterns/SpacerPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/SpacerPattern.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use DOMElement;
 
 /** @internal Pattern recognizers are implementation details of HtmlTransformer. */
@@ -12,7 +13,7 @@ final class SpacerPattern implements PatternRecognizerInterface
 
     public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
-        if ( '' !== trim($element->textContent ?? '') || 0 !== $this->childElementCount($element) ) {
+        if ( '' !== trim($element->textContent ?? '') || 0 !== SourceDom::childElementCount($element) ) {
             return null;
         }
 
@@ -33,19 +34,6 @@ final class SpacerPattern implements PatternRecognizerInterface
 
         return new PatternRecognitionResult($context->createBlock('core/spacer', $attrs, array(), $element));
     }
-
-    private function childElementCount(DOMElement $element): int
-    {
-        $count = 0;
-        foreach ( $element->childNodes as $child ) {
-            if ( $child instanceof DOMElement ) {
-                ++$count;
-            }
-        }
-
-        return $count;
-    }
-
     public static function heightFromStyle(string $style): string
     {
         if ( ! preg_match('/(?:^|;)\s*height\s*:\s*([^;]+)/i', $style, $matches) ) {

--- a/php-transformer/src/HtmlToBlocks/Style/AuthorSelectorSemanticPreparer.php
+++ b/php-transformer/src/HtmlToBlocks/Style/AuthorSelectorSemanticPreparer.php
@@ -5,6 +5,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformerAnalysisCache;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerSession;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use DOMElement;
 
 /** Prepares source identities needed to project author selectors onto canonical blocks. */
@@ -217,7 +218,7 @@ final class AuthorSelectorSemanticPreparer
                     $path = $element->getNodePath() ?? '';
                     if ( '' !== $path ) {
                         $marker = $projections->ensureAttributeMarker($path);
-                        $element->setAttribute('class', self::mergeClassNames($element->getAttribute('class'), $marker));
+                        $element->setAttribute('class', SourceDom::mergeClassNames($element->getAttribute('class'), $marker));
                     }
                 }
             }
@@ -241,7 +242,7 @@ final class AuthorSelectorSemanticPreparer
                 $path = $element->getNodePath() ?? '';
                 if ( '' !== $path ) {
                     $marker = $projections->ensureAttributeMarker($path);
-                    $element->setAttribute('class', self::mergeClassNames($element->getAttribute('class'), $marker));
+                    $element->setAttribute('class', SourceDom::mergeClassNames($element->getAttribute('class'), $marker));
                 }
             }
         }
@@ -280,7 +281,7 @@ final class AuthorSelectorSemanticPreparer
             if ( '' !== $path ) {
                 $marker = '' === $marker ? $authorStyles->allocateMarker('attribute-state') : $marker;
                 $projections->addAttributeStateMarker($path, $marker);
-                $element->setAttribute('class', self::mergeClassNames($element->getAttribute('class'), $marker));
+                $element->setAttribute('class', SourceDom::mergeClassNames($element->getAttribute('class'), $marker));
             }
         }
         if ( '' !== $marker ) {
@@ -311,7 +312,7 @@ final class AuthorSelectorSemanticPreparer
                     continue;
                 }
                 $marker = $projections->ensureAttributeMarker($path);
-                $element->setAttribute('class', self::mergeClassNames($element->getAttribute('class'), $marker));
+                $element->setAttribute('class', SourceDom::mergeClassNames($element->getAttribute('class'), $marker));
                 $markers[] = $marker;
             }
             if ( array() !== $markers ) {
@@ -383,20 +384,6 @@ final class AuthorSelectorSemanticPreparer
     {
         return 1 === preg_match('/^[A-Za-z][A-Za-z0-9_-]*$/', trim($id));
     }
-
-    private static function mergeClassNames(string ...$classNames): string
-    {
-        $classes = array();
-        foreach ( $classNames as $className ) {
-            foreach ( preg_split('/\s+/', trim($className)) ?: array() as $class ) {
-                if ( '' !== $class && ! in_array($class, $classes, true) ) {
-                    $classes[] = $class;
-                }
-            }
-        }
-        return implode(' ', $classes);
-    }
-
     private function ancestorElement(DOMElement $element, string $tagName): ?DOMElement
     {
         for ( $parent = $element->parentNode; $parent instanceof DOMElement; $parent = $parent->parentNode ) {

--- a/php-transformer/src/HtmlToBlocks/Style/GeneratedBlockStyleProjector.php
+++ b/php-transformer/src/HtmlToBlocks/Style/GeneratedBlockStyleProjector.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use DOMElement;
 
@@ -31,7 +32,7 @@ final class GeneratedBlockStyleProjector
         $submenuBackground = 'core/navigation-submenu' === $name ? trim((string) ($fallback['color']['background'] ?? '')) : '';
         if ( '' !== $submenuBackground && array() !== $this->styleResolver->cssDeclarations('background-color:' . $submenuBackground) ) {
             $className = 'blocks-engine-navigation-submenu-background-' . hash('sha256', $submenuBackground);
-            $attrs['className'] = self::mergeClassNames((string) ($attrs['className'] ?? ''), $className);
+            $attrs['className'] = SourceDom::mergeClassNames((string) ($attrs['className'] ?? ''), $className);
             $generatedStyles->registerNavigationSubmenuBackground($className, $submenuBackground);
         }
         $classes = preg_split('/\s+/', trim((string) ($attrs['className'] ?? ''))) ?: array();
@@ -106,7 +107,7 @@ final class GeneratedBlockStyleProjector
             $fallbackDeclarations
         );
         if ( '' !== $carrier ) {
-            $attrs['className'] = self::mergeClassNames((string) ($attrs['className'] ?? ''), $carrier);
+            $attrs['className'] = SourceDom::mergeClassNames((string) ($attrs['className'] ?? ''), $carrier);
         }
         return $attrs;
     }
@@ -287,18 +288,5 @@ final class GeneratedBlockStyleProjector
     private static function isInheritedCssWideValue(string $value): bool
     {
         return in_array(strtolower(trim($value)), array( 'inherit', 'unset' ), true);
-    }
-
-    private static function mergeClassNames(string ...$classNames): string
-    {
-        $classes = array();
-        foreach ( $classNames as $className ) {
-            foreach ( preg_split('/\s+/', trim($className)) ?: array() as $class ) {
-                if ( '' !== $class && ! in_array($class, $classes, true) ) {
-                    $classes[] = $class;
-                }
-            }
-        }
-        return implode(' ', $classes);
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Style/HighValueStyleBoundaryPolicy.php
+++ b/php-transformer/src/HtmlToBlocks/Style/HighValueStyleBoundaryPolicy.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use DOMElement;
 
 final class HighValueStyleBoundaryPolicy
@@ -25,16 +26,16 @@ final class HighValueStyleBoundaryPolicy
         }
 
         if ( '' === trim($element->textContent ?? '') && in_array($tagName, array( 'span', 'i', 'b' ), true) && $element->parentNode instanceof DOMElement ) {
-            $parentTokens = strtolower($this->attr($element->parentNode, 'class') . ' ' . $this->attr($element->parentNode, 'id'));
+            $parentTokens = strtolower(SourceDom::attr($element->parentNode, 'class') . ' ' . SourceDom::attr($element->parentNode, 'id'));
             if ( preg_match('/(?:^|[^a-z0-9])(?:dots?|icons?|badges?|chips?|pills?|indicators?|markers?|orbs?)(?:[^a-z0-9]|$)/', $parentTokens) ) {
                 return true;
             }
         }
 
         $tokens = strtolower(trim(implode(' ', array(
-            $this->attr($element, 'class'),
-            $this->attr($element, 'id'),
-            $this->attr($element, 'role'),
+            SourceDom::attr($element, 'class'),
+            SourceDom::attr($element, 'id'),
+            SourceDom::attr($element, 'role'),
         ))));
 
         if ( preg_match('/(?:^|[^a-z0-9])(?:btn|button|cta|action|nav|menu|logo|brand|branding|cards?|tile|panel|pricing|price|product|grid|columns|layout|stack|cluster|row|wrap|hero|masthead|banner|badge|chip|pill|status|indicator|marker|dot|orb|media|image|photo|gallery|cover|thumb|thumbnail|art|artwork|illustration)(?:[^a-z0-9]|$)/', $tokens) ) {
@@ -48,10 +49,5 @@ final class HighValueStyleBoundaryPolicy
         }
 
         return false;
-    }
-
-    private function attr(DOMElement $element, string $name): string
-    {
-        return $element->hasAttribute($name) ? $element->getAttribute($name) : '';
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Style/SourceBlockAttributeProjector.php
+++ b/php-transformer/src/HtmlToBlocks/Style/SourceBlockAttributeProjector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\ShellLandmarkPolicy;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use DOMElement;
 
 /** Projects source identities and structural carriers onto canonical block attributes. */
@@ -39,12 +40,12 @@ final class SourceBlockAttributeProjector
     ): array {
         $sourceTagName = strtolower($sourceElement->tagName);
         if ( 'core/image' === $name && 'figure' !== $sourceTagName ) {
-            $attrs['className'] = self::mergeClassNames((string) ($attrs['className'] ?? ''), self::SYNTHETIC_IMAGE_FIGURE_CLASS);
+            $attrs['className'] = SourceDom::mergeClassNames((string) ($attrs['className'] ?? ''), self::SYNTHETIC_IMAGE_FIGURE_CLASS);
         }
         if ( 'core/paragraph' === $name && $facts->isInlineSourceElement ) {
-            $attrs['className'] = self::mergeClassNames((string) ($attrs['className'] ?? ''), self::SYNTHETIC_PARAGRAPH_CLASS);
+            $attrs['className'] = SourceDom::mergeClassNames((string) ($attrs['className'] ?? ''), self::SYNTHETIC_PARAGRAPH_CLASS);
             if ( 'a' === $sourceTagName && $this->sourceAnchorHasNoTextDecoration($sourceElement) ) {
-                $attrs['className'] = self::mergeClassNames((string) ($attrs['className'] ?? ''), self::SYNTHETIC_ANCHOR_UNDECORATED_CLASS);
+                $attrs['className'] = SourceDom::mergeClassNames((string) ($attrs['className'] ?? ''), self::SYNTHETIC_ANCHOR_UNDECORATED_CLASS);
             }
             if ( 'a' === $sourceTagName ) {
                 $attrs = $this->withSyntheticHeaderAnchorCarrier($attrs, $sourceElement, $context->generatedStyles);
@@ -55,20 +56,20 @@ final class SourceBlockAttributeProjector
             $attrs['className'] = $projectionClassName;
         }
         if ( 'core/group' === $name && $facts->isAuthorLayoutItem ) {
-            $attrs['className'] = self::mergeClassNames((string) ($attrs['className'] ?? ''), self::CSS_OWNED_LAYOUT_ITEM_CLASS);
+            $attrs['className'] = SourceDom::mergeClassNames((string) ($attrs['className'] ?? ''), self::CSS_OWNED_LAYOUT_ITEM_CLASS);
         }
         if ( 'core/group' === $name && $this->isAtomicInlineChildFlow($sourceElement, $innerBlocks) ) {
-            $attrs['className'] = self::mergeClassNames((string) ($attrs['className'] ?? ''), self::CSS_OWNED_INLINE_FLOW_CLASS);
+            $attrs['className'] = SourceDom::mergeClassNames((string) ($attrs['className'] ?? ''), self::CSS_OWNED_INLINE_FLOW_CLASS);
         }
         if ( 'core/group' === $name && 'grid' === (string) ($attrs['layout']['type'] ?? '') ) {
             $gapCarrier = $this->styleResolver->inlineGeometryClassName($sourceElement, array(), array( 'gap' ));
             if ( '' !== $gapCarrier ) {
-                $attrs['className'] = self::mergeClassNames((string) ($attrs['className'] ?? ''), $gapCarrier);
+                $attrs['className'] = SourceDom::mergeClassNames((string) ($attrs['className'] ?? ''), $gapCarrier);
             }
         }
         $tableMarker = $context->selectorProjections->tableMarker($sourceElement->getNodePath() ?? '');
         if ( 'core/table' === $name && '' !== $tableMarker ) {
-            $attrs['className'] = self::mergeClassNames((string) ($attrs['className'] ?? ''), $tableMarker);
+            $attrs['className'] = SourceDom::mergeClassNames((string) ($attrs['className'] ?? ''), $tableMarker);
         }
 
         $attrs = $this->projectButtonAttributes($name, $attrs, $sourceElement, $logicalSourceElement, $facts, $context);
@@ -93,17 +94,17 @@ final class SourceBlockAttributeProjector
     {
         $sourceTagMarker = $context->selectorProjections->tagMarker(strtolower($element->tagName));
         if ( '' !== $sourceTagMarker ) {
-            $className = self::mergeClassNames($className, $sourceTagMarker);
+            $className = SourceDom::mergeClassNames($className, $sourceTagMarker);
         }
         if ( $element->parentNode instanceof DOMElement
             && 'body' === strtolower($element->parentNode->tagName)
             && array() !== $context->authorStyles->sourceBodyProjectionClasses()
         ) {
-            $className = self::mergeClassNames($className, ...$context->authorStyles->sourceBodyProjectionClasses());
+            $className = SourceDom::mergeClassNames($className, ...$context->authorStyles->sourceBodyProjectionClasses());
         }
         $semanticMarkers = $context->selectorProjections->semanticMarkersForPath($element->getNodePath() ?? '');
         if ( array() !== $semanticMarkers ) {
-            $className = self::mergeClassNames($className, ...$semanticMarkers);
+            $className = SourceDom::mergeClassNames($className, ...$semanticMarkers);
         }
         return $className;
     }
@@ -135,7 +136,7 @@ final class SourceBlockAttributeProjector
         if ( $facts->hasAuthorControlProjection ) {
             $controlMarker = '' !== $logicalControlPath ? $context->selectorProjections->ensureControlMarker($logicalControlPath) : '';
             if ( '' !== $controlMarker ) {
-                $attrs['className'] = self::mergeClassNames((string) ($attrs['className'] ?? ''), $controlMarker);
+                $attrs['className'] = SourceDom::mergeClassNames((string) ($attrs['className'] ?? ''), $controlMarker);
                 if ( 'core/button' === $name ) {
                     $this->generatedStyleProjector->registerNativeButtonStyleRule($controlMarker, $attrs, $context->generatedStyles, $nativeButtonTextAlignment, $logicalControl);
                     if ( $facts->isDirectChildOfAuthorFlexLayout ) {
@@ -153,7 +154,7 @@ final class SourceBlockAttributeProjector
             $nativeButtonMarker = $hasNativeButtonColor
                 ? $context->authorStyles->allocateMarker('native-button')
                 : 'blocks-engine-native-button-alignment-' . $nativeButtonTextAlignment;
-            $attrs['className'] = self::mergeClassNames((string) ($attrs['className'] ?? ''), $nativeButtonMarker);
+            $attrs['className'] = SourceDom::mergeClassNames((string) ($attrs['className'] ?? ''), $nativeButtonMarker);
             $this->generatedStyleProjector->registerNativeButtonStyleRule($nativeButtonMarker, $hasNativeButtonColor ? $attrs : array(), $context->generatedStyles, $nativeButtonTextAlignment);
             self::registerButtonWidth($attrs, $nativeButtonMarker, $context, $this->generatedStyleProjector);
         }
@@ -240,7 +241,7 @@ final class SourceBlockAttributeProjector
         }
         $css = $this->styleResolver->cssDeclarationString($declarations);
         $className = self::SYNTHETIC_HEADER_ANCHOR_CLASS_PREFIX . substr(hash('sha256', $css), 0, 16);
-        $attrs['className'] = self::mergeClassNames((string) ($attrs['className'] ?? ''), $className);
+        $attrs['className'] = SourceDom::mergeClassNames((string) ($attrs['className'] ?? ''), $className);
         $generatedStyles->registerSyntheticHeaderAnchor($className, 'p.' . $className . '>a{' . $css . '}');
         return $attrs;
     }
@@ -263,18 +264,5 @@ final class SourceBlockAttributeProjector
             }
         }
         return false;
-    }
-
-    private static function mergeClassNames(string ...$classNames): string
-    {
-        $classes = array();
-        foreach ( $classNames as $className ) {
-            foreach ( preg_split('/\s+/', trim($className)) ?: array() as $class ) {
-                if ( '' !== $class && ! in_array($class, $classes, true) ) {
-                    $classes[] = $class;
-                }
-            }
-        }
-        return implode(' ', $classes);
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
@@ -25,199 +25,87 @@ trait DomHelpersTrait
 
     private function innerHtml(DOMElement $element): string
     {
-        $element = $this->canonicalizedSerializationClone($element);
-        $html = '';
-        foreach ( $element->childNodes as $child ) {
-            $html .= $element->ownerDocument->saveHTML($child);
-        }
-
-        return trim($html);
+        return SourceDom::innerHtml($element);
     }
 
     private function innerHtmlPreservingWhitespace(DOMElement $element): string
     {
-        $element = $this->canonicalizedSerializationClone($element);
-        $html = '';
-        foreach ( $element->childNodes as $child ) {
-            $html .= $element->ownerDocument->saveHTML($child);
-        }
-
-        return $html;
+        return SourceDom::innerHtmlPreservingWhitespace($element);
     }
 
     private function outerHtml(DOMElement $element): string
     {
-        $element = $this->canonicalizedSerializationClone($element);
-        return trim($element->ownerDocument->saveHTML($element) ?: '');
+        return SourceDom::outerHtml($element);
     }
 
     private function canonicalizedSerializationClone(DOMElement $element): DOMElement
     {
-        $clone = $element->cloneNode(true);
-        if ( ! $clone instanceof DOMElement ) {
-            throw new \LogicException('Cloning a DOMElement must produce a DOMElement.');
-        }
-        $this->canonicalizeLinkUrls($clone);
-        return $clone;
+        return SourceDom::canonicalizedSerializationClone($element);
     }
 
     private function canonicalizeLinkUrls(DOMElement $element): void
     {
-        $anchors = 'a' === strtolower($element->tagName) ? array( $element ) : array();
-        foreach ( $element->getElementsByTagName('a') as $anchor ) {
-            if ( $anchor instanceof DOMElement ) {
-                $anchors[] = $anchor;
-            }
-        }
-
-        foreach ( $anchors as $anchor ) {
-            if ( ! $anchor->hasAttribute('href') ) {
-                continue;
-            }
-
-            $href = LinkUrlSanitizer::sanitize($anchor->getAttribute('href'));
-            if ( '' === $href ) {
-                $anchor->removeAttribute('href');
-                continue;
-            }
-            if ( $href !== $anchor->getAttribute('href') ) {
-                $anchor->setAttribute('href', $href);
-            }
-        }
+        SourceDom::canonicalizeLinkUrls($element);
     }
 
     private function attr(DOMElement $element, string $name): string
     {
-        return $element->hasAttribute($name) ? $element->getAttribute($name) : '';
+        return SourceDom::attr($element, $name);
     }
 
     private function safeAnchor(string $id): string
     {
-        $id = trim($id);
-        if ( '' === $id || ! preg_match('/^[A-Za-z][A-Za-z0-9_-]*$/', $id) ) {
-            return '';
-        }
-
-        return $id;
+        return SourceDom::safeAnchor($id);
     }
 
     private function hasClass(DOMElement $element, string $className): bool
     {
-        return in_array($className, preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array(), true);
+        return SourceDom::hasClass($element, $className);
     }
 
     private function elementSelector(DOMElement $element): string
     {
-        $parts = array();
-        $current = $element;
-        while ( $current instanceof DOMElement && 'body' !== strtolower($current->tagName) ) {
-            $tagName = strtolower($current->tagName);
-            $index = 1;
-            for ( $sibling = $current->previousSibling; $sibling instanceof DOMNode; $sibling = $sibling->previousSibling ) {
-                if ( $sibling instanceof DOMElement && strtolower($sibling->tagName) === $tagName ) {
-                    ++$index;
-                }
-            }
-            array_unshift($parts, $tagName . ':nth-of-type(' . $index . ')');
-            $current = $current->parentNode instanceof DOMElement ? $current->parentNode : null;
-        }
-
-        return implode(' > ', $parts);
+        return SourceDom::elementSelector($element);
     }
 
-    /**
-     * @return array<string, string>
-     */
     private function htmlAttributes(DOMElement $element): array
     {
-        $attributes = array();
-        foreach ( $element->attributes ?? array() as $attribute ) {
-            $attributes[$attribute->nodeName] = $attribute->nodeValue ?? '';
-        }
-
-        ksort($attributes);
-        return $attributes;
+        return SourceDom::htmlAttributes($element);
     }
 
-    /**
-     * @return array<int, string>
-     */
     private function ancestorTags(DOMElement $element): array
     {
-        $tags = array();
-        for ( $parent = $element->parentNode; $parent instanceof DOMElement && 'body' !== strtolower($parent->tagName); $parent = $parent->parentNode ) {
-            $tags[] = strtolower($parent->tagName);
-        }
-
-        return $tags;
+        return SourceDom::ancestorTags($element);
     }
 
-    /**
-     * @return array<int, string>
-     */
     private function classNames(DOMElement $element): array
     {
-        return array_values(array_filter(preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array()));
+        return SourceDom::classNames($element);
     }
 
     private function childElementCount(DOMElement $element): int
     {
-        $count = 0;
-        foreach ( $element->childNodes as $child ) {
-            if ( $child instanceof DOMElement ) {
-                ++$count;
-            }
-        }
-
-        return $count;
+        return SourceDom::childElementCount($element);
     }
 
     private function closestTagName(DOMElement $element): ?string
     {
-        return $element->parentNode instanceof DOMElement ? strtolower($element->parentNode->tagName) : null;
+        return SourceDom::closestTagName($element);
     }
 
     private function firstChildElement(DOMElement $element, string $tagName): ?DOMElement
     {
-        foreach ( $element->childNodes as $child ) {
-            if ( $child instanceof DOMElement && strtolower($child->tagName) === $tagName ) {
-                return $child;
-            }
-        }
-        return null;
+        return SourceDom::firstChildElement($element, $tagName);
     }
 
     private function onlyChildElement(DOMElement $element, string $tagName): ?DOMElement
     {
-        $match = null;
-        foreach ( $element->childNodes as $child ) {
-            if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
-                continue;
-            }
-
-            if ( ! $child instanceof DOMElement || strtolower($child->tagName) !== $tagName || null !== $match ) {
-                return null;
-            }
-
-            $match = $child;
-        }
-
-        return $match;
+        return SourceDom::onlyChildElement($element, $tagName);
     }
 
-    /**
-     * @param array<int, string> $excludedTags
-     */
     private function innerHtmlWithoutTags(DOMElement $element, array $excludedTags): string
     {
-        $html = '';
-        foreach ( $element->childNodes as $child ) {
-            if ( $child instanceof DOMElement && in_array(strtolower($child->tagName), $excludedTags, true) ) {
-                continue;
-            }
-            $html .= $element->ownerDocument->saveHTML($child);
-        }
-        return trim($html);
+        return SourceDom::innerHtmlWithoutTags($element, $excludedTags);
     }
 
     private function safeFallbackHtml(DOMElement $element): string
@@ -263,298 +151,87 @@ trait DomHelpersTrait
 
     private function safeFallbackHtmlString(string $html): string
     {
-        $html = preg_replace('@<(script|style)[^>]*?>.*?</\\1>@si', '', $html) ?? '';
-        $html = preg_replace('@<link\b[^>]*\/?>@si', '', $html) ?? '';
-        $html = preg_replace('/\s+on[a-z]+\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $html) ?? '';
-        $html = preg_replace_callback(
-            '/\s+([a-zA-Z_:][\w:.-]*)\s*=\s*("([^"]*)"|\'([^\']*)\'|([^\s>]+))/i',
-            function (array $matches): string {
-                $attribute = strtolower($matches[1]);
-                $value = $matches[3] ?? $matches[4] ?? $matches[5] ?? '';
-                if ( 'srcset' === $attribute ) {
-                    $srcset = $this->safeFallbackSrcset($value);
-                    return '' === $srcset
-                        ? ''
-                        : ' ' . $matches[1] . '="' . htmlspecialchars($srcset, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"';
-                }
-                return $this->isFallbackUrlAttribute($attribute) && ! $this->safeFallbackUrl($value, $attribute)
-                    ? ''
-                    : $matches[0];
-            },
-            $html
-        ) ?? '';
-        $html = preg_replace_callback('@<meta\b[^>]*>@i', function (array $matches): string {
-            $tag = $matches[0];
-            if ( ! preg_match('/\bhttp-equiv\s*=\s*("refresh"|\'refresh\'|refresh)(?:\s|>)/i', $tag) ) {
-                return $tag;
-            }
-            return preg_match('/\bcontent\s*=\s*("[^\"]*(?:url\s*=\s*)?(?:javascript|vbscript|data|file)\s*:[^\"]*"|\'[^\']*(?:url\s*=\s*)?(?:javascript|vbscript|data|file)\s*:[^\']*\'|[^\s>]*(?:javascript|vbscript|data|file)\s*:)/i', $tag)
-                ? ''
-                : $tag;
-        }, $html) ?? '';
-        $html = preg_replace('/\s+srcdoc\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $html) ?? '';
-
-        return trim($html);
+        return SourceDom::safeFallbackHtmlString($html);
     }
 
     private function isFallbackUrlAttribute(string $attribute): bool
     {
-        return in_array($attribute, array(
-            'action', 'archive', 'background', 'cite', 'codebase', 'data', 'formaction',
-            'href', 'longdesc', 'manifest', 'ping', 'poster', 'profile', 'src', 'usemap', 'xlink:href',
-        ), true);
+        return SourceDom::isFallbackUrlAttribute($attribute);
     }
 
-    /**
-     * Keep only safe srcset candidates while retaining their source-selection
-     * descriptors. The URL policy deliberately matches fallback image `src`.
-     */
     private function safeFallbackSrcset(string $srcset): string
     {
-        $candidates = array();
-        foreach ( SrcsetParser::parse($srcset) as $candidate ) {
-            if ( $this->safeFallbackUrl($candidate['url'], 'src') ) {
-                $candidates[] = $candidate['url'] . ( '' !== $candidate['descriptor'] ? ' ' . $candidate['descriptor'] : '' );
-            }
-        }
-
-        return implode(', ', $candidates);
+        return SourceDom::safeFallbackSrcset($srcset);
     }
 
     private function safeFallbackUrl(string $url, string $attribute): bool
     {
-        $normalized = strtolower(preg_replace('/[\x00-\x20\x7f]+/', '', html_entity_decode($url, ENT_QUOTES | ENT_HTML5, 'UTF-8')) ?? '');
-        for ( $index = 0; $index < 2 && str_contains($normalized, '%'); ++$index ) {
-            $normalized = rawurldecode($normalized);
-        }
-
-        if ( '' === $normalized || ! preg_match('/^([a-z][a-z0-9+.-]*):/i', $normalized, $scheme) ) {
-            return true;
-        }
-        if ( in_array($scheme[1], array( 'http', 'https', 'mailto', 'tel' ), true) ) {
-            return true;
-        }
-
-        return 'src' === $attribute && (bool) preg_match('#^data:image/(?:avif|gif|jpeg|png|webp);base64,[a-z0-9+/=]+$#i', $normalized);
+        return SourceDom::safeFallbackUrl($url, $attribute);
     }
 
-    /**
-     * @return array{html: string, bytes: int, truncated: bool}
-     */
     private function boundedFallbackHtml(string $html): array
     {
-        $bytes = strlen($html);
-        if ( $bytes > 2000 ) {
-            return array(
-                'html'      => substr($html, 0, 2000) . '...',
-                'bytes'     => $bytes,
-                'truncated' => true,
-            );
-        }
-
-        return array(
-            'html'      => $html,
-            'bytes'     => $bytes,
-            'truncated' => false,
-        );
+        return SourceDom::boundedFallbackHtml($html);
     }
 
-    /**
-     * @return array{text: string, bytes: int, truncated: bool}
-     */
     private function boundedFallbackText(string $text): array
     {
-        $bytes = strlen($text);
-        if ( $bytes > 2000 ) {
-            return array(
-                'text'      => substr($text, 0, 2000) . '...',
-                'bytes'     => $bytes,
-                'truncated' => true,
-            );
-        }
-
-        return array(
-            'text'      => $text,
-            'bytes'     => $bytes,
-            'truncated' => false,
-        );
+        return SourceDom::boundedFallbackText($text);
     }
 
     private function directElementChildCount(DOMElement $element): int
     {
-        $count = 0;
-        foreach ( $element->childNodes as $child ) {
-            if ( $child instanceof DOMElement ) {
-                ++$count;
-            }
-        }
-
-        return $count;
+        return SourceDom::directElementChildCount($element);
     }
 
     private function mergeClassNames(string ...$classNames): string
     {
-        $classes = array();
-        foreach ( $classNames as $className ) {
-            foreach ( preg_split('/\s+/', trim($className)) ?: array() as $class ) {
-                if ( '' !== $class && ! in_array($class, $classes, true) ) {
-                    $classes[] = $class;
-                }
-            }
-        }
-
-        return implode(' ', $classes);
+        return SourceDom::mergeClassNames(...$classNames);
     }
 
     private function htmlAttributeString(array $attrs): string
     {
-        $html = '';
-        foreach ( $attrs as $name => $value ) {
-            $html .= ' ' . $name . '="' . htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"';
-        }
-        return $html;
+        return SourceDom::htmlAttributeString($attrs);
     }
 
-    /**
-     * @param array<int, string> $tagNames
-     */
     private function hasAncestorTag(DOMElement $element, array $tagNames): bool
     {
-        for ( $node = $element->parentNode; $node instanceof DOMElement && 'body' !== strtolower($node->tagName); $node = $node->parentNode ) {
-            if ( in_array(strtolower($node->tagName), $tagNames, true) ) {
-                return true;
-            }
-        }
-
-        return false;
+        return SourceDom::hasAncestorTag($element, $tagNames);
     }
 
     private function hasSourceNavigationSignal(DOMElement $element): bool
     {
-        if ( 'navigation' === strtolower($this->attr($element, 'role')) ) {
-            return true;
-        }
-
-        foreach ( array( 'class', 'id' ) as $attribute ) {
-            foreach ( preg_split('/[^a-z0-9]+/', strtolower($this->attr($element, $attribute))) ?: array() as $token ) {
-                if ( in_array($token, array( 'nav', 'navbar', 'navigation', 'menu', 'links' ), true) ) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
+        return SourceDom::hasSourceNavigationSignal($element);
     }
 
-    /**
-     * Sanitize a navigation URL, dropping control characters and javascript: schemes.
-     */
     private function safeNavigationUrl(string $url): string
     {
-        return LinkUrlSanitizer::sanitize($url);
+        return SourceDom::safeNavigationUrl($url);
     }
 
     private function runtimeIslandSelector(DOMElement $element): string
     {
-        $id = trim($this->attr($element, 'id'));
-        if ( '' !== $id ) {
-            return '#' . $id;
-        }
-
-        foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) {
-            if ( '' !== $class ) {
-                return '.' . $class;
-            }
-        }
-
-        return $this->elementSelector($element);
+        return SourceDom::runtimeIslandSelector($element);
     }
 
-    /**
-     * @return array<int, array<string, string>>
-     */
     private function eventMetadata(DOMElement $element): array
     {
-        $events = array();
-        foreach ( $this->htmlAttributes($element) as $name => $value ) {
-            if ( preg_match('/^on([a-z]+)$/i', $name, $matches) ) {
-                $events[] = array(
-                    'type'      => strtolower($matches[1]),
-                    'attribute' => strtolower($name),
-                );
-            }
-            if ( preg_match('/^data-(?:action|on|event)$/i', $name) && '' !== trim($value) ) {
-                $events[] = array(
-                    'type'      => 'declared',
-                    'attribute' => $name,
-                );
-            }
-        }
-
-        return $events;
+        return SourceDom::eventMetadata($element);
     }
 
     private function isSafeSvgContent(string $content): bool
     {
-        return '' !== trim($content) && preg_match('/<svg(?:\s|>)/i', $content) && ! preg_match('/<\s*script\b|\son[a-z]+\s*=|javascript\s*:/i', $content);
+        return SourceDom::isSafeSvgContent($content);
     }
 
-    /**
-     * Whether an inline SVG carries any drawable artwork worth preserving.
-     *
-     * Returns true when the SVG has at least one shape/structure element
-     * (path/circle/rect/text/g/...) outside of any foreignObject subtree.
-     * Elements that carry no visual artwork on their own — script/style/
-     * foreignObject (all stripped during sanitization) and the metadata-only
-     * title/desc/metadata — do not count. An SVG whose only content is unsafe
-     * has nothing left to render once sanitized, so callers fall back to the
-     * bounded diagnostic instead of emitting an empty graphic.
-     */
     private function svgHasDrawableContent(DOMElement $element): bool
     {
-        foreach ( $element->getElementsByTagName('*') as $child ) {
-            if ( ! $child instanceof DOMElement ) {
-                continue;
-            }
-            $tag = strtolower($child->tagName);
-            if ( in_array($tag, array( 'script', 'style', 'foreignobject', 'title', 'desc', 'metadata', 'defs' ), true) ) {
-                continue;
-            }
-            if ( $this->hasAncestorTag($child, array( 'foreignobject' )) ) {
-                continue;
-            }
-            // A <use> that points at an external sprite file (href="sprite.svg#id"
-            // rather than a local "#id") cannot be inlined: the referenced symbol
-            // lives in another file that does not travel with the imported markup,
-            // so the emitted <use> would render nothing. It carries no drawable
-            // artwork of its own, so it does not, by itself, make the SVG
-            // preservable — the SVG falls through to the bounded fallback
-            // diagnostic instead of emitting a broken external reference. A local
-            // <use href="#id"> (resolved against an in-document symbol/defs) and
-            // any real shape element still count as drawable.
-            if ( 'use' === $tag && $this->isExternalSpriteUse($child) ) {
-                continue;
-            }
-
-            return true;
-        }
-
-        return false;
+        return SourceDom::svgHasDrawableContent($element);
     }
 
-    /**
-     * Whether a <use> element references an external sprite file rather than an
-     * in-document fragment. An external reference is any href/xlink:href whose
-     * target is not a bare local "#id" fragment.
-     */
     private function isExternalSpriteUse(DOMElement $element): bool
     {
-        $href = trim($this->attr($element, 'href'));
-        if ( '' === $href ) {
-            $href = trim($this->attr($element, 'xlink:href'));
-        }
-
-        return '' !== $href && '#' !== substr($href, 0, 1);
+        return SourceDom::isExternalSpriteUse($element);
     }
 
     /**
@@ -589,27 +266,13 @@ trait DomHelpersTrait
         return trim($html);
     }
 
-    /**
-     * @param array<int, array<string, mixed>> $rows
-     * @return array<int, array<string, mixed>>
-     */
     private function dedupeArrayRows(array $rows): array
     {
-        return DeterministicRowDeduplicator::dedupe($rows);
+        return SourceDom::dedupeArrayRows($rows);
     }
 
-    /**
-     * Whether $container is $element or one of its ancestors. Shared DOM
-     * ancestry helper; consumed by form dispatch and navigation suppression.
-     */
     private function elementContains(DOMElement $container, DOMElement $element): bool
     {
-        for ( $node = $element; $node instanceof DOMElement; $node = $node->parentNode ) {
-            if ( $node->isSameNode($container) ) {
-                return true;
-            }
-        }
-
-        return false;
+        return SourceDom::elementContains($container, $element);
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Support/SourceDom.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SourceDom.php
@@ -1,0 +1,550 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support;
+
+use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\SrcsetParser;
+use Automattic\BlocksEngine\PhpTransformer\Support\DeterministicRowDeduplicator;
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+
+/**
+ * The engine's shared DOM reading vocabulary.
+ *
+ * Reading an attribute, counting element children, serializing inner HTML,
+ * building a selector for an element — the small, exact operations that every
+ * part of the transformer performs constantly.
+ *
+ * These are pure functions of their arguments. They are static deliberately:
+ * a pure function needs no instance, so a caller needs no constructor argument
+ * and no injected closure to reach one. That is the whole point. This
+ * vocabulary previously lived only in {@see DomHelpersTrait}, which meant a
+ * class that was not already the transformer could not reach it, and the
+ * package accumulated three separate workarounds — forwarding closures through
+ * context objects, copy-pasted private duplicates, and independent
+ * reimplementations that were free to disagree.
+ *
+ * Operations needing transform state (source-tag markers, fallback
+ * sanitization, the WordPress runtime) are not part of this vocabulary and
+ * remain on {@see DomHelpersTrait}.
+ */
+final class SourceDom
+{
+    public static function innerHtml(DOMElement $element): string
+    {
+        $element = self::canonicalizedSerializationClone($element);
+        $html = '';
+        foreach ( $element->childNodes as $child ) {
+            $html .= $element->ownerDocument->saveHTML($child);
+        }
+
+        return trim($html);
+    }
+
+    public static function innerHtmlPreservingWhitespace(DOMElement $element): string
+    {
+        $element = self::canonicalizedSerializationClone($element);
+        $html = '';
+        foreach ( $element->childNodes as $child ) {
+            $html .= $element->ownerDocument->saveHTML($child);
+        }
+
+        return $html;
+    }
+
+    public static function outerHtml(DOMElement $element): string
+    {
+        $element = self::canonicalizedSerializationClone($element);
+        return trim($element->ownerDocument->saveHTML($element) ?: '');
+    }
+
+    public static function canonicalizedSerializationClone(DOMElement $element): DOMElement
+    {
+        $clone = $element->cloneNode(true);
+        if ( ! $clone instanceof DOMElement ) {
+            throw new \LogicException('Cloning a DOMElement must produce a DOMElement.');
+        }
+        self::canonicalizeLinkUrls($clone);
+        return $clone;
+    }
+
+    public static function canonicalizeLinkUrls(DOMElement $element): void
+    {
+        $anchors = 'a' === strtolower($element->tagName) ? array( $element ) : array();
+        foreach ( $element->getElementsByTagName('a') as $anchor ) {
+            if ( $anchor instanceof DOMElement ) {
+                $anchors[] = $anchor;
+            }
+        }
+
+        foreach ( $anchors as $anchor ) {
+            if ( ! $anchor->hasAttribute('href') ) {
+                continue;
+            }
+
+            $href = LinkUrlSanitizer::sanitize($anchor->getAttribute('href'));
+            if ( '' === $href ) {
+                $anchor->removeAttribute('href');
+                continue;
+            }
+            if ( $href !== $anchor->getAttribute('href') ) {
+                $anchor->setAttribute('href', $href);
+            }
+        }
+    }
+
+    public static function attr(DOMElement $element, string $name): string
+    {
+        return $element->hasAttribute($name) ? $element->getAttribute($name) : '';
+    }
+
+    public static function safeAnchor(string $id): string
+    {
+        $id = trim($id);
+        if ( '' === $id || ! preg_match('/^[A-Za-z][A-Za-z0-9_-]*$/', $id) ) {
+            return '';
+        }
+
+        return $id;
+    }
+
+    public static function hasClass(DOMElement $element, string $className): bool
+    {
+        return in_array($className, preg_split('/\s+/', trim(self::attr($element, 'class'))) ?: array(), true);
+    }
+
+    public static function elementSelector(DOMElement $element): string
+    {
+        $parts = array();
+        $current = $element;
+        while ( $current instanceof DOMElement && 'body' !== strtolower($current->tagName) ) {
+            $tagName = strtolower($current->tagName);
+            $index = 1;
+            for ( $sibling = $current->previousSibling; $sibling instanceof DOMNode; $sibling = $sibling->previousSibling ) {
+                if ( $sibling instanceof DOMElement && strtolower($sibling->tagName) === $tagName ) {
+                    ++$index;
+                }
+            }
+            array_unshift($parts, $tagName . ':nth-of-type(' . $index . ')');
+            $current = $current->parentNode instanceof DOMElement ? $current->parentNode : null;
+        }
+
+        return implode(' > ', $parts);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function htmlAttributes(DOMElement $element): array
+    {
+        $attributes = array();
+        foreach ( $element->attributes ?? array() as $attribute ) {
+            $attributes[$attribute->nodeName] = $attribute->nodeValue ?? '';
+        }
+
+        ksort($attributes);
+        return $attributes;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function ancestorTags(DOMElement $element): array
+    {
+        $tags = array();
+        for ( $parent = $element->parentNode; $parent instanceof DOMElement && 'body' !== strtolower($parent->tagName); $parent = $parent->parentNode ) {
+            $tags[] = strtolower($parent->tagName);
+        }
+
+        return $tags;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function classNames(DOMElement $element): array
+    {
+        return array_values(array_filter(preg_split('/\s+/', trim(self::attr($element, 'class'))) ?: array()));
+    }
+
+    public static function childElementCount(DOMElement $element): int
+    {
+        $count = 0;
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement ) {
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+
+    public static function closestTagName(DOMElement $element): ?string
+    {
+        return $element->parentNode instanceof DOMElement ? strtolower($element->parentNode->tagName) : null;
+    }
+
+    public static function firstChildElement(DOMElement $element, string $tagName): ?DOMElement
+    {
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement && strtolower($child->tagName) === $tagName ) {
+                return $child;
+            }
+        }
+        return null;
+    }
+
+    public static function onlyChildElement(DOMElement $element, string $tagName): ?DOMElement
+    {
+        $match = null;
+        foreach ( $element->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
+                continue;
+            }
+
+            if ( ! $child instanceof DOMElement || strtolower($child->tagName) !== $tagName || null !== $match ) {
+                return null;
+            }
+
+            $match = $child;
+        }
+
+        return $match;
+    }
+
+    /**
+     * @param array<int, string> $excludedTags
+     */
+    public static function innerHtmlWithoutTags(DOMElement $element, array $excludedTags): string
+    {
+        $html = '';
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement && in_array(strtolower($child->tagName), $excludedTags, true) ) {
+                continue;
+            }
+            $html .= $element->ownerDocument->saveHTML($child);
+        }
+        return trim($html);
+    }
+
+    public static function safeFallbackHtmlString(string $html): string
+    {
+        $html = preg_replace('@<(script|style)[^>]*?>.*?</\\1>@si', '', $html) ?? '';
+        $html = preg_replace('@<link\b[^>]*\/?>@si', '', $html) ?? '';
+        $html = preg_replace('/\s+on[a-z]+\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $html) ?? '';
+        $html = preg_replace_callback(
+            '/\s+([a-zA-Z_:][\w:.-]*)\s*=\s*("([^"]*)"|\'([^\']*)\'|([^\s>]+))/i',
+            function (array $matches): string {
+                $attribute = strtolower($matches[1]);
+                $value = $matches[3] ?? $matches[4] ?? $matches[5] ?? '';
+                if ( 'srcset' === $attribute ) {
+                    $srcset = self::safeFallbackSrcset($value);
+                    return '' === $srcset
+                        ? ''
+                        : ' ' . $matches[1] . '="' . htmlspecialchars($srcset, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"';
+                }
+                return self::isFallbackUrlAttribute($attribute) && ! self::safeFallbackUrl($value, $attribute)
+                    ? ''
+                    : $matches[0];
+            },
+            $html
+        ) ?? '';
+        $html = preg_replace_callback('@<meta\b[^>]*>@i', function (array $matches): string {
+            $tag = $matches[0];
+            if ( ! preg_match('/\bhttp-equiv\s*=\s*("refresh"|\'refresh\'|refresh)(?:\s|>)/i', $tag) ) {
+                return $tag;
+            }
+            return preg_match('/\bcontent\s*=\s*("[^\"]*(?:url\s*=\s*)?(?:javascript|vbscript|data|file)\s*:[^\"]*"|\'[^\']*(?:url\s*=\s*)?(?:javascript|vbscript|data|file)\s*:[^\']*\'|[^\s>]*(?:javascript|vbscript|data|file)\s*:)/i', $tag)
+                ? ''
+                : $tag;
+        }, $html) ?? '';
+        $html = preg_replace('/\s+srcdoc\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $html) ?? '';
+
+        return trim($html);
+    }
+
+    public static function isFallbackUrlAttribute(string $attribute): bool
+    {
+        return in_array($attribute, array(
+            'action', 'archive', 'background', 'cite', 'codebase', 'data', 'formaction',
+            'href', 'longdesc', 'manifest', 'ping', 'poster', 'profile', 'src', 'usemap', 'xlink:href',
+        ), true);
+    }
+
+    /**
+     * Keep only safe srcset candidates while retaining their source-selection
+     * descriptors. The URL policy deliberately matches fallback image `src`.
+     */
+    public static function safeFallbackSrcset(string $srcset): string
+    {
+        $candidates = array();
+        foreach ( SrcsetParser::parse($srcset) as $candidate ) {
+            if ( self::safeFallbackUrl($candidate['url'], 'src') ) {
+                $candidates[] = $candidate['url'] . ( '' !== $candidate['descriptor'] ? ' ' . $candidate['descriptor'] : '' );
+            }
+        }
+
+        return implode(', ', $candidates);
+    }
+
+    public static function safeFallbackUrl(string $url, string $attribute): bool
+    {
+        $normalized = strtolower(preg_replace('/[\x00-\x20\x7f]+/', '', html_entity_decode($url, ENT_QUOTES | ENT_HTML5, 'UTF-8')) ?? '');
+        for ( $index = 0; $index < 2 && str_contains($normalized, '%'); ++$index ) {
+            $normalized = rawurldecode($normalized);
+        }
+
+        if ( '' === $normalized || ! preg_match('/^([a-z][a-z0-9+.-]*):/i', $normalized, $scheme) ) {
+            return true;
+        }
+        if ( in_array($scheme[1], array( 'http', 'https', 'mailto', 'tel' ), true) ) {
+            return true;
+        }
+
+        return 'src' === $attribute && (bool) preg_match('#^data:image/(?:avif|gif|jpeg|png|webp);base64,[a-z0-9+/=]+$#i', $normalized);
+    }
+
+    /**
+     * @return array{html: string, bytes: int, truncated: bool}
+     */
+    public static function boundedFallbackHtml(string $html): array
+    {
+        $bytes = strlen($html);
+        if ( $bytes > 2000 ) {
+            return array(
+                'html'      => substr($html, 0, 2000) . '...',
+                'bytes'     => $bytes,
+                'truncated' => true,
+            );
+        }
+
+        return array(
+            'html'      => $html,
+            'bytes'     => $bytes,
+            'truncated' => false,
+        );
+    }
+
+    /**
+     * @return array{text: string, bytes: int, truncated: bool}
+     */
+    public static function boundedFallbackText(string $text): array
+    {
+        $bytes = strlen($text);
+        if ( $bytes > 2000 ) {
+            return array(
+                'text'      => substr($text, 0, 2000) . '...',
+                'bytes'     => $bytes,
+                'truncated' => true,
+            );
+        }
+
+        return array(
+            'text'      => $text,
+            'bytes'     => $bytes,
+            'truncated' => false,
+        );
+    }
+
+    public static function directElementChildCount(DOMElement $element): int
+    {
+        $count = 0;
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement ) {
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+
+    public static function mergeClassNames(string ...$classNames): string
+    {
+        $classes = array();
+        foreach ( $classNames as $className ) {
+            foreach ( preg_split('/\s+/', trim($className)) ?: array() as $class ) {
+                if ( '' !== $class && ! in_array($class, $classes, true) ) {
+                    $classes[] = $class;
+                }
+            }
+        }
+
+        return implode(' ', $classes);
+    }
+
+    public static function htmlAttributeString(array $attrs): string
+    {
+        $html = '';
+        foreach ( $attrs as $name => $value ) {
+            $html .= ' ' . $name . '="' . htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"';
+        }
+        return $html;
+    }
+
+    /**
+     * @param array<int, string> $tagNames
+     */
+    public static function hasAncestorTag(DOMElement $element, array $tagNames): bool
+    {
+        for ( $node = $element->parentNode; $node instanceof DOMElement && 'body' !== strtolower($node->tagName); $node = $node->parentNode ) {
+            if ( in_array(strtolower($node->tagName), $tagNames, true) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static function hasSourceNavigationSignal(DOMElement $element): bool
+    {
+        if ( 'navigation' === strtolower(self::attr($element, 'role')) ) {
+            return true;
+        }
+
+        foreach ( array( 'class', 'id' ) as $attribute ) {
+            foreach ( preg_split('/[^a-z0-9]+/', strtolower(self::attr($element, $attribute))) ?: array() as $token ) {
+                if ( in_array($token, array( 'nav', 'navbar', 'navigation', 'menu', 'links' ), true) ) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Sanitize a navigation URL, dropping control characters and javascript: schemes.
+     */
+    public static function safeNavigationUrl(string $url): string
+    {
+        return LinkUrlSanitizer::sanitize($url);
+    }
+
+    public static function runtimeIslandSelector(DOMElement $element): string
+    {
+        $id = trim(self::attr($element, 'id'));
+        if ( '' !== $id ) {
+            return '#' . $id;
+        }
+
+        foreach ( preg_split('/\s+/', trim(self::attr($element, 'class'))) ?: array() as $class ) {
+            if ( '' !== $class ) {
+                return '.' . $class;
+            }
+        }
+
+        return self::elementSelector($element);
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    public static function eventMetadata(DOMElement $element): array
+    {
+        $events = array();
+        foreach ( self::htmlAttributes($element) as $name => $value ) {
+            if ( preg_match('/^on([a-z]+)$/i', $name, $matches) ) {
+                $events[] = array(
+                    'type'      => strtolower($matches[1]),
+                    'attribute' => strtolower($name),
+                );
+            }
+            if ( preg_match('/^data-(?:action|on|event)$/i', $name) && '' !== trim($value) ) {
+                $events[] = array(
+                    'type'      => 'declared',
+                    'attribute' => $name,
+                );
+            }
+        }
+
+        return $events;
+    }
+
+    public static function isSafeSvgContent(string $content): bool
+    {
+        return '' !== trim($content) && preg_match('/<svg(?:\s|>)/i', $content) && ! preg_match('/<\s*script\b|\son[a-z]+\s*=|javascript\s*:/i', $content);
+    }
+
+    /**
+     * Whether an inline SVG carries any drawable artwork worth preserving.
+     *
+     * Returns true when the SVG has at least one shape/structure element
+     * (path/circle/rect/text/g/...) outside of any foreignObject subtree.
+     * Elements that carry no visual artwork on their own — script/style/
+     * foreignObject (all stripped during sanitization) and the metadata-only
+     * title/desc/metadata — do not count. An SVG whose only content is unsafe
+     * has nothing left to render once sanitized, so callers fall back to the
+     * bounded diagnostic instead of emitting an empty graphic.
+     */
+    public static function svgHasDrawableContent(DOMElement $element): bool
+    {
+        foreach ( $element->getElementsByTagName('*') as $child ) {
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+            $tag = strtolower($child->tagName);
+            if ( in_array($tag, array( 'script', 'style', 'foreignobject', 'title', 'desc', 'metadata', 'defs' ), true) ) {
+                continue;
+            }
+            if ( self::hasAncestorTag($child, array( 'foreignobject' )) ) {
+                continue;
+            }
+            // A <use> that points at an external sprite file (href="sprite.svg#id"
+            // rather than a local "#id") cannot be inlined: the referenced symbol
+            // lives in another file that does not travel with the imported markup,
+            // so the emitted <use> would render nothing. It carries no drawable
+            // artwork of its own, so it does not, by itself, make the SVG
+            // preservable — the SVG falls through to the bounded fallback
+            // diagnostic instead of emitting a broken external reference. A local
+            // <use href="#id"> (resolved against an in-document symbol/defs) and
+            // any real shape element still count as drawable.
+            if ( 'use' === $tag && self::isExternalSpriteUse($child) ) {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether a <use> element references an external sprite file rather than an
+     * in-document fragment. An external reference is any href/xlink:href whose
+     * target is not a bare local "#id" fragment.
+     */
+    public static function isExternalSpriteUse(DOMElement $element): bool
+    {
+        $href = trim(self::attr($element, 'href'));
+        if ( '' === $href ) {
+            $href = trim(self::attr($element, 'xlink:href'));
+        }
+
+        return '' !== $href && '#' !== substr($href, 0, 1);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     * @return array<int, array<string, mixed>>
+     */
+    public static function dedupeArrayRows(array $rows): array
+    {
+        return DeterministicRowDeduplicator::dedupe($rows);
+    }
+
+    /**
+     * Whether $container is $element or one of its ancestors. Shared DOM
+     * ancestry helper; consumed by form dispatch and navigation suppression.
+     */
+    public static function elementContains(DOMElement $container, DOMElement $element): bool
+    {
+        for ( $node = $element; $node instanceof DOMElement; $node = $node->parentNode ) {
+            if ( $node->isSameNode($container) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/php-transformer/tests/unit/source-dom.php
+++ b/php-transformer/tests/unit/source-dom.php
@@ -1,0 +1,150 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Unit tests for the shared DOM reading vocabulary (#242).
+ *
+ * Plain-PHP test script in the style of tests/unit/source-element-classifier.php
+ * — no PHPUnit.
+ *
+ * These operations were previously reachable only through DomHelpersTrait,
+ * which meant they could not be asserted without a class that was already the
+ * transformer. Every case below calls a static method directly.
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
+
+$failures = 0;
+$passes   = 0;
+
+$assert = static function (bool $condition, string $message) use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . PHP_EOL);
+};
+
+/** Build the first element child of an HTML fragment. */
+$element = static function (string $html): DOMElement {
+    $doc = new DOMDocument();
+    libxml_use_internal_errors(true);
+    $doc->loadHTML(
+        '<!DOCTYPE html><html><body>' . $html . '</body></html>',
+        LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+    );
+    libxml_clear_errors();
+    $body = $doc->getElementsByTagName('body')->item(0);
+    foreach ( $body->childNodes as $child ) {
+        if ( $child instanceof DOMElement ) {
+            return $child;
+        }
+    }
+
+    throw new RuntimeException('fragment has no element child');
+};
+
+// --- attribute reading ------------------------------------------------------
+
+$assert(SourceDom::attr($element('<a href="/x">y</a>'), 'href') === '/x', 'a present attribute is returned');
+$assert(SourceDom::attr($element('<a>y</a>'), 'href') === '', 'a missing attribute is the empty string, not null');
+$assert(SourceDom::attr($element('<a href="">y</a>'), 'href') === '', 'an empty attribute stays empty');
+
+// --- class handling ---------------------------------------------------------
+
+$assert(SourceDom::hasClass($element('<div class="a b">x</div>'), 'b'), 'a class in a list is found');
+$assert(! SourceDom::hasClass($element('<div class="ab">x</div>'), 'b'), 'a substring is not a class match');
+$assert(SourceDom::classNames($element('<div class=" a   b ">x</div>')) === array('a', 'b'), 'class lists collapse whitespace');
+
+$assert(SourceDom::mergeClassNames('a b', 'b c') === 'a b c', 'merging class lists de-duplicates');
+$assert(SourceDom::mergeClassNames('  a  ', '', 'a') === 'a', 'merging trims and drops empties');
+$assert(SourceDom::mergeClassNames() === '', 'merging nothing yields the empty string');
+
+// --- child inspection -------------------------------------------------------
+
+$assert(SourceDom::childElementCount($element('<div><p>a</p>text<p>b</p></div>')) === 2, 'text nodes are not element children');
+$assert(SourceDom::childElementCount($element('<div>text only</div>')) === 0, 'a text-only element has no element children');
+
+$only = SourceDom::onlyChildElement($element('<figure>  <img src="a.png">  </figure>'), 'img');
+$assert($only instanceof DOMElement, 'whitespace around a sole child is ignored');
+$assert(SourceDom::onlyChildElement($element('<figure><img><img></figure>'), 'img') === null, 'two candidates are not an only child');
+$assert(SourceDom::onlyChildElement($element('<figure>text<img></figure>'), 'img') === null, 'meaningful text disqualifies an only child');
+
+// --- ancestry: the <body> boundary ------------------------------------------
+// This boundary is the contract. A second implementation that walked past
+// <body> to the document root was the one real divergence found in the
+// duplicated copies of this vocabulary.
+
+$nested = $element('<header><div><a href="/x" id="leaf">y</a></div></header>');
+$leaf   = $nested->getElementsByTagName('a')->item(0);
+$assert(SourceDom::hasAncestorTag($leaf, array('header')), 'an ancestor tag is found');
+$assert(SourceDom::hasAncestorTag($leaf, array('nav', 'header')), 'any tag in the list matches');
+$assert(! SourceDom::hasAncestorTag($leaf, array('nav')), 'an absent ancestor tag is not found');
+$assert(! SourceDom::hasAncestorTag($leaf, array('body')), 'the walk stops at <body> rather than matching it');
+$assert(! SourceDom::hasAncestorTag($leaf, array('html')), 'the walk does not reach past <body> to <html>');
+$assert(! SourceDom::hasAncestorTag($nested, array('header')), 'an element is not its own ancestor');
+
+// --- selectors --------------------------------------------------------------
+
+$sel = $element('<section><p>a</p><p id="second">b</p></section>');
+$second = $sel->getElementsByTagName('p')->item(1);
+$assert(
+    SourceDom::elementSelector($second) === 'section:nth-of-type(1) > p:nth-of-type(2)',
+    'selectors are nth-of-type paths rooted below <body>'
+);
+
+$assert(SourceDom::safeAnchor('valid-id_1') === 'valid-id_1', 'a conforming anchor is preserved');
+$assert(SourceDom::safeAnchor('  spaced  ') === 'spaced', 'an anchor is trimmed');
+$assert(SourceDom::safeAnchor('1leading-digit') === '', 'an anchor may not start with a digit');
+$assert(SourceDom::safeAnchor('has space') === '', 'an anchor may not contain a space');
+$assert(SourceDom::safeAnchor('') === '', 'an empty anchor stays empty');
+
+// --- URL safety -------------------------------------------------------------
+
+$assert(SourceDom::safeFallbackUrl('https://example.test/a', 'href'), 'https is allowed');
+$assert(SourceDom::safeFallbackUrl('/relative/path', 'href'), 'a schemeless URL is allowed');
+$assert(SourceDom::safeFallbackUrl('mailto:a@example.test', 'href'), 'mailto is allowed');
+$assert(! SourceDom::safeFallbackUrl('javascript:alert(1)', 'href'), 'javascript: is rejected');
+$assert(
+    ! SourceDom::safeFallbackUrl('java&#115;cript:alert(1)', 'href'),
+    'an entity-encoded javascript scheme is rejected'
+);
+$assert(
+    ! SourceDom::safeFallbackUrl('java%73cript:alert(1)', 'href'),
+    'a percent-encoded javascript scheme is rejected'
+);
+$assert(
+    ! SourceDom::safeFallbackUrl("java\tscript:alert(1)", 'href'),
+    'control characters do not smuggle a scheme past the check'
+);
+$assert(
+    SourceDom::safeFallbackUrl('data:image/png;base64,iVBORw0KGgo=', 'src'),
+    'a base64 image data URL is allowed on src'
+);
+$assert(
+    ! SourceDom::safeFallbackUrl('data:image/png;base64,iVBORw0KGgo=', 'href'),
+    'the same data URL is not allowed on href'
+);
+$assert(
+    ! SourceDom::safeFallbackUrl('data:text/html;base64,PHNjcmlwdD4=', 'src'),
+    'a non-image data URL is rejected even on src'
+);
+
+// --- statelessness ----------------------------------------------------------
+
+$probe = $element('<div class="a">x</div>');
+$first = SourceDom::attr($probe, 'class');
+SourceDom::mergeClassNames('x', 'y');
+SourceDom::safeAnchor('other');
+$assert($first === SourceDom::attr($probe, 'class'), 'static calls carry no state between invocations');
+
+echo 'Source DOM vocabulary tests: ' . $passes . ' passed' . PHP_EOL;
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, 'Source DOM vocabulary tests: ' . $failures . ' FAILED' . PHP_EOL);
+    exit(1);
+}


### PR DESCRIPTION
Workstream 1 slice for #242. Follows #1485.

## The problem is the container, not the code

`Support\DomHelpersTrait` holds the operations every part of the transformer performs constantly — read an attribute, count element children, serialize inner HTML, build a selector. 36 of its 42 methods are pure functions of their arguments.

But it is a **trait**, so only a class that is already the transformer can `use` it. Every collaborator extracted under this epic needs the same vocabulary and cannot have it, and the package has accumulated all three available workarounds:

| workaround | count |
|---|---|
| forwarding closures through `*Context` objects | 56 |
| byte-identical copy-pasted private duplicates | 22 |
| independent reimplementations | 10 |
| arrow closures in `HtmlTransformer` forwarding trait members | 74 |

`attr()` — three lines — existed **18 times**. `childElementCount` 7×, `outerHtml` 6×, `elementSelector` 6×, `innerHtml` 5×.

This is the mechanism behind the closure web, and it is still growing: closure parameters across the 38 context classes went 323 → 327 during #1485.

### What the duplication actually cost

Two findings, and I want to be precise about which is which.

**One real divergence.** Two `hasAncestorTag` implementations, same name, different contracts:

```php
// DomHelpersTrait — array of tags, stops at <body>
for ($node = $element->parentNode; $node instanceof DOMElement && 'body' !== strtolower($node->tagName); ...)

// SourceBlockAttributeProjector — single tag, walks to the document root
for ($parent = $element->parentNode; $parent instanceof DOMElement; ...)
```

At its one call site both return the same answer for well-formed documents, so this is latent risk rather than a demonstrable bug. It is the recompute-and-disagree shape #1482 documents for navigation, sitting one layer lower. **This PR does not change it** — a behavioural fix does not belong inside a move. The `<body>` boundary is now pinned by a test so the canonical contract is explicit before anything reconciles the copy.

**One name collision that is not duplication.** `ArtifactCompiler::htmlAttributes(string $tag)` parses a raw HTML tag string; the trait's `htmlAttributes(DOMElement)` reads attributes off a node. Different jobs, same name. Consolidating on the duplicate count alone would have broken it. Left alone; it wants a rename, separately.

## What this changes

The 36 pure operations move to `Support\SourceDom` as **static** methods. That is the design decision:

> These are pure functions of their arguments. They are static deliberately: a pure function needs no instance, so a caller needs no constructor argument and no injected closure to reach one.

`DomHelpersTrait` keeps its six state-dependent operations — the ones needing source-tag markers, fallback sanitization, or the WordPress runtime — and delegates the rest. Its twenty users are untouched.

The 22 byte-identical duplicates across 20 files are deleted and now call `SourceDom`. Two of them were in `SourceElementClassifier`, which #1485 shipped last night — the pattern reproduced itself within a day, which is the argument for fixing the container rather than the copies.

## Proof

**Pure extraction, mechanically checked.** Every inserted line across all 24 files is a `SourceDom` reference, an import, or the one-line test registration:

```
$ git diff -U0 | grep '^+' | grep -v '^+++' | grep -vcE 'SourceDom|^\+use '
1
+      "php tests/unit/source-dom.php",
```

**No behavior change.** `serializedBlocks` SHA-256 for all 385 fixture HTML files, before and after: **385 compared, 0 differing, 0 throwing.**

**Suite.** `composer test` exit 0, including 292 parity fixtures and the package install proof.

**New coverage.** `tests/unit/source-dom.php` — 37 assertions, registered in `test:unit`. It pins the contracts that the duplicates were free to get wrong: the `<body>` boundary on ancestor walks, `safeAnchor` rejecting a leading digit, `onlyChildElement` tolerating surrounding whitespace but not text, and `safeFallbackUrl` rejecting entity-encoded, percent-encoded, and control-character-smuggled `javascript:` schemes while allowing a base64 image `data:` URL on `src` but not on `href`.

Verified to have teeth by mutation: removing the `<body>` guard and disabling the percent-decode loop fails 3 assertions — including both `hasAncestorTag` boundary cases, the exact divergence above. Reverting restores 37 passing.

## Result

`SourceDom`: 551 lines, 36 static methods, no dependencies. `DomHelpersTrait`: 615 → 279 lines. Net **−754 / +930** across 24 files, where the additions are the extracted vocabulary plus its first tests.

## Next in this sequence

- Convert `*Context` classes to call `SourceDom` directly and drop the 56 forwarders with their closure parameters — the first real reduction against the 327.
- Reconcile the `hasAncestorTag` divergence against the now-pinned contract, and rename `ArtifactCompiler::htmlAttributes`.

## AI assistance disclosure

Researched and implemented with AI assistance: Claude Sonnet 4.5 running in the opencode CLI agent, operated by @chubes4. The AI computed the purity fixpoint, classified the 88 copies into forwarders / identical duplicates / real reimplementations, found the `hasAncestorTag` divergence and the `htmlAttributes` collision, performed the extraction, wrote the tests, and ran the corpus-hash and mutation verification. Chris Huber directed the target selection and is responsible for the scope and final change.
