### PR TITLE
Reserve no editor height for withheld group pickers

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/NavigationStyleProjector.php
+++ b/php-transformer/src/HtmlToBlocks/Style/NavigationStyleProjector.php
@@ -93,9 +93,11 @@ final class NavigationStyleProjector
             $selector = ':root .' . HtmlTransformer::EMPTY_VISUAL_GROUP_CLASS . '.wp-block-group__placeholder';
             // A painted source layer holds geometry, not authored children, so
             // core's empty-group variation picker stacks unrelated layout
-            // controls at the top of the document. Bound the placeholder and
-            // withhold that picker so the editor shows the source composition.
-            $rules[] = $selector . '{position:relative!important;inset:auto!important;width:auto!important;height:auto!important;min-height:2rem!important;overflow:hidden!important}'
+            // controls at the top of the document. Withhold that picker, and
+            // reserve no height for it: the source layer is painted out of
+            // normal flow, so any reserved height displaces every block after
+            // it and moves the composition down the canvas.
+            $rules[] = $selector . '{position:relative!important;inset:auto!important;width:auto!important;height:auto!important;min-height:0!important;overflow:hidden!important}'
                 . $selector . '>*{display:none!important}';
         }
         if ( preg_match('/\bbody\b[^{}]*\{[^}]*(?:overflow\s*:\s*(?:hidden|clip)|height\s*:\s*100(?:d|s|l)?vh)/is', $this->context->authorStyles()->combinedCss()) ) {

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1230,6 +1230,9 @@ $assert(1 === preg_match('/<div class="[^"]*wp-block-group[^"]*page-bg[^"]*"/', 
 $fixedBackgroundEditorCss = implode("\n", array_map(static fn (array $asset): string => 'editor-static-state' === ($asset['source'] ?? '') ? (string) ($asset['content'] ?? '') : '', $fixedBackgroundLayer['assets'] ?? array()));
 $assert(str_contains($fixedBackgroundLayerMarkup, 'blocks-engine-empty-visual-group') && str_contains($fixedBackgroundEditorCss, '.blocks-engine-empty-visual-group.wp-block-group__placeholder{position:relative!important;inset:auto!important'), 'empty painted groups retain frontend geometry while their Gutenberg placeholder is bounded in normal flow');
 $assert(str_contains($fixedBackgroundEditorCss, '.blocks-engine-empty-visual-group.wp-block-group__placeholder>*{display:none!important}'), 'painted source layers withhold core empty-group variation pickers so they do not stack layout controls in the editor');
+// Reserving height for a withheld picker displaces every following block, which
+// moves the whole source composition down the editor canvas.
+$assert(str_contains($fixedBackgroundEditorCss, 'min-height:0!important') && ! str_contains($fixedBackgroundEditorCss, '.blocks-engine-empty-visual-group.wp-block-group__placeholder{position:relative!important;inset:auto!important;width:auto!important;height:auto!important;min-height:2rem'), 'painted source layers reserve no editor height for the picker they withhold');
 
 $styleOnlyVisualShell = ( new HtmlTransformer() )->transform(
     '<style>.footer-wrap{background:#000}.footer-wrap .container{padding:40px 0}</style><main><div class="footer-wrap"><div class="container"><style>.footer-wrap{min-height:80px}</style></div></div></main>'


### PR DESCRIPTION
## Problem

Painted source layers materialize as empty `core/group` blocks. In the editor, core renders its empty-group variation picker inside them, so an earlier change withheld that picker. The placeholder still reserved `min-height: 2rem` for it, which is height the source layer never occupies: on the frontend these layers are painted out of normal flow.

Measured in the editor canvas of a generated site, four such placeholders sit consecutively at the top of the document:

| placeholder | reserved height | canvas top |
|---|---|---|
| 1 | 32px | 87 |
| 2 | 32px | 119 |
| 3 | 32px | 151 |
| 4 | 32px | 183 |

That is **128px of displacement** applied before any authored content, which pushes the hero and everything after it down the canvas. The frontend is unaffected, so the editor and the rendered page disagree about where the composition starts.

## Change

Reserve no height for a picker that is withheld. The placeholder keeps its normal-flow bounding (`position:relative; inset:auto`) so it cannot escape the canvas, and takes `min-height: 0` so it displaces nothing.

## Verification

- 292 parity fixtures pass unchanged.
- Contract coverage asserts both halves of the contract together: the picker is withheld, and no height is reserved for it.

## AI assistance disclosure

Implemented with AI assistance: Claude Sonnet 4.5 running in the opencode CLI agent. The AI measured the placeholder geometry in a live editor canvas, identified the reserved height as the displacement source, made the change, and ran the suite. A human reviewed and directed the work.
