### PR TITLE
Recover navigation presentation the source inherits

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2088,6 +2088,9 @@ final class HtmlTransformer
         foreach ( $this->navigationStyleProjector->navigationLinkTextColorRules($serializedBlocks) as $navigationLinkTextColorRule ) {
             $afterAuthorCssParts[] = $navigationLinkTextColorRule;
         }
+        foreach ( $this->generatedSupportStyles()->navigationInheritedPresentationRules() as $navigationInheritedRule ) {
+            $afterAuthorCssParts[] = $navigationInheritedRule;
+        }
         foreach ( $this->navigationStyleProjector->navigationLinkIconRules($serializedBlocks) as $navigationLinkIconRule ) {
             $afterAuthorCssParts[] = $navigationLinkIconRule;
         }
@@ -2580,7 +2583,10 @@ final class HtmlTransformer
                 fn (DOMElement $sourceElement): array => $this->navigationStyleProjector->navigationColorInteractionStates($sourceElement),
                 fn (DOMElement $sourceElement): string => $this->navigationToggleSuppressor->navigationOverlayMenu($sourceElement),
                 fn (DOMElement $sourceElement): string => $this->responsiveNavigationToggleMarker($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->navigationLinkIconMarker($sourceElement)
+                fn (DOMElement $sourceElement): string => $this->navigationLinkIconMarker($sourceElement),
+                function (DOMElement $sourceElement, array $authorClasses): void {
+                    $this->recordInheritedNavigationPresentation($sourceElement, $authorClasses);
+                }
             ),
             new MediaPatternContext(
                 fn (DOMElement $sourceElement): string => $this->styleResolver->mergedPresentationStyle($sourceElement),
@@ -2791,6 +2797,74 @@ final class HtmlTransformer
         $this->generatedSupportStyles()->registerNavigationLinkIcon($marker, $declarations);
 
         return $marker;
+    }
+
+    /**
+     * Deliver navigation presentation the source inherits, as CSS.
+     *
+     * Native navigation replaces the source structure, so a menu that took its
+     * colour and type from an ancestor loses them: the anchor declares only
+     * `inherit`, and the destination theme supplies the value instead. Resolve
+     * what the source would have inherited and state it on the navigation.
+     *
+     * The rule hangs off classes the block already carries, so nothing about
+     * the emitted markup changes. That matters: shell identity compares block
+     * markup across documents, and a value that varies per page would split one
+     * shared template part into one part per page.
+     *
+     * @param array<int, string> $authorClasses
+     */
+    private function recordInheritedNavigationPresentation(DOMElement $navigation, array $authorClasses): void
+    {
+        if ( array() === $authorClasses ) {
+            return;
+        }
+
+        $declarations = array();
+        foreach ( array( 'color', 'font-family', 'font-size', 'font-weight', 'font-style', 'letter-spacing', 'text-transform' ) as $property ) {
+            $value = $this->inheritedNavigationValue($navigation, $property);
+            if ( '' !== $value ) {
+                $declarations[] = $property . ':' . $value;
+            }
+        }
+        if ( array() === $declarations ) {
+            return;
+        }
+
+        $selector = '.wp-block-navigation.' . implode('.', $authorClasses);
+        $this->generatedSupportStyles()->registerNavigationInheritedPresentation(
+            $selector,
+            $selector . '{' . implode(';', $declarations) . '}'
+        );
+    }
+
+    /**
+     * Resolve a value the source inherits, by walking its ancestor chain.
+     *
+     * Stops at the nearest ancestor stating a usable value, which is what CSS
+     * inheritance would have produced in the source document.
+     */
+    private function inheritedNavigationValue(DOMElement $element, string $property): string
+    {
+        $node  = $element;
+        $depth = 0;
+        while ( $node instanceof DOMElement && $depth < 24 ) {
+            ++$depth;
+            $resolved     = $this->styleResolver->resolveCssVariablesInValue(
+                $this->styleResolver->specificityResolvedPresentationStyle($node)
+            );
+            $declarations = $this->styleResolver->cssDeclarations($resolved);
+            $value        = trim((string) ($declarations[$property] ?? ''));
+            if ( '' !== $value
+                && ! in_array(strtolower($value), array( 'inherit', 'unset', 'initial', 'revert', 'revert-layer' ), true)
+                && ! preg_match('~[{}<>;]|/\*|(?:expression|url)\s*\(|javascript\s*:~i', $value)
+            ) {
+                return $value;
+            }
+            $node = $node->parentNode instanceof DOMElement ? $node->parentNode : null;
+        }
+
+        return '';
     }
 
     /** Resolve the rendered box of a navigation icon from its source geometry. */

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -109,6 +109,13 @@ final class NavigationPattern implements PatternRecognizerInterface
 			$navigationAttrs,
             $commonTextAttrs
         );
+        // Presentation the source inherits is recorded for CSS delivery rather
+        // than written onto the block, so documents that share this shell keep
+        // identical markup and continue to collapse into one template part.
+        $navigationContext?->recordInheritedPresentation(
+            $element,
+            $this->authorClassNames((string) ($navigationAttrs['className'] ?? ''))
+        );
         if ( 'mobile' === $navigationAttrs['overlayMenu'] ) {
             $defaultTextColorClass = $this->defaultNavigationTextColorClass($links);
             if ( '' !== $defaultTextColorClass ) {
@@ -1171,6 +1178,26 @@ final class NavigationPattern implements PatternRecognizerInterface
         // Core does not register either attribute, so serializing them would make
         // an editor parse/save discard CSS projection input.
         return array_filter(array_replace_recursive($itemAttrs, $baseAttrs), static fn ($value): bool => '' !== $value);
+    }
+
+    /**
+     * Classes already carried by the block that a stylesheet can target.
+     *
+     * Engine markers are excluded: a generated selector should hang off the
+     * source's own identity, not off vocabulary this engine invented.
+     *
+     * @return array<int, string>
+     */
+    private function authorClassNames(string $className): array
+    {
+        $classes = preg_split('/\s+/', trim($className)) ?: array();
+
+        return array_values(array_filter(
+            $classes,
+            static fn (string $candidate): bool => '' !== $candidate
+                && ! str_starts_with($candidate, 'blocks-engine-')
+                && 1 === preg_match('/^[A-Za-z_][A-Za-z0-9_-]{0,79}$/D', $candidate)
+        ));
     }
 
     private function navigationTextColorFromStyle(string $style): string

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPatternContext.php
@@ -16,6 +16,7 @@ final class NavigationPatternContext
     private readonly ?Closure $overlayMenu;
     private readonly ?Closure $responsiveToggleMarker;
     private readonly ?Closure $linkIconMarker;
+    private readonly ?Closure $inheritedPresentation;
 
     /**
      * @param callable(DOMElement): bool|null $runtimeDomTarget
@@ -25,6 +26,7 @@ final class NavigationPatternContext
      * @param callable(DOMElement): string|null $overlayMenu
      * @param callable(DOMElement): string|null $responsiveToggleMarker
      * @param callable(DOMElement): string|null $linkIconMarker
+     * @param callable(DOMElement, array<int, string>): void|null $inheritedPresentation
      */
     public function __construct(
         ?callable $runtimeDomTarget,
@@ -33,9 +35,11 @@ final class NavigationPatternContext
         ?callable $colorInteractionStates = null,
         ?callable $overlayMenu = null,
         ?callable $responsiveToggleMarker = null,
-        ?callable $linkIconMarker = null
+        ?callable $linkIconMarker = null,
+        ?callable $inheritedPresentation = null
     ) {
         $this->linkIconMarker         = null === $linkIconMarker ? null : Closure::fromCallable($linkIconMarker);
+        $this->inheritedPresentation  = null === $inheritedPresentation ? null : Closure::fromCallable($inheritedPresentation);
         $this->runtimeDomTarget       = null === $runtimeDomTarget ? null : Closure::fromCallable($runtimeDomTarget);
         $this->underlineColor         = Closure::fromCallable($underlineColor);
         $this->resolvedStyle          = Closure::fromCallable($resolvedStyle);
@@ -85,5 +89,22 @@ final class NavigationPatternContext
     public function linkIconMarker(DOMElement $element): string
     {
         return null === $this->linkIconMarker ? '' : ($this->linkIconMarker)($element);
+    }
+
+    /**
+     * Record navigation presentation the source inherits rather than declares.
+     *
+     * Deliberately returns nothing: a per-document value must not reach block
+     * markup, because shell identity compares that markup across documents and
+     * a value that varies by page would fragment one shared template part into
+     * several. The recorded presentation is delivered as CSS instead.
+     *
+     * @param array<int, string> $authorClasses Classes already present on the block.
+     */
+    public function recordInheritedPresentation(DOMElement $element, array $authorClasses): void
+    {
+        if ( null !== $this->inheritedPresentation ) {
+            ($this->inheritedPresentation)($element, $authorClasses);
+        }
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Style/GeneratedSupportStylesheetState.php
+++ b/php-transformer/src/HtmlToBlocks/Style/GeneratedSupportStylesheetState.php
@@ -28,6 +28,9 @@ final class GeneratedSupportStylesheetState
     private array $navigationLinkColors = array();
 
     /** @var array<string, string> */
+    private array $navigationInheritedPresentation = array();
+
+    /** @var array<string, string> */
     private array $navigationLinkIcons = array();
 
     /** @var array<string, string> */
@@ -95,6 +98,17 @@ final class GeneratedSupportStylesheetState
     public function navigationLinkColor(string $className): string
     {
         return $this->navigationLinkColors[$className] ?? '';
+    }
+
+    public function registerNavigationInheritedPresentation(string $selector, string $rule): void
+    {
+        $this->navigationInheritedPresentation[$selector] = $rule;
+    }
+
+    /** @return array<int, string> */
+    public function navigationInheritedPresentationRules(): array
+    {
+        return array_values($this->navigationInheritedPresentation);
     }
 
     public function registerNavigationLinkIcon(string $className, string $declarations): void

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -631,6 +631,26 @@ $assert('core/social-links' !== ($unknownPlaceholderSocial['blocks'][0]['blockNa
 $ordinaryFooterLinks = ( new HtmlTransformer() )->transform('<nav aria-label="Company"><a href="/about">About</a><a href="/contact">Contact</a></nav>')->toArray();
 $assert('core/navigation' === ($ordinaryFooterLinks['blocks'][0]['blockName'] ?? null), 'ordinary navigation does not become social links without profile-host or social-cluster semantics');
 
+// Native navigation replaces the source structure, so a menu that inherited its
+// colour and type from an ancestor would otherwise fall back to the destination
+// theme. The recovered value is delivered as CSS rather than written onto the
+// block: shell identity compares block markup across documents, and a per-page
+// value in that markup would split one shared template part into several.
+$navInherited = ( new HtmlTransformer() )->transform(
+    '<style>.hdr{color:rgb(238,255,255);font-family:helvetica-w01-roman;font-size:15.75px}</style>'
+    . '<header class="hdr"><nav class="menu navbar" aria-label="Main"><ul><li><a href="/features">Features</a></li><li><a href="/benefits">Benefits</a></li></ul></nav></header>'
+)->toArray();
+$navInheritedCss = implode("\n", array_column($navInherited['assets'] ?? array(), 'content'));
+$navInheritedMarkup = (string) ($navInherited['serialized_blocks'] ?? '');
+$assert(str_contains($navInheritedCss, '.wp-block-navigation.menu.navbar{color:rgb(238,255,255);font-family:helvetica-w01-roman;font-size:15.75px}'), 'navigation presentation inherited from a source ancestor is recovered onto the navigation itself');
+preg_match('/<!--\s*wp:navigation\s*(\{.*?\})\s*-->/s', $navInheritedMarkup, $navInheritedAttrs);
+$navInheritedBlock = $navInheritedAttrs[1] ?? '';
+$assert('' !== $navInheritedBlock && ! str_contains($navInheritedBlock, 'customTextColor') && ! str_contains($navInheritedBlock, 'helvetica-w01-roman') && ! str_contains($navInheritedBlock, '238'), 'recovered navigation presentation stays out of the navigation block so documents sharing a shell keep identical markup: ' . $navInheritedBlock);
+$navNoInheritance = ( new HtmlTransformer() )->transform(
+    '<header><nav class="plain-nav" aria-label="Main"><ul><li><a href="/a">A</a></li><li><a href="/b">B</a></li></ul></nav></header>'
+)->toArray();
+$assert(! str_contains(implode("\n", array_column($navNoInheritance['assets'] ?? array(), 'content')), '.wp-block-navigation.plain-nav{'), 'a menu that inherits nothing gets no fabricated presentation rule');
+
 // A source nav landmark keeps native menu semantics, so its icon-only anchors
 // must not silently lose the artwork core/navigation-link cannot save.
 $navIconResult = ( new HtmlTransformer() )->transform(


### PR DESCRIPTION
Partially addresses #1482.

## Problem

A generated site's menu renders with none of the source's typography or colour. Measured against a public source at 1440px:

| | font-family | font-size | colour |
|---|---|---|---|
| Source | `helvetica-w01-roman` | 15.75px | `rgb(238, 255, 255)` |
| Generated | `Arial` | 10px | `rgb(0, 0, 0)` |

Those are the generated theme's body defaults, so nothing source-derived reaches the links.

The colour rule is generated and its stylesheet is enqueued, so this is not a delivery failure. It emits:

```css
… .blocks-engine-navigation-link-color-4881… > .wp-block-navigation-item__content { color: inherit }
```

`color: inherit`, because the source anchor's declared colour genuinely *is* `inherit`. Enumerating matching rules in both documents also finds no rule setting `font-family` or `font-size` on the anchor or its label span in either: the source's navigation typography is inherited too.

The projection is faithful to the source *declaration* and wrong about the *resolved value*. Copying `inherit` reproduces the source only while the ancestor that supplied the value is also reproduced, and native navigation replaces that structure.

## Change

Resolve what the source would have inherited by walking its ancestor chain, and state it on the navigation.

The recovered value is delivered as **CSS**, hung off classes the block already carries, rather than written onto the block. That placement is the substance of the change, not an implementation detail: an earlier attempt put the resolved value on `core/navigation`'s native attributes (`customTextColor`, `style.typography.*`) and broke `shared-shell-plan`. Shell identity compares block markup across documents, so a value that varies per page fragments one shared template part into one part per page. Keeping the value in CSS fixes the typography while leaving shell identity untouched.

Generated selectors use only the source's own classes; engine markers are excluded, so this adds no marker vocabulary.

## Verification

- 292 parity fixtures pass unchanged.
- `shared-shell-plan` passes, which is the contract the earlier attempt broke.
- New contract coverage asserts all three halves: the rule is recovered, it stays out of the navigation block's markup, and a menu that inherits nothing gets no fabricated rule.

## Scope

This addresses the inherited-presentation failure described in #1482. The broader model in that issue — one `NavigationModel`, a typed residue list, and a single emitter replacing the 16 marker vocabularies — remains open.

## AI assistance disclosure

Implemented with AI assistance: Claude Sonnet 4.5 running in the opencode CLI agent. The AI measured the computed styles and matching CSS rules in both documents, identified `color: inherit` as the emitted value, prototyped the native-attribute approach and diagnosed its shared-shell regression, implemented the CSS-delivered approach instead, and ran the suite. A human directed the work and the placement decision.
