### PR TITLE
fix(php-transformer): settle captured reveal animations that can never complete

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -156,6 +156,7 @@
       "php tests/unit/core-html-fallback-reduction.php",
       "php tests/unit/inert-capture-scaffolding.php",
       "php tests/unit/inert-closed-state-interactions.php",
+      "php tests/unit/reveal-animation-settling.php",
       "php tests/unit/geometry-chain-coalescing.php",
       "php tests/unit/pattern-recursive-converter.php",
       "php tests/unit/pattern-recognizer-registry.php",

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1387,7 +1387,8 @@ final class HtmlTransformer
             (string) ($options['static_css'] ?? ''),
             true !== ($options['skip_author_stylesheet_materialization'] ?? false),
             $serializedBlocks,
-            $sourceProvenance
+            $sourceProvenance,
+            $authorStylesheetProjections
         );
         $this->navigationStyleProjector->materializeEditorStaticStateStylesheet();
         $blockValidityReport = $this->runtime->validateBlockSerialization($blocks);
@@ -2002,8 +2003,11 @@ final class HtmlTransformer
         return array_slice($entries, 0, 20);
     }
 
-    /** @param array<int, array<string, mixed>> $sourceProvenance */
-    private function materializeAuthorStylesheet(string $html, string $staticCss, bool $includeAuthorStyles = true, string $serializedBlocks = '', array $sourceProvenance = array()): void
+    /**
+     * @param array<int, array<string, mixed>> $sourceProvenance
+     * @param list<array{path: string, content: string, bytes: int, hash: string, source_hash: string}> $authorStylesheetProjections
+     */
+    private function materializeAuthorStylesheet(string $html, string $staticCss, bool $includeAuthorStyles = true, string $serializedBlocks = '', array $sourceProvenance = array(), array $authorStylesheetProjections = array()): void
     {
         $beforeAuthorCssParts = array();
         $authorCssParts = array();
@@ -2186,8 +2190,15 @@ final class HtmlTransformer
         array_push($afterAuthorCssParts, ...$this->styleResolver->closedStateRepairCssRules());
         // A captured reveal whose driver did not survive import must still
         // settle at the appearance it was travelling towards, not at the hidden
-        // keyframe it starts from (#239).
-        array_push($afterAuthorCssParts, ...( new RevealAnimationSettler() )->settleRules($authorCss));
+        // keyframe it starts from (#239). Read the projected author CSS the
+        // theme actually ships: when the artifact pipeline materializes the
+        // author stylesheets itself, that is the per-asset projection rather
+        // than the copy inlined here, and only the projected form carries the
+        // state markers the repair has to reproduce in its selectors.
+        $settleableAuthorCss = '' !== trim($authorCss)
+            ? $authorCss
+            : implode("\n\n", array_column($authorStylesheetProjections, 'content'));
+        array_push($afterAuthorCssParts, ...( new RevealAnimationSettler() )->settleRules($settleableAuthorCss));
         $this->materializeStylesheetAsset($beforeAuthorCssParts, 'engine-support', 'before-author', 'engine-support-before-author');
         $this->materializeStylesheetAsset($authorCssParts, 'author-css', 'author', 'source-author');
         $this->materializeStylesheetAsset($afterAuthorCssParts, 'engine-support', 'after-author', 'engine-support-after-author');

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -124,6 +124,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\LayoutGeometryStat
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\NavigationStyleProjectionContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\NavigationStyleProjector;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\PresentationResolutionCache;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\RevealAnimationSettler;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssSelectorMatcher;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssSelectorMatchCache;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssStylesheetTransformer;
@@ -2183,6 +2184,10 @@ final class HtmlTransformer
         }
         array_push($afterAuthorCssParts, ...$this->generatedSupportStyles()->buttonAfterAuthorCss());
         array_push($afterAuthorCssParts, ...$this->styleResolver->closedStateRepairCssRules());
+        // A captured reveal whose driver did not survive import must still
+        // settle at the appearance it was travelling towards, not at the hidden
+        // keyframe it starts from (#239).
+        array_push($afterAuthorCssParts, ...( new RevealAnimationSettler() )->settleRules($authorCss));
         $this->materializeStylesheetAsset($beforeAuthorCssParts, 'engine-support', 'before-author', 'engine-support-before-author');
         $this->materializeStylesheetAsset($authorCssParts, 'author-css', 'author', 'source-author');
         $this->materializeStylesheetAsset($afterAuthorCssParts, 'engine-support', 'after-author', 'engine-support-after-author');

--- a/php-transformer/src/HtmlToBlocks/Style/CssStylesheetTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssStylesheetTransformer.php
@@ -58,6 +58,22 @@ final class CssStylesheetTransformer
     }
 
     /**
+     * Visit every `@keyframes` rule with its animation name and its raw body.
+     *
+     * `visitStyleRules()` deliberately stops at `@keyframes`: its children are
+     * offsets, not selectors. A caller that needs to know what state an
+     * animation starts and ends in has to read them, so they are surfaced here
+     * rather than by re-scanning the stylesheet with a regular expression.
+     * Prefixed variants (`@-webkit-keyframes`) report the same name.
+     *
+     * @param callable(string, string): void $visitKeyframes
+     */
+    public function visitKeyframeRules(string $stylesheet, callable $visitKeyframes): void
+    {
+        $this->visitKeyframeRulesIn($stylesheet, $visitKeyframes);
+    }
+
+    /**
      * @return array{preamble: string, stylesheet: string}
      */
     public function splitLeadingAtRulePreamble(string $stylesheet): array
@@ -201,6 +217,49 @@ final class CssStylesheetTransformer
             }
             $offset = $blockEnd + 1;
         }
+    }
+
+    /** @param callable(string, string): void $visitKeyframes */
+    private function visitKeyframeRulesIn(string $css, callable $visitKeyframes): void
+    {
+        $offset = 0;
+        $length = strlen($css);
+        while ( $offset < $length ) {
+            $boundary = $this->nextRuleBoundary($css, $offset);
+            if ( null === $boundary || ';' === $css[ $boundary ] ) {
+                $offset = null === $boundary ? $length : $boundary + 1;
+                continue;
+            }
+            $blockEnd = $this->matchingBrace($css, $boundary);
+            if ( null === $blockEnd ) {
+                return;
+            }
+            $prelude = substr($css, $offset, $boundary - $offset);
+            $body = substr($css, $boundary + 1, $blockEnd - $boundary - 1);
+            if ( $this->isAtRule($prelude) ) {
+                $name = self::atRuleName($prelude);
+                if ( 'keyframes' === $name || str_ends_with($name, '-keyframes') ) {
+                    $animationName = self::keyframesAnimationName($prelude);
+                    if ( '' !== $animationName ) {
+                        $visitKeyframes($animationName, $body);
+                    }
+                } elseif ( $this->walksNestedRules($prelude) ) {
+                    $this->visitKeyframeRulesIn($body, $visitKeyframes);
+                }
+            }
+            $offset = $blockEnd + 1;
+        }
+    }
+
+    private static function keyframesAnimationName(string $prelude): string
+    {
+        $name = trim((string) preg_replace('#/\\*.*?\\*/#s', ' ', $prelude));
+        $name = trim((string) preg_replace('/^@[A-Za-z-]+/', '', $name));
+        if ( 2 <= strlen($name) && ( ('"' === $name[0] && '"' === substr($name, -1)) || ("'" === $name[0] && "'" === substr($name, -1)) ) ) {
+            $name = substr($name, 1, -1);
+        }
+
+        return trim($name);
     }
 
     private function nextRuleBoundary(string $css, int $offset): ?int

--- a/php-transformer/src/HtmlToBlocks/Style/NavigationStyleProjector.php
+++ b/php-transformer/src/HtmlToBlocks/Style/NavigationStyleProjector.php
@@ -79,9 +79,21 @@ final class NavigationStyleProjector
         $anchorProjectionCss = $this->editorAnchorProjectionCss();
         if ( '' !== $anchorProjectionCss ) {
             $rules[] = $anchorProjectionCss;
+            // The anchor projection restates author rules on the deterministic
+            // wrapper classes, animations included. Settle those copies too, or
+            // the editor keeps the source's hidden start keyframe on exactly the
+            // elements the projection exists to reach.
+            foreach ( ( new RevealAnimationSettler() )->settleRules($anchorProjectionCss) as $settledRule ) {
+                $rules[] = $settledRule;
+            }
         }
         if ( preg_match('/(?:^|[;{])\s*(?:-webkit-)?animation(?:-[a-z-]+)?\s*:/i', $this->context->authorStyles()->combinedCss()) ) {
-            $rules[] = ':root *,:root *::before,:root *::after{animation-delay:-999999s!important;animation-iteration-count:1!important;animation-fill-mode:both!important;transition:none!important}';
+            // The editor shows a settled document, so every animation is wound
+            // past its end. A paused play state and a scroll-driven timeline
+            // both have to be overridden for that to hold: without them the
+            // negative delay lands on an animation that never advances, and the
+            // element stays on whatever keyframe its fill mode paints.
+            $rules[] = ':root *,:root *::before,:root *::after{animation-delay:-999999s!important;animation-iteration-count:1!important;animation-fill-mode:both!important;animation-play-state:running!important;animation-timeline:auto!important;transition:none!important}';
         }
         if ( $this->context->runtimeBehavior()->emptyRuntimeTargetGenerated() ) {
             $selector = ':root .' . HtmlTransformer::EMPTY_RUNTIME_TARGET_CLASS . '.wp-block-group__placeholder';

--- a/php-transformer/src/HtmlToBlocks/Style/RevealAnimationSettler.php
+++ b/php-transformer/src/HtmlToBlocks/Style/RevealAnimationSettler.php
@@ -1,0 +1,367 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
+
+/**
+ * Settle captured entrance animations that can never reach their end state.
+ *
+ * A reveal animation is only ever a way of arriving at a resting appearance.
+ * Sources drive one from script — Wix pauses `animation: motion-fadeIn … backwards
+ * paused` until its runtime stamps `data-motion-enter="done"`, older themes hold
+ * `opacity:0` until an IntersectionObserver adds an in-view class. Capture can also
+ * hand the animation to a scroll-driven timeline (`animation-timeline: view()`).
+ * Import carries the CSS and drops the driver, so the animation is left in a state
+ * it cannot leave: `animation-fill-mode: backwards` pins the element to the `0%`
+ * keyframe, and with a paused play state or a timeline that never becomes active
+ * that keyframe is forever. When `0%` is `opacity: 0`, the content is in the DOM,
+ * in the block markup, and permanently unpainted (#239).
+ *
+ * The governing rule is that a captured reveal must never leave content less
+ * visible than its own settled end state. So an animation that cannot progress is
+ * not carried as a live animation at all: it is replaced by the resolved state it
+ * was travelling towards — its `100%`/`to` keyframe — which is what a visitor of
+ * the source would have seen.
+ *
+ * Deliberately narrow. An animation that can still run on the document timeline is
+ * untouched, and so is one whose start keyframe is no less visible than its end
+ * (a paused marquee or spinner keeps its own declarations, since settling a
+ * cyclical animation to its last frame would move content rather than reveal it).
+ */
+final class RevealAnimationSettler
+{
+    /**
+     * End-keyframe declarations worth restating. These are the properties a
+     * reveal animates on its way to the resting appearance; anything else the
+     * keyframes touch is left to the element's own cascade once the animation
+     * is gone.
+     */
+    private const SETTLED_PROPERTIES = array(
+        'clip-path' => true,
+        'filter' => true,
+        'opacity' => true,
+        'rotate' => true,
+        'scale' => true,
+        'transform' => true,
+        'translate' => true,
+        'visibility' => true,
+        '-webkit-transform' => true,
+    );
+
+    /** Shorthand tokens that are never an `animation-name`. */
+    private const RESERVED_ANIMATION_KEYWORDS = array(
+        'alternate' => true,
+        'alternate-reverse' => true,
+        'backwards' => true,
+        'both' => true,
+        'ease' => true,
+        'ease-in' => true,
+        'ease-in-out' => true,
+        'ease-out' => true,
+        'forwards' => true,
+        'infinite' => true,
+        'inherit' => true,
+        'initial' => true,
+        'linear' => true,
+        'normal' => true,
+        'paused' => true,
+        'reverse' => true,
+        'revert' => true,
+        'revert-layer' => true,
+        'running' => true,
+        'step-end' => true,
+        'step-start' => true,
+        'unset' => true,
+    );
+
+    /**
+     * Repair rules for every rule in the stylesheet that leaves content parked
+     * in a reveal animation's hidden start state.
+     *
+     * @return list<string>
+     */
+    public function settleRules(string $css): array
+    {
+        if ( 1 !== preg_match('/(?:^|[;{\s])animation(?:-[a-z-]+)?\s*:/i', $css) ) {
+            return array();
+        }
+        $keyframes = $this->keyframeBoundaryStates($css);
+        if ( array() === $keyframes ) {
+            return array();
+        }
+
+        $settled = array();
+        ( new CssStylesheetTransformer() )->visitStyleRules(
+            $css,
+            function (string $prelude, string $body) use ($keyframes, &$settled): void {
+                $endState = $this->suspendedRevealEndState($this->declarations($body), $keyframes);
+                if ( null === $endState ) {
+                    return;
+                }
+                foreach ( CssStylesheetTransformer::splitSelectorList($prelude) ?? array() as $selector ) {
+                    $selector = $this->settleableSelector($selector);
+                    if ( '' === $selector ) {
+                        continue;
+                    }
+                    foreach ( $endState as $property => $value ) {
+                        $settled[$selector][$property] = $value;
+                    }
+                }
+            }
+        );
+
+        ksort($settled, SORT_STRING);
+        $rules = array();
+        foreach ( $settled as $selector => $declarations ) {
+            ksort($declarations, SORT_STRING);
+            $body = '';
+            foreach ( $declarations as $property => $value ) {
+                $body .= $property . ':' . $value . '!important;';
+            }
+            $rules[] = ':root ' . $selector . '{' . rtrim($body, ';') . '}';
+        }
+
+        return $rules;
+    }
+
+    /**
+     * The resolved resting declarations for a rule whose animation cannot
+     * complete, or null when the rule is safe as authored.
+     *
+     * @param array<string, string> $declarations
+     * @param array<string, array{start: array<string, string>, end: array<string, string>}> $keyframes
+     * @return array<string, string>|null
+     */
+    private function suspendedRevealEndState(array $declarations, array $keyframes): ?array
+    {
+        $animation = $this->animationConfiguration($declarations);
+        if ( array() === $animation['names'] || ! $animation['suspended'] || ! $animation['fills_before'] ) {
+            return null;
+        }
+
+        foreach ( $animation['names'] as $name ) {
+            $frames = $keyframes[$name] ?? null;
+            if ( null === $frames || ! $this->hidesAtStart($frames['start'], $frames['end']) ) {
+                continue;
+            }
+            $settled = array( 'animation' => 'none' );
+            foreach ( $frames['end'] as $property => $value ) {
+                if ( isset(self::SETTLED_PROPERTIES[ $property ]) ) {
+                    $settled[ $property ] = $value;
+                }
+            }
+
+            return $settled;
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve the animation names a rule applies, whether the animation can
+     * still progress, and whether its before-phase state is what the element
+     * actually shows.
+     *
+     * @param array<string, string> $declarations
+     * @return array{names: list<string>, suspended: bool, fills_before: bool}
+     */
+    private function animationConfiguration(array $declarations): array
+    {
+        $names = array();
+        $paused = false;
+        $fillMode = '';
+        $delay = 0.0;
+
+        $shorthand = trim((string) ($declarations['animation'] ?? ''));
+        if ( '' !== $shorthand ) {
+            foreach ( CssValueSplitter::splitTopLevel($shorthand, array( ',' )) as $layer ) {
+                $layerName = '';
+                $times = array();
+                foreach ( CssValueSplitter::splitTopLevelWhitespace($layer) as $token ) {
+                    $lower = strtolower($token);
+                    $seconds = $this->timeSeconds($lower);
+                    if ( null !== $seconds ) {
+                        $times[] = $seconds;
+                        continue;
+                    }
+                    if ( in_array($lower, array( 'none', 'forwards', 'backwards', 'both' ), true) ) {
+                        $fillMode = $lower;
+                        continue;
+                    }
+                    if ( 'paused' === $lower ) {
+                        $paused = true;
+                        continue;
+                    }
+                    if ( 'running' === $lower ) {
+                        $paused = false;
+                        continue;
+                    }
+                    if ( isset(self::RESERVED_ANIMATION_KEYWORDS[ $lower ]) || is_numeric($lower) || str_contains($token, '(') ) {
+                        continue;
+                    }
+                    if ( '' === $layerName ) {
+                        $layerName = $token;
+                    }
+                }
+                if ( isset($times[1]) ) {
+                    $delay = $times[1];
+                }
+                if ( '' !== $layerName ) {
+                    $names[] = $layerName;
+                }
+            }
+        }
+
+        $longhandNames = trim((string) ($declarations['animation-name'] ?? ''));
+        if ( '' !== $longhandNames ) {
+            $names = array();
+            foreach ( CssValueSplitter::splitTopLevel($longhandNames, array( ',' )) as $name ) {
+                if ( 'none' !== strtolower($name) ) {
+                    $names[] = $name;
+                }
+            }
+        }
+        if ( isset($declarations['animation-play-state']) ) {
+            $paused = in_array('paused', CssValueSplitter::splitTopLevel(strtolower($declarations['animation-play-state']), array( ',' )), true);
+        }
+        if ( isset($declarations['animation-fill-mode']) ) {
+            $fillMode = strtolower(trim((string) (CssValueSplitter::splitTopLevel($declarations['animation-fill-mode'], array( ',' ))[0] ?? '')));
+        }
+        if ( isset($declarations['animation-delay']) ) {
+            $delay = $this->timeSeconds(strtolower(trim((string) (CssValueSplitter::splitTopLevel($declarations['animation-delay'], array( ',' ))[0] ?? '')))) ?? $delay;
+        }
+
+        // A scroll-driven timeline has no document clock behind it. Whether it
+        // ever advances depends on a scroll container the conversion does not
+        // control, and on this import it does not: `getAnimations()` reports the
+        // animation running while its progress — and the element's opacity —
+        // stays at zero.
+        $timeline = strtolower(trim((string) ($declarations['animation-timeline'] ?? '')));
+        $timelineDriven = '' !== $timeline && ! in_array($timeline, array( 'auto', 'none', 'initial', 'inherit', 'unset', 'revert', 'revert-layer' ), true);
+
+        return array(
+            'names' => $names,
+            'suspended' => $paused || $timelineDriven,
+            // The before phase is what the element shows either because the fill
+            // mode paints it there, or because a non-positive delay leaves the
+            // stalled animation inside its active phase at time zero.
+            'fills_before' => in_array($fillMode, array( 'backwards', 'both' ), true) || $delay <= 0.0,
+        );
+    }
+
+    /**
+     * @param array<string, string> $start
+     * @param array<string, string> $end
+     */
+    private function hidesAtStart(array $start, array $end): bool
+    {
+        $startVisibility = strtolower(trim((string) ($start['visibility'] ?? '')));
+        if ( in_array($startVisibility, array( 'hidden', 'collapse' ), true) && $startVisibility !== strtolower(trim((string) ($end['visibility'] ?? ''))) ) {
+            return true;
+        }
+        if ( 'none' === strtolower(trim((string) ($start['display'] ?? ''))) && 'none' !== strtolower(trim((string) ($end['display'] ?? ''))) ) {
+            return true;
+        }
+
+        $startOpacity = $this->opacity($start['opacity'] ?? null);
+        if ( null === $startOpacity ) {
+            return false;
+        }
+        $endOpacity = $this->opacity($end['opacity'] ?? null);
+
+        // An end opacity that is absent or computed (`var(--comp-opacity, 1)`)
+        // resolves to something the element itself decides, which by definition
+        // is at least as visible as a start that dims it.
+        return null === $endOpacity ? $startOpacity < 1.0 : $startOpacity < $endOpacity;
+    }
+
+    /**
+     * Index every `@keyframes` rule by name, keeping the declarations of its
+     * first and last offsets.
+     *
+     * @return array<string, array{start: array<string, string>, end: array<string, string>}>
+     */
+    private function keyframeBoundaryStates(string $css): array
+    {
+        $transformer = new CssStylesheetTransformer();
+        $keyframes = array();
+        $transformer->visitKeyframeRules(
+            $css,
+            function (string $name, string $body) use ($transformer, &$keyframes): void {
+                $frames = $keyframes[ $name ] ?? array( 'start' => array(), 'end' => array() );
+                $transformer->visitStyleRules(
+                    $body,
+                    function (string $prelude, string $declarationBlock) use (&$frames): void {
+                        $declarations = $this->declarations($declarationBlock);
+                        if ( array() === $declarations ) {
+                            return;
+                        }
+                        foreach ( CssStylesheetTransformer::splitSelectorList($prelude) ?? array() as $offset ) {
+                            $offset = strtolower(trim($offset));
+                            if ( 'from' === $offset || '0%' === $offset ) {
+                                $frames['start'] = array_merge($frames['start'], $declarations);
+                            } elseif ( 'to' === $offset || '100%' === $offset ) {
+                                $frames['end'] = array_merge($frames['end'], $declarations);
+                            }
+                        }
+                    }
+                );
+                $keyframes[ $name ] = $frames;
+            }
+        );
+
+        return $keyframes;
+    }
+
+    /** @return array<string, string> */
+    private function declarations(string $body): array
+    {
+        $declarations = array();
+        foreach ( CssValueSplitter::splitTopLevel($body, array( ';' )) as $declaration ) {
+            $separator = strpos($declaration, ':');
+            if ( false === $separator || 0 === $separator ) {
+                continue;
+            }
+            $property = strtolower(trim(substr($declaration, 0, $separator)));
+            $value = trim(substr($declaration, $separator + 1));
+            $value = trim((string) preg_replace('/!\s*important\s*$/i', '', $value));
+            if ( '' !== $property && '' !== $value ) {
+                $declarations[ $property ] = $value;
+            }
+        }
+
+        return $declarations;
+    }
+
+    /**
+     * A selector the repair can safely restate. Pseudo-elements are skipped —
+     * they are decoration rather than the imported content that must stay
+     * readable — and so is a selector carrying an interior comment, which
+     * cannot be dropped without risking a changed combinator.
+     */
+    private function settleableSelector(string $selector): string
+    {
+        $selector = trim((string) preg_replace('#^(?:\s*/\*.*?\*/\s*)+|(?:\s*/\*.*?\*/\s*)+$#s', '', trim($selector)));
+
+        return '' === $selector || str_contains($selector, '::') || str_contains($selector, '/*') ? '' : $selector;
+    }
+
+    private function opacity(?string $value): ?float
+    {
+        $value = strtolower(trim((string) $value));
+        if ( 1 === preg_match('/^([0-9]*\.?[0-9]+)%$/', $value, $match) ) {
+            return (float) $match[1] / 100.0;
+        }
+
+        return 1 === preg_match('/^[0-9]*\.?[0-9]+$/', $value) ? (float) $value : null;
+    }
+
+    private function timeSeconds(string $token): ?float
+    {
+        if ( 1 !== preg_match('/^(-?[0-9]*\.?[0-9]+)(m?s)$/', $token, $match) ) {
+            return null;
+        }
+
+        return 'ms' === $match[2] ? (float) $match[1] / 1000.0 : (float) $match[1];
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Style/RevealAnimationSettler.php
+++ b/php-transformer/src/HtmlToBlocks/Style/RevealAnimationSettler.php
@@ -31,20 +31,31 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
 final class RevealAnimationSettler
 {
     /**
-     * End-keyframe declarations worth restating. These are the properties a
-     * reveal animates on its way to the resting appearance; anything else the
-     * keyframes touch is left to the element's own cascade once the animation
-     * is gone.
+     * How visible the content is. The reveal reached these values, so restating
+     * them can only leave the element as visible as the source left it — worth
+     * doing even where the element's own cascade would already suffice, because
+     * that cascade is often the very thing the reveal was hiding it with.
      */
-    private const SETTLED_PROPERTIES = array(
+    private const VISIBILITY_PROPERTIES = array(
+        'display' => true,
+        'opacity' => true,
+        'visibility' => true,
+    );
+
+    /**
+     * Where the content sits and how it is painted. Only a fill mode that
+     * retains the end frame leaves these applied once the animation finishes;
+     * under any other fill the element goes back to its own transform, and
+     * restating the keyframe's would move it. Anything the keyframes touch
+     * beyond both lists is left to the element's own cascade.
+     */
+    private const RETAINED_PROPERTIES = array(
         'clip-path' => true,
         'filter' => true,
-        'opacity' => true,
         'rotate' => true,
         'scale' => true,
         'transform' => true,
         'translate' => true,
-        'visibility' => true,
         '-webkit-transform' => true,
     );
 
@@ -146,7 +157,7 @@ final class RevealAnimationSettler
             }
             $settled = array( 'animation' => 'none' );
             foreach ( $frames['end'] as $property => $value ) {
-                if ( isset(self::SETTLED_PROPERTIES[ $property ]) ) {
+                if ( isset(self::VISIBILITY_PROPERTIES[ $property ]) || ( $animation['retains_end'] && isset(self::RETAINED_PROPERTIES[ $property ]) ) ) {
                     $settled[ $property ] = $value;
                 }
             }
@@ -163,7 +174,7 @@ final class RevealAnimationSettler
      * actually shows.
      *
      * @param array<string, string> $declarations
-     * @return array{names: list<string>, suspended: bool, fills_before: bool}
+     * @return array{names: list<string>, suspended: bool, fills_before: bool, retains_end: bool}
      */
     private function animationConfiguration(array $declarations): array
     {
@@ -246,6 +257,7 @@ final class RevealAnimationSettler
             // mode paints it there, or because a non-positive delay leaves the
             // stalled animation inside its active phase at time zero.
             'fills_before' => in_array($fillMode, array( 'backwards', 'both' ), true) || $delay <= 0.0,
+            'retains_end' => in_array($fillMode, array( 'forwards', 'both' ), true),
         );
     }
 

--- a/php-transformer/tests/unit/reveal-animation-settling.php
+++ b/php-transformer/tests/unit/reveal-animation-settling.php
@@ -137,6 +137,25 @@ foreach ( array( 'comp-k3nod418', 'comp-k3jrzme8' ) as $id ) {
     );
 }
 
+// The artifact pipeline materializes the author stylesheets itself and hands the
+// transform the projected copies, so the repair has to read those rather than the
+// author CSS this method would otherwise inline.
+$pipelineResult = ( new HtmlTransformer() )->transform($html, array(
+    'skip_author_stylesheet_materialization' => true,
+    'author_stylesheet_assets' => array( array( 'path' => 'assets/css/capture.css', 'content' => $css ) ),
+))->toArray();
+$pipelineAfterAuthor = $collect(
+    is_array($pipelineResult['assets'] ?? null) ? $pipelineResult['assets'] : array(),
+    static fn (array $asset): bool => 'engine-support' === ($asset['source'] ?? '') && 'after-author' === ($asset['stylesheet_placement'] ?? '')
+);
+foreach ( array( 'comp-k3nod418', 'comp-k3jrzme8' ) as $id ) {
+    $assert(
+        str_contains($pipelineAfterAuthor, ':root #' . $id . '{animation:none!important;opacity:var(--comp-opacity, 1)!important}'),
+        'a pipeline transform that materializes its own author stylesheets still settles #' . $id,
+        $pipelineAfterAuthor
+    );
+}
+
 $editorStaticState = $collect($assets, static fn (array $asset): bool => 'editor-static-state' === ($asset['source'] ?? ''));
 $assert(
     str_contains($editorStaticState, 'animation-play-state:running!important') && str_contains($editorStaticState, 'animation-timeline:auto!important'),

--- a/php-transformer/tests/unit/reveal-animation-settling.php
+++ b/php-transformer/tests/unit/reveal-animation-settling.php
@@ -52,11 +52,20 @@ $assert(
 );
 
 // Reveals expressed with the longhands, and with visibility rather than opacity.
-$longhand = '@keyframes reveal{from{opacity:0;visibility:hidden;transform:translateY(40px)}to{opacity:1;visibility:visible;transform:none}}.reveal{animation-name:reveal;animation-duration:.6s;animation-fill-mode:backwards;animation-play-state:paused}';
+$revealFrames = '@keyframes reveal{from{opacity:0;visibility:hidden;transform:translateY(40px)}to{opacity:1;visibility:visible;transform:none}}';
+$longhand = $revealFrames . '.reveal{animation-name:reveal;animation-duration:.6s;animation-fill-mode:backwards;animation-play-state:paused}';
 $assert(
-    array( ':root .reveal{animation:none!important;opacity:1!important;transform:none!important;visibility:visible!important}' ) === $settler->settleRules($longhand),
-    'longhand reveals settle, restating every end-state property the keyframes animate',
+    array( ':root .reveal{animation:none!important;opacity:1!important;visibility:visible!important}' ) === $settler->settleRules($longhand),
+    'longhand reveals settle at the visibility their end keyframe reached',
     implode(' | ', $settler->settleRules($longhand))
+);
+// Only a fill mode that retains the end frame leaves its geometry applied. Under
+// any other, the element goes back to its own transform when the reveal finishes,
+// and restating the keyframe's would move it instead.
+$assert(
+    array( ':root .reveal{animation:none!important;opacity:1!important;transform:none!important;visibility:visible!important}' ) === $settler->settleRules($revealFrames . '.reveal{animation:reveal .6s both paused}'),
+    'a retaining fill mode also settles the geometry the end keyframe holds',
+    implode(' | ', $settler->settleRules($revealFrames . '.reveal{animation:reveal .6s both paused}'))
 );
 
 // A stalled animation with no fill still shows its start frame when the delay

--- a/php-transformer/tests/unit/reveal-animation-settling.php
+++ b/php-transformer/tests/unit/reveal-animation-settling.php
@@ -1,0 +1,152 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * A captured reveal must never leave content less visible than its end state.
+ *
+ * Wix pauses an entrance animation (`animation: motion-fadeIn … backwards paused`)
+ * behind a runtime attribute, and capture can hand the same animation to a
+ * scroll-driven timeline (`animation-timeline: view()`). Both are carried by
+ * import while the driver that would finish them is not, and
+ * `animation-fill-mode: backwards` then pins the element to the `0% {opacity:0}`
+ * keyframe forever: the content is in the block markup and never paints (#239).
+ *
+ * The repair replaces an animation that cannot progress with the resolved state
+ * it was travelling towards. An animation that can still run, and one whose start
+ * keyframe is no less visible than its end, are left exactly as authored.
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssStylesheetTransformer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\RevealAnimationSettler;
+
+$failures = 0;
+$passes = 0;
+$assert = static function (bool $condition, string $message, string $detail = '') use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ( '' !== $detail ? ' - ' . $detail : '' ) . PHP_EOL);
+};
+
+$settler = new RevealAnimationSettler();
+$fadeIn = '@keyframes motion-fadeIn{0%{opacity:0}100%{opacity:var(--comp-opacity, 1)}}';
+
+// The two shapes observed on the imported site, verbatim.
+$paused = $fadeIn . '@media (prefers-reduced-motion: no-preference){#comp-k3nod418:not(.blocks-engine-attribute-state-c78e1e3229d6-119){animation:motion-fadeIn 1200ms 1ms cubic-bezier(0.445, 0.05, 0.55, 0.95) backwards 1 paused;animation-composition:replace}}';
+$assert(
+    array( ':root #comp-k3nod418:not(.blocks-engine-attribute-state-c78e1e3229d6-119){animation:none!important;opacity:var(--comp-opacity, 1)!important}' ) === $settler->settleRules($paused),
+    'a paused entrance animation settles at its end keyframe on the selector that applied it',
+    implode(' | ', $settler->settleRules($paused))
+);
+
+$scrollDriven = $fadeIn . '@supports (animation-timeline: view()){#comp-k3o4lijt{animation:motion-fadeIn 1200ms 1100ms cubic-bezier(0.445, 0.05, 0.55, 0.95) backwards 1;animation-composition:replace;animation-play-state:running;animation-timeline:view();animation-range:entry 0% cover 40%}}';
+$assert(
+    array( ':root #comp-k3o4lijt{animation:none!important;opacity:var(--comp-opacity, 1)!important}' ) === $settler->settleRules($scrollDriven),
+    'a scroll-driven entrance animation settles rather than resting on an unadvanced timeline',
+    implode(' | ', $settler->settleRules($scrollDriven))
+);
+
+// Reveals expressed with the longhands, and with visibility rather than opacity.
+$longhand = '@keyframes reveal{from{opacity:0;visibility:hidden;transform:translateY(40px)}to{opacity:1;visibility:visible;transform:none}}.reveal{animation-name:reveal;animation-duration:.6s;animation-fill-mode:backwards;animation-play-state:paused}';
+$assert(
+    array( ':root .reveal{animation:none!important;opacity:1!important;transform:none!important;visibility:visible!important}' ) === $settler->settleRules($longhand),
+    'longhand reveals settle, restating every end-state property the keyframes animate',
+    implode(' | ', $settler->settleRules($longhand))
+);
+
+// A stalled animation with no fill still shows its start frame when the delay
+// leaves it inside the active phase at time zero.
+$noFillNoDelay = $fadeIn . '.hero{animation:motion-fadeIn 1s;animation-play-state:paused}';
+$assert(
+    array() !== $settler->settleRules($noFillNoDelay),
+    'a paused animation with no delay settles even without a backwards fill mode'
+);
+$assert(
+    array() === $settler->settleRules($fadeIn . '.hero{animation:motion-fadeIn 1s 2s;animation-play-state:paused}'),
+    'a paused animation that only its fill mode could paint is left alone when it has none',
+    implode(' | ', $settler->settleRules($fadeIn . '.hero{animation:motion-fadeIn 1s 2s;animation-play-state:paused}'))
+);
+
+// Everything that is not a stalled reveal stays exactly as authored.
+foreach ( array(
+    'a runnable entrance animation on the document timeline' => $fadeIn . '.hero{animation:motion-fadeIn 1.2s backwards 1}',
+    'a paused cyclical animation, whose last frame is not a resting state' => '@keyframes spin{from{transform:rotate(0)}to{transform:rotate(360deg)}}.spinner{animation:spin 1s linear infinite paused}',
+    'a paused marquee that only moves' => '@keyframes slide{from{transform:translateX(0)}to{transform:translateX(-100%)}}.track{animation:slide 8s linear infinite paused}',
+    'a scroll-driven animation that only ever adds visibility' => '@keyframes fadeOutIn{0%{opacity:1}100%{opacity:1}}.bar{animation:fadeOutIn 1s backwards;animation-timeline:scroll()}',
+    'an animation whose keyframes are not in the stylesheet' => '.hero{animation:elsewhere 1s backwards paused}',
+    'a stylesheet with no animations at all' => '.hero{opacity:1}',
+) as $description => $css ) {
+    $assert(array() === $settler->settleRules($css), 'leaves alone: ' . $description, implode(' | ', $settler->settleRules($css)));
+}
+
+// Pseudo-elements are decoration, not the imported content the repair protects.
+$assert(
+    array() === $settler->settleRules($fadeIn . '.hero::after{animation:motion-fadeIn 1s backwards paused}'),
+    'pseudo-element animations are not restated'
+);
+
+// Keyframes are found wherever they are declared, including inside conditions.
+$nested = '@media screen{@keyframes motion-fadeIn{0%{opacity:0}to{opacity:1}}}.hero{animation:motion-fadeIn 1s backwards paused}';
+$assert(
+    array( ':root .hero{animation:none!important;opacity:1!important}' ) === $settler->settleRules($nested),
+    'keyframes nested in a condition are still read',
+    implode(' | ', $settler->settleRules($nested))
+);
+
+$names = array();
+( new CssStylesheetTransformer() )->visitKeyframeRules('@-webkit-keyframes "quoted"{from{opacity:0}}@media screen{@keyframes nested{to{opacity:1}}}@font-face{font-family:x}', static function (string $name) use (&$names): void {
+    $names[] = $name;
+});
+$assert(array( 'quoted', 'nested' ) === $names, 'keyframes visiting reports prefixed, quoted, and nested rules only', implode(',', $names));
+
+// End to end: the hidden content paints, in the theme CSS and in the editor.
+$html = <<<'HTML'
+<div id="page">
+  <h2 id="comp-k3nod418">We have the freedom to choose, so we chose to be good.</h2>
+  <p id="comp-k3jrzme8">Our mission is a kinder salon.</p>
+</div>
+HTML;
+$css = '@keyframes motion-fadeIn{0%{opacity:0}100%{opacity:var(--comp-opacity, 1)}}'
+    . '@media (prefers-reduced-motion: no-preference){#comp-k3nod418{animation:motion-fadeIn 1200ms 1ms ease backwards 1 paused;animation-composition:replace}}'
+    . '@supports (animation-timeline: view()){#comp-k3jrzme8{animation:motion-fadeIn 1200ms 1ms ease backwards 1;animation-play-state:running;animation-timeline:view();animation-range:entry 0% cover 40%}}';
+
+$result = ( new HtmlTransformer() )->transform($html, array( 'static_css' => $css ))->toArray();
+$assets = is_array($result['assets'] ?? null) ? $result['assets'] : array();
+$collect = static function (array $assets, callable $keep): string {
+    $chunks = array();
+    foreach ( $assets as $asset ) {
+        if ( 'css' === ($asset['kind'] ?? '') && $keep($asset) ) {
+            $chunks[] = (string) ($asset['content'] ?? '');
+        }
+    }
+
+    return implode("\n", $chunks);
+};
+
+$afterAuthor = $collect($assets, static fn (array $asset): bool => 'engine-support' === ($asset['source'] ?? '') && 'after-author' === ($asset['stylesheet_placement'] ?? ''));
+foreach ( array( 'comp-k3nod418', 'comp-k3jrzme8' ) as $id ) {
+    $assert(
+        str_contains($afterAuthor, ':root #' . $id . '{animation:none!important;opacity:var(--comp-opacity, 1)!important}'),
+        'the theme stylesheet settles #' . $id . ' after the author CSS that hides it',
+        $afterAuthor
+    );
+}
+
+$editorStaticState = $collect($assets, static fn (array $asset): bool => 'editor-static-state' === ($asset['source'] ?? ''));
+$assert(
+    str_contains($editorStaticState, 'animation-play-state:running!important') && str_contains($editorStaticState, 'animation-timeline:auto!important'),
+    'the editor static state overrides the play state and timeline it winds animations past',
+    $editorStaticState
+);
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, "reveal animation settling: {$failures} failed, {$passes} passed\n");
+    exit(1);
+}
+
+fwrite(STDOUT, "reveal animation settling: {$passes} passed\n");


### PR DESCRIPTION
Fixes #239.

## What is wrong

On an imported Wix site, three elements carrying the homepage's core content render permanently invisible — about 390px of blank white space where the heading, the mission paragraph and the "book appointment now" CTA should be. The content is in the DOM and in the block markup. It simply never paints.

The source drives its entrance animations from script. Its own stylesheet holds the element at the animation's first keyframe until its runtime stamps an attribute:

```css
@keyframes motion-fadeIn { 0% { opacity: 0 } 100% { opacity: var(--comp-opacity, 1) } }

#comp-k3nod418:not([data-motion-enter="done"]) {
  animation: motion-fadeIn 1200ms 1ms cubic-bezier(…) backwards 1 paused;
}
```

Capture also rewrites the same animation onto a scroll-driven timeline:

```css
@supports (animation-timeline: view()) {
  #comp-k3nod418 {
    animation: motion-fadeIn 1200ms 1ms cubic-bezier(…) backwards 1;
    animation-play-state: running;
    animation-timeline: view();
    animation-range: entry 0% cover 40%;
  }
}
```

Import carries both and drops the driver that would finish either one. `animation-fill-mode: backwards` puts the element on the `0% { opacity: 0 }` keyframe during the before phase, and neither variant ever leaves it: one is `paused`, and the other rides a `view()` timeline that, as emitted, never advances — `getAnimations()` reports `playState: "running"` while the computed opacity stays `"0"` indefinitely.

This is #239's failure, in its current form. The issue describes the IntersectionObserver era; the code emits CSS scroll-driven animations now, and the outcome is the same: content hidden because the reveal's driver was not carried.

## What changed

A captured reveal is only ever a way of arriving at a resting appearance, so an animation that cannot progress is no longer carried as a live animation. It is replaced by the resolved state it was travelling towards, which is what a visitor of the source would have seen.

`RevealAnimationSettler` reads the projected author CSS the theme actually ships, indexes every `@keyframes` rule through a new `CssStylesheetTransformer::visitKeyframeRules()`, and for each rule that parks content in a hidden start keyframe emits the settled state after the author CSS:

```css
:root #comp-k3nod418{animation:none!important;opacity:var(--comp-opacity, 1)!important}
```

The same repair is projected onto the editor's anchor classes, and the editor's existing settle-everything rule now overrides play state and timeline too — without those, its `animation-delay:-999999s` lands on an animation that never advances and the element keeps whatever keyframe its fill mode paints. A file named `editor-static-state-*.css` should express a captured animation's resolved state, not re-declare a live scroll-driven one.

Nothing here is keyed to Wix or to the name `motion-fadeIn`. The trigger is the CSS configuration, so it covers a paused reveal, a scroll-driven reveal, the shorthand and the longhands, and reveals expressed with `visibility`/`display` as well as `opacity`.

Deliberately narrow. Untouched:

- an animation that can still run on the document timeline;
- an animation whose start keyframe is no less visible than its end — a paused marquee or spinner keeps its own declarations, since settling a cyclical animation to its last frame would move content rather than reveal it;
- a paused animation whose before phase nothing paints (no `backwards`/`both` fill, positive delay);
- pseudo-element animations, which are decoration rather than imported content.

Where a reveal *is* settled, only its end visibility (`opacity`/`visibility`/`display`) is restated unconditionally. The end frame's geometry — `transform` and friends — is restated only under `forwards`/`both`, the fill modes that actually keep it: any other fill hands the element back to its own transform when the reveal finishes, so restating the keyframe's would move content rather than reveal it.

## Evidence

A real import of the same 4-page capture, before and after, at 1280 wide.

| | trunk | this branch |
|---|---|---|
| `#comp-k3nod418` computed opacity | `0` | `1` |
| `#comp-k3jrzme8` computed opacity | `0` | `1` |
| `#comp-k3o4lijt` computed opacity | `0` | `1` |
| elements at computed `opacity: 0`, homepage | 8 | 2 |
| elements with a running animation, homepage | 6 | 0 |
| `scrollHeight` / rendered text length, all 4 pages | unchanged | unchanged |
| console errors, all 4 pages | 0 | 0 |

The two remaining `opacity: 0` elements are the legitimate "Skip to Main Content" buttons. The three targets keep their exact geometry (`y`/`width`/`height` identical), so nothing reflows — the band that was blank now carries its text. In the editor: 146 blocks, 0 invalid, 0 warnings, 0 console errors, matching the baseline.

## Tests

`php-transformer/tests/unit/reveal-animation-settling.php` (registered in `composer test:unit`) locks in both observed shapes verbatim, the longhand and `visibility` forms, the fill-mode split on geometry, keyframes nested in a condition, the new `visitKeyframeRules()` walk, six cases that must stay untouched, and an end-to-end pass through `HtmlTransformer` for both the inline-author-CSS path and the pipeline path that materializes its own author stylesheets.

Full `composer test` (140 scripts), the 292 parity fixtures, `composer validate --strict` and the repository acceptance matrix contract all pass.
