### PR TITLE
Keep the source's paint on a pushed-down link wrapper

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -189,7 +189,8 @@
             "php tests/unit/button-link-dispatcher.php",
             "php tests/unit/button-element-converter.php",
             "php tests/unit/runtime-resource-element-converter.php",
-            "php tests/unit/link-bearing-element-lowering.php"
+            "php tests/unit/link-bearing-element-lowering.php",
+            "php tests/unit/link-wrapper-text-color-parity.php"
     ],
     "test:parity": "php tests/parity/run.php",
     "test:migration:examples": "php tests/migration/examples.php",

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -398,6 +398,15 @@ final class HtmlTransformer
      */
     public const EMPTY_RUNTIME_TARGET_CLASS = 'blocks-engine-empty-runtime-target';
 
+    /**
+     * Marks a RichText block whose text was painted by the source, and into
+     * whose content a content-wrapping anchor's link had to be pushed. The
+     * synthesized inline `<a>` becomes the text's nearest painted ancestor, so
+     * the browser's link colour would replace the source colour; the projected
+     * rule makes that anchor inherit its host block's colour instead.
+     */
+    private const PROPAGATED_LINK_COLOR_CARRIER_CLASS = 'blocks-engine-propagated-link-color';
+
     private const CSS_OWNED_LAYOUT_CLASS = 'blocks-engine-css-owned-layout';
 
     private const CSS_OWNED_FLOW_CLASS = 'blocks-engine-css-owned-flow';
@@ -2084,6 +2093,13 @@ final class HtmlTransformer
             // A semantic Group used as a direct grid/flex item contains native
             // paragraph blocks. Neutralize only those generated inner defaults.
             $beforeAuthorCssParts[] = ':root :where(.wp-block-group.' . self::CSS_OWNED_LAYOUT_ITEM_CLASS . ')>*{margin-block-start:0;margin-block-end:0}';
+        }
+        if ( str_contains($serializedBlocks, self::PROPAGATED_LINK_COLOR_CARRIER_CLASS) ) {
+            // The source painted this text; the anchor around it only exists
+            // because a content-wrapping link was pushed into the block. It
+            // follows the author cascade so a later authored rule can still
+            // repaint the link deliberately.
+            $afterAuthorCssParts[] = ':root :where(.' . self::PROPAGATED_LINK_COLOR_CARRIER_CLASS . ')>a{color:inherit}';
         }
         foreach ( $this->navigationStyleProjector->navigationLinkTextColorRules($serializedBlocks) as $navigationLinkTextColorRule ) {
             $afterAuthorCssParts[] = $navigationLinkTextColorRule;
@@ -10368,7 +10384,72 @@ final class HtmlTransformer
             'target'         => $this->attr($anchor, 'target'),
             'rel'            => $this->attr($anchor, 'rel'),
             'textDecoration' => 'none' === $textDecoration ? 'none' : '',
+            'color'          => $this->linkWrapperPaintsAuthoredTextColor($anchor) ? 'inherit' : '',
         ), static fn (string $value): bool => '' !== trim($value));
+    }
+
+    /**
+     * Whether an element strictly inside a content-wrapping anchor paints every
+     * run of the anchor's text.
+     *
+     * Pushing the wrapper's href down onto an inner RichText block (see
+     * {@see self::propagateInlineLink()}) rebuilds the anchor INSIDE the block
+     * that the painting element became, so the synthesized `<a>` — not that
+     * element — is now the text's nearest painted ancestor and the browser's
+     * link colour replaces the source colour. Making the anchor inherit
+     * restores the source's painted colour, whatever it is, because the block
+     * that inherits from still carries the source's own styling hooks.
+     *
+     * The wrapper's own colour is deliberately not counted. It has no painting
+     * element inside the anchor to lose: source rules that reach the anchor by
+     * type still reach the rebuilt one, and no repaint is owed. Text sitting
+     * directly in the anchor is likewise unpainted from within, so a wrapper
+     * that holds any is left exactly as it is today.
+     */
+    private function linkWrapperPaintsAuthoredTextColor(DOMElement $anchor): bool
+    {
+        $textOwners = array();
+        foreach ( array_merge(array( $anchor ), $this->descendantElements($anchor)) as $element ) {
+            foreach ( $element->childNodes as $node ) {
+                if ( XML_TEXT_NODE === $node->nodeType && '' !== trim($node->textContent ?? '') ) {
+                    $textOwners[] = $element;
+                    break;
+                }
+            }
+        }
+
+        if ( array() === $textOwners ) {
+            return false;
+        }
+
+        foreach ( $textOwners as $textOwner ) {
+            if ( ! $this->paintsTextColorBelow($textOwner, $anchor) ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Whether the cascade paints `$element` — or an ancestor of it below
+     * `$anchor` — with a colour of its own. That is the inheritance chain the
+     * rebuilt anchor severs, so it is the chain that decides whether the anchor
+     * must inherit.
+     */
+    private function paintsTextColorBelow(DOMElement $element, DOMElement $anchor): bool
+    {
+        for ( $node = $element; $node instanceof DOMElement && ! $node->isSameNode($anchor); $node = $node->parentNode ) {
+            $declarations = $this->styleResolver->cssDeclarations(
+                $this->styleResolver->specificityResolvedPresentationStyle($node)
+            );
+            $color = strtolower(trim((string) ($declarations['color'] ?? '')));
+            if ( '' !== $color && ! in_array($color, array( 'inherit', 'initial', 'unset', 'revert', 'revert-layer', 'currentcolor' ), true) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -10486,6 +10567,12 @@ final class HtmlTransformer
         }
 
         $replacementAttrs = array_merge($attrs, array( 'content' => $wrapped ));
+        if ( 'inherit' === (string) ($linkAttrs['color'] ?? '') ) {
+            $replacementAttrs['className'] = $this->mergeClassNames(
+                (string) ($replacementAttrs['className'] ?? ''),
+                self::PROPAGATED_LINK_COLOR_CARRIER_CLASS
+            );
+        }
         if ( 'none' === (string) ($linkAttrs['textDecoration'] ?? '') ) {
             $style = is_array($replacementAttrs['style'] ?? null) ? $replacementAttrs['style'] : array();
             $typography = is_array($style['typography'] ?? null) ? $style['typography'] : array();

--- a/php-transformer/tests/unit/link-wrapper-text-color-parity.php
+++ b/php-transformer/tests/unit/link-wrapper-text-color-parity.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\BlockValidityValidator;
+
+/**
+ * A content-wrapping `<a>` is converted to a group and its link is pushed down
+ * onto the RichText blocks inside it. That rebuilds the anchor between the text
+ * and the element that painted it, so the browser's link colour would replace
+ * the source's. The carrier class plus its projected rule keep the source paint.
+ */
+$carrier = 'blocks-engine-propagated-link-color';
+
+$transform = static function (string $css, string $body): array {
+    return ( new HtmlTransformer() )->transform('<html><head><style>' . $css . '</style></head><body>' . $body . '</body></html>')->toArray();
+};
+$afterAuthorCss = static function (array $result): string {
+    $css = '';
+    foreach ( $result['assets'] ?? array() as $asset ) {
+        if ( 'after-author' === (string) ($asset['stylesheet_placement'] ?? '') ) {
+            $css .= (string) ($asset['content'] ?? '');
+        }
+    }
+
+    return $css;
+};
+
+$card = '<div><ul><li class="item"><a class="wrap" href="/services"><div class="mid"><div><p class="label">SERVICES</p></div></div></a></li></ul></div>';
+
+// A painted inner element loses its place in the paint chain, so the rebuilt
+// anchor must inherit.
+$painted = $transform('.label{color:rgb(65,65,65)}.wrap{text-decoration:none}', $card);
+$paintedMarkup = (string) ($painted['serialized_blocks'] ?? '');
+if ( ! str_contains($paintedMarkup, '<p class="label ' . $carrier . '"') || ! str_contains($paintedMarkup, '>SERVICES</a>') ) {
+    throw new RuntimeException('A pushed-down link inside painted source text must mark its host block as inheriting the paint.');
+}
+if ( ! str_contains($afterAuthorCss($painted), ':root :where(.' . $carrier . ')>a{color:inherit}') ) {
+    throw new RuntimeException('The carrier class must project a colour-inheritance rule after the author cascade.');
+}
+if ( 'pass' !== ( ( new BlockValidityValidator() )->validateBlocks($painted['blocks'] ?? array())['status'] ?? '' ) ) {
+    throw new RuntimeException('Carrying the paint must leave the blocks Gutenberg-valid.');
+}
+
+// Nothing inside the wrapper paints the text: the source rendered it with the
+// browser's link colour, and so must the import.
+$unpainted = $transform('.wrap{text-decoration:none}', $card);
+if ( str_contains((string) ($unpainted['serialized_blocks'] ?? ''), $carrier) ) {
+    throw new RuntimeException('Text the source left to the browser link colour must not be forced to inherit.');
+}
+
+// The wrapper's own colour has no painting element inside the anchor to lose.
+$anchorOnly = $transform('.wrap{color:rgb(9,9,9)}', $card);
+if ( str_contains((string) ($anchorOnly['serialized_blocks'] ?? ''), $carrier) ) {
+    throw new RuntimeException('A colour resolved on the wrapper itself must not trigger the carrier.');
+}
+
+// A colour resolved anywhere between the text and the wrapper counts, since the
+// intervening element is the one the rebuilt anchor now sits inside.
+$intermediate = $transform('.mid{color:rgb(12,34,56)}', $card);
+if ( ! str_contains((string) ($intermediate['serialized_blocks'] ?? ''), $carrier) ) {
+    throw new RuntimeException('A colour painted between the text and the wrapper must trigger the carrier.');
+}
+
+// A colour keyword that paints nothing of its own leaves the chain unpainted.
+foreach ( array( 'inherit', 'initial', 'unset', 'currentColor' ) as $keyword ) {
+    if ( str_contains((string) ($transform('.label{color:' . $keyword . '}', $card)['serialized_blocks'] ?? ''), $carrier) ) {
+        throw new RuntimeException('A non-painting colour keyword must not trigger the carrier: ' . $keyword);
+    }
+}
+
+// Text sitting directly in the wrapper has no inner painter, so the wrapper is
+// left exactly as it is without the carrier.
+$directText = $transform('.label{color:rgb(65,65,65)}', '<div><a class="wrap" href="/services">Shop <div><p class="label">SERVICES</p></div></a></div>');
+if ( str_contains((string) ($directText['serialized_blocks'] ?? ''), $carrier) ) {
+    throw new RuntimeException('A wrapper holding unpainted direct text must not be forced to inherit.');
+}
+
+// Determinism.
+$repeat = $transform('.label{color:rgb(65,65,65)}.wrap{text-decoration:none}', $card);
+if ( ($repeat['serialized_blocks'] ?? null) !== ($painted['serialized_blocks'] ?? null) || $afterAuthorCss($repeat) !== $afterAuthorCss($painted) ) {
+    throw new RuntimeException('Link-wrapper colour carrying must be deterministic.');
+}
+
+fwrite(STDOUT, "link wrapper text colour parity contract passed\n");


### PR DESCRIPTION
## Problem

An `<a href>` that wraps block-level content becomes a `core/group`, and its link is pushed down onto the RichText blocks inside it as an inline `<a>` around their text (`HtmlTransformer::convertLinkWrapperGroup()` → `propagateInlineLink()`).

That rebuild puts the anchor **inside** the block that the source's painting element became. The anchor, not that element, is now the text's nearest painted ancestor, so the browser's default link colour replaces the colour the source painted.

Measured on `https://www.maneethical.com` (Wix), imported through Studio + static-site-importer, Playwright at 1280x900. The source menu item is:

```html
<a class="qMvpu5" href="/services/index.html">
  <div class="EWeavx"><div>
    <p class="wGxoBM" id="comp-k3mm4s7p2label">SERVICES</p>
  </div></div>
</a>
```

with `.wGxoBM{color:rgb(var(--txt,var(--color_15,color_15)))}` — the `<p>` inside the anchor is what paints the label.

The import emits `<p class="wGxoBM …"><a href="/services">SERVICES</a></p>`. The class still paints the `<p>` grey, but the rebuilt anchor repaints the text:

| label (front page) | source | import before | import after |
|---|---|---|---|
| HOME (current page) | `rgb(177, 211, 187)` | `rgb(0, 0, 238)` | `rgb(177, 211, 187)` |
| ABOUT | `rgb(65, 65, 65)` | `rgb(0, 0, 238)` | `rgb(65, 65, 65)` |
| SERVICES | `rgb(65, 65, 65)` | `rgb(0, 0, 238)` | `rgb(65, 65, 65)` |
| PRODUCTS | `rgb(65, 65, 65)` | `rgb(0, 0, 238)` | `rgb(65, 65, 65)` |
| CONTACT | `rgb(65, 65, 65)` | `rgb(0, 0, 238)` | `rgb(65, 65, 65)` |
| Shop | `rgb(65, 65, 65)` | `rgb(0, 0, 238)` | `rgb(65, 65, 65)` |

Text decoration was already carried across this rebuild (`textDecoration` in `linkPropagationAttributes()`); colour was not.

## Change

`linkPropagationAttributes()` now also asks whether an element **strictly inside** the wrapper paints every run of the wrapper's text, resolving the cascade winner via `specificityResolvedPresentationStyle()`. When it does, `propagateInlineLink()` marks the host block with `blocks-engine-propagated-link-color`, and `materializeAuthorStylesheet()` projects one rule after the author cascade:

```css
:root :where(.blocks-engine-propagated-link-color)>a{color:inherit}
```

Inheriting — rather than stamping a resolved value — restores whatever the source painted, because the block being inherited from still carries the source's own styling hooks. It also reproduces per-page state colours for free (the current item stays green on each page, see the table).

The condition is deliberately narrow, and nothing about it is site- or class-specific:

- **A colour resolved on the wrapper itself does not count.** It has no painting element inside the anchor to lose — source rules that reach the anchor by type still reach the rebuilt one — so no repaint is owed.
- **Text sitting directly in the wrapper does not count**, for the same reason; a wrapper holding any is left exactly as it is today.
- **Non-painting keywords** (`inherit`, `initial`, `unset`, `revert`, `currentColor`) do not count.
- **A wrapper whose text the source left to the browser's link colour is untouched**, so that parity is preserved by doing nothing.

The rule follows the author cascade so an authored rule can still repaint the link deliberately.

## Proof

Rebuilt the paired static-site-importer dev ZIP against this branch and re-ran a real 4-page import of the Wix capture, then re-measured with Playwright. Painted colour of every text run inside a link, source vs import, across `/`, `/about/`, `/services/`:

| | before | after |
|---|---|---|
| matching | 8 | 35 |
| differing | 30 | 3 |

The 3 remaining differences are one unrelated footer credit link (`Lumo Design Studio`), identical before and after — untouched by this change.

Import quality gates unchanged: 0 fallback blocks, 0 invalid blocks, 0 core/html, validation `passed`.

`tests/unit/link-wrapper-text-color-parity.php` locks in the emitted carrier, the projected rule, block validity, determinism, and each of the four negative cases above. `composer test` and `tests/contract/production-acceptance-matrix.php` pass locally (292 parity fixtures unchanged).

## Not in this PR

The same import also renders three source-hidden `More`-menu items and a screen-reader hint with real geometry instead of the source's zero geometry. That is a separate root cause (`StyleResolver::stripFrozenHiddenState()`) and is filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtVE4gr2RA7GE3FKbBS7C5
