### PR TITLE
Recover menu presentation from replaced source wrappers

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2088,6 +2088,9 @@ final class HtmlTransformer
         foreach ( $this->navigationStyleProjector->navigationLinkTextColorRules($serializedBlocks) as $navigationLinkTextColorRule ) {
             $afterAuthorCssParts[] = $navigationLinkTextColorRule;
         }
+        foreach ( $this->generatedSupportStyles()->navigationInheritedPresentationRules() as $navigationInheritedRule ) {
+            $afterAuthorCssParts[] = $navigationInheritedRule;
+        }
         foreach ( $this->navigationStyleProjector->navigationLinkIconRules($serializedBlocks) as $navigationLinkIconRule ) {
             $afterAuthorCssParts[] = $navigationLinkIconRule;
         }
@@ -2580,7 +2583,10 @@ final class HtmlTransformer
                 fn (DOMElement $sourceElement): array => $this->navigationStyleProjector->navigationColorInteractionStates($sourceElement),
                 fn (DOMElement $sourceElement): string => $this->navigationToggleSuppressor->navigationOverlayMenu($sourceElement),
                 fn (DOMElement $sourceElement): string => $this->responsiveNavigationToggleMarker($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->navigationLinkIconMarker($sourceElement)
+                fn (DOMElement $sourceElement): string => $this->navigationLinkIconMarker($sourceElement),
+                function (DOMElement $sourceElement, array $authorClasses): void {
+                    $this->recordInheritedNavigationPresentation($sourceElement, $authorClasses);
+                }
             ),
             new MediaPatternContext(
                 fn (DOMElement $sourceElement): string => $this->styleResolver->mergedPresentationStyle($sourceElement),
@@ -2791,6 +2797,74 @@ final class HtmlTransformer
         $this->generatedSupportStyles()->registerNavigationLinkIcon($marker, $declarations);
 
         return $marker;
+    }
+
+    /**
+     * Deliver navigation presentation the source inherits, as CSS.
+     *
+     * Native navigation replaces the source structure, so a menu that took its
+     * colour and type from an ancestor loses them: the anchor declares only
+     * `inherit`, and the destination theme supplies the value instead. Resolve
+     * what the source would have inherited and state it on the navigation.
+     *
+     * The rule hangs off classes the block already carries, so nothing about
+     * the emitted markup changes. That matters: shell identity compares block
+     * markup across documents, and a value that varies per page would split one
+     * shared template part into one part per page.
+     *
+     * @param array<int, string> $authorClasses
+     */
+    private function recordInheritedNavigationPresentation(DOMElement $navigation, array $authorClasses): void
+    {
+        if ( array() === $authorClasses ) {
+            return;
+        }
+
+        $declarations = array();
+        foreach ( array( 'color', 'font-family', 'font-size', 'font-weight', 'font-style', 'letter-spacing', 'text-transform' ) as $property ) {
+            $value = $this->inheritedNavigationValue($navigation, $property);
+            if ( '' !== $value ) {
+                $declarations[] = $property . ':' . $value;
+            }
+        }
+        if ( array() === $declarations ) {
+            return;
+        }
+
+        $selector = '.wp-block-navigation.' . implode('.', $authorClasses);
+        $this->generatedSupportStyles()->registerNavigationInheritedPresentation(
+            $selector,
+            $selector . '{' . implode(';', $declarations) . '}'
+        );
+    }
+
+    /**
+     * Resolve a value the source inherits, by walking its ancestor chain.
+     *
+     * Stops at the nearest ancestor stating a usable value, which is what CSS
+     * inheritance would have produced in the source document.
+     */
+    private function inheritedNavigationValue(DOMElement $element, string $property): string
+    {
+        $node  = $element;
+        $depth = 0;
+        while ( $node instanceof DOMElement && $depth < 24 ) {
+            ++$depth;
+            $resolved     = $this->styleResolver->resolveCssVariablesInValue(
+                $this->styleResolver->specificityResolvedPresentationStyle($node)
+            );
+            $declarations = $this->styleResolver->cssDeclarations($resolved);
+            $value        = trim((string) ($declarations[$property] ?? ''));
+            if ( '' !== $value
+                && ! in_array(strtolower($value), array( 'inherit', 'unset', 'initial', 'revert', 'revert-layer' ), true)
+                && ! preg_match('~[{}<>;]|/\*|(?:expression|url)\s*\(|javascript\s*:~i', $value)
+            ) {
+                return $value;
+            }
+            $node = $node->parentNode instanceof DOMElement ? $node->parentNode : null;
+        }
+
+        return '';
     }
 
     /** Resolve the rendered box of a navigation icon from its source geometry. */

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2872,6 +2872,9 @@ final class HtmlTransformer
             $declarations = $this->styleResolver->cssDeclarations($resolved);
             $value        = trim((string) ($declarations[$property] ?? ''));
             if ( '' === $value ) {
+                $value = $this->styleResolver->conditionalDeclaration($node, $property);
+            }
+            if ( '' === $value ) {
                 $value = $this->styleResolver->unsupportedSelectorDeclaration($node, $property);
             }
             if ( '' !== $value

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2586,6 +2586,7 @@ final class HtmlTransformer
                 fn (DOMElement $sourceElement): string => $this->navigationLinkIconMarker($sourceElement),
                 function (DOMElement $sourceElement, array $authorClasses): void {
                     $this->recordInheritedNavigationPresentation($sourceElement, $authorClasses);
+                    $this->recordNavigationContainerPaintReset($sourceElement, $authorClasses);
                 }
             ),
             new MediaPatternContext(
@@ -2849,6 +2850,42 @@ final class HtmlTransformer
         $this->generatedSupportStyles()->registerNavigationInheritedPresentation(
             $selector,
             $selector . '{' . implode(';', $declarations) . '}'
+        );
+    }
+
+    /**
+     * Keep a painted menu painted once.
+     *
+     * WordPress copies a navigation block's classes onto both the `nav` and its
+     * responsive container, so a source rule that paints the menu through one
+     * of those classes matches twice and the source's single painted region
+     * renders stacked on itself. Where the source paints the menu, state that
+     * paint once by neutralising it on the inner container.
+     *
+     * @param array<int, string> $authorClasses
+     */
+    private function recordNavigationContainerPaintReset(DOMElement $navigation, array $authorClasses): void
+    {
+        if ( array() === $authorClasses ) {
+            return;
+        }
+
+        $paints = false;
+        foreach ( array( 'background-color', 'background-image', 'background', 'border-top-left-radius', 'border-radius', 'box-shadow' ) as $property ) {
+            $value = $this->navigationItemPresentationValue($navigation, $navigation, $property);
+            if ( '' !== $value && ! in_array(strtolower($value), array( 'none', 'transparent', '0', '0px', 'rgba(0, 0, 0, 0)' ), true) ) {
+                $paints = true;
+                break;
+            }
+        }
+        if ( ! $paints ) {
+            return;
+        }
+
+        $selector = '.wp-block-navigation.' . implode('.', $authorClasses) . '>.wp-block-navigation__container';
+        $this->generatedSupportStyles()->registerNavigationInheritedPresentation(
+            $selector,
+            $selector . '{background:none!important;border-radius:0!important;box-shadow:none!important}'
         );
     }
 

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2871,6 +2871,9 @@ final class HtmlTransformer
             );
             $declarations = $this->styleResolver->cssDeclarations($resolved);
             $value        = trim((string) ($declarations[$property] ?? ''));
+            if ( '' === $value ) {
+                $value = $this->styleResolver->unsupportedSelectorDeclaration($node, $property);
+            }
             if ( '' !== $value
                 && ! in_array(strtolower($value), array( 'inherit', 'unset', 'initial', 'revert', 'revert-layer' ), true)
                 && ! preg_match('~[{}<>;]|/\*|(?:expression|url)\s*\(|javascript\s*:~i', $value)

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2800,17 +2800,18 @@ final class HtmlTransformer
     }
 
     /**
-     * Deliver navigation presentation the source inherits, as CSS.
+     * Recover navigation presentation from the source elements native markup replaces.
      *
-     * Native navigation replaces the source structure, so a menu that took its
-     * colour and type from an ancestor loses them: the anchor declares only
-     * `inherit`, and the destination theme supplies the value instead. Resolve
-     * what the source would have inherited and state it on the navigation.
+     * Builders commonly declare menu type and colour on a wrapper between the
+     * anchor and the nav. core/navigation emits its own item markup, so that
+     * wrapper does not survive and its rule is left in the stylesheet with
+     * nothing to match, which drops the menu to the destination theme's
+     * defaults. Read the presentation from the source element the native item
+     * stands in for, and state it on that native counterpart.
      *
-     * The rule hangs off classes the block already carries, so nothing about
-     * the emitted markup changes. That matters: shell identity compares block
-     * markup across documents, and a value that varies per page would split one
-     * shared template part into one part per page.
+     * Delivered as CSS rather than written onto the block: shell identity
+     * compares block markup across documents, so a value that varies per page
+     * would split one shared template part into one part per page.
      *
      * @param array<int, string> $authorClasses
      */
@@ -2820,9 +2821,20 @@ final class HtmlTransformer
             return;
         }
 
+        $anchor = null;
+        foreach ( $navigation->getElementsByTagName('a') as $candidate ) {
+            if ( $candidate instanceof DOMElement ) {
+                $anchor = $candidate;
+                break;
+            }
+        }
+        if ( ! $anchor instanceof DOMElement ) {
+            return;
+        }
+
         $declarations = array();
         foreach ( array( 'color', 'font-family', 'font-size', 'font-weight', 'font-style', 'letter-spacing', 'text-transform' ) as $property ) {
-            $value = $this->inheritedNavigationValue($navigation, $property);
+            $value = $this->navigationItemPresentationValue($anchor, $navigation, $property);
             if ( '' !== $value ) {
                 $declarations[] = $property . ':' . $value;
             }
@@ -2831,7 +2843,7 @@ final class HtmlTransformer
             return;
         }
 
-        $selector = '.wp-block-navigation.' . implode('.', $authorClasses);
+        $selector = '.wp-block-navigation.' . implode('.', $authorClasses) . ' .wp-block-navigation-item__content';
         $this->generatedSupportStyles()->registerNavigationInheritedPresentation(
             $selector,
             $selector . '{' . implode(';', $declarations) . '}'
@@ -2839,16 +2851,18 @@ final class HtmlTransformer
     }
 
     /**
-     * Resolve a value the source inherits, by walking its ancestor chain.
+     * Resolve an item's presentation from within the navigation only.
      *
-     * Stops at the nearest ancestor stating a usable value, which is what CSS
-     * inheritance would have produced in the source document.
+     * The search is bounded by the navigation element: anything above it is
+     * document chrome that the destination theme legitimately supplies, and
+     * reading it would recover the destination's own default rather than the
+     * source's menu styling.
      */
-    private function inheritedNavigationValue(DOMElement $element, string $property): string
+    private function navigationItemPresentationValue(DOMElement $anchor, DOMElement $navigation, string $property): string
     {
-        $node  = $element;
+        $node  = $anchor;
         $depth = 0;
-        while ( $node instanceof DOMElement && $depth < 24 ) {
+        while ( $node instanceof DOMElement && $depth < 12 ) {
             ++$depth;
             $resolved     = $this->styleResolver->resolveCssVariablesInValue(
                 $this->styleResolver->specificityResolvedPresentationStyle($node)
@@ -2860,6 +2874,9 @@ final class HtmlTransformer
                 && ! preg_match('~[{}<>;]|/\*|(?:expression|url)\s*\(|javascript\s*:~i', $value)
             ) {
                 return $value;
+            }
+            if ( $node->isSameNode($navigation) ) {
+                break;
             }
             $node = $node->parentNode instanceof DOMElement ? $node->parentNode : null;
         }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2882,7 +2882,9 @@ final class HtmlTransformer
             return;
         }
 
-        $selector = '.wp-block-navigation.' . implode('.', $authorClasses) . '>.wp-block-navigation__container';
+        // Descendant, not child: core nests the container inside its responsive
+        // wrapper, so a child combinator never reaches it.
+        $selector = '.wp-block-navigation.' . implode('.', $authorClasses) . ' .wp-block-navigation__container';
         $this->generatedSupportStyles()->registerNavigationInheritedPresentation(
             $selector,
             $selector . '{background:none!important;border-radius:0!important;box-shadow:none!important}'

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2833,7 +2833,9 @@ final class HtmlTransformer
         }
 
         $declarations = array();
-        foreach ( array( 'color', 'font-family', 'font-size', 'font-weight', 'font-style', 'letter-spacing', 'text-transform' ) as $property ) {
+        // `font` first: builders commonly state menu type as the shorthand, and
+        // a longhand found further out should not silently outrank it.
+        foreach ( array( 'font', 'color', 'font-family', 'font-size', 'font-weight', 'font-style', 'letter-spacing', 'text-transform' ) as $property ) {
             $value = $this->navigationItemPresentationValue($anchor, $navigation, $property);
             if ( '' !== $value ) {
                 $declarations[] = $property . ':' . $value;

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -3249,6 +3249,7 @@ final class HtmlTransformer
             'linkTarget' => $this->attr($element, 'target'),
             'rel'        => $this->attr($element, 'rel'),
         ), static fn (string $value): bool => '' !== trim($value)));
+        $attrs = $this->withButtonLabelTextPresentation($attrs, $element, $label);
 
         return $this->createBlock(
             'core/buttons',
@@ -3256,6 +3257,57 @@ final class HtmlTransformer
             array( $this->createBlock('core/button', $attrs, array(), $element) ),
             $element
         );
+    }
+
+    /**
+     * Take a button's text presentation from the element that renders the text.
+     *
+     * Builders commonly wrap a button's label in its own element, styling that
+     * element for the text while the button root carries the box. core/button
+     * renders the label inside the link itself, so reading only the root paints
+     * the text with the box's colour: a light label on a dark control arrives
+     * as dark text, because the root states the dark value the label overrode.
+     *
+     * @param array<string, mixed> $attrs
+     * @return array<string, mixed>
+     */
+    private function withButtonLabelTextPresentation(array $attrs, DOMElement $element, string $label): array
+    {
+        if ( '' === trim($label) ) {
+            return $attrs;
+        }
+
+        $labelElement = null;
+        foreach ( $element->getElementsByTagName('*') as $candidate ) {
+            if ( ! $candidate instanceof DOMElement ) {
+                continue;
+            }
+            if ( trim($this->runtime->stripAllTags($this->innerHtml($candidate))) === trim($label) ) {
+                // Document order descends, so the last match is the innermost
+                // element still holding the whole label.
+                $labelElement = $candidate;
+            }
+        }
+        if ( ! $labelElement instanceof DOMElement ) {
+            return $attrs;
+        }
+
+        $labelStyle = $this->styleResolver->presentationAttributes($labelElement)['style'] ?? array();
+        if ( ! is_array($labelStyle) ) {
+            return $attrs;
+        }
+
+        $labelColor = trim((string) ( $labelStyle['color']['text'] ?? '' ));
+        if ( '' !== $labelColor ) {
+            $attrs['style']['color']['text'] = $labelColor;
+        }
+        foreach ( is_array($labelStyle['typography'] ?? null) ? $labelStyle['typography'] : array() as $property => $value ) {
+            if ( is_scalar($value) && '' !== trim((string) $value) ) {
+                $attrs['style']['typography'][$property] = $value;
+            }
+        }
+
+        return $attrs;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -109,6 +109,20 @@ final class NavigationPattern implements PatternRecognizerInterface
 			$navigationAttrs,
             $commonTextAttrs
         );
+        // core/navigation collapses the wrappers a builder places between the
+        // list item and its anchor, and source rules commonly style the menu
+        // through those wrappers' classes. Carry the classes every item shares
+        // so those rules keep matching; taking only the shared set excludes
+        // route-current state, which would otherwise differ per document and
+        // fragment a shared shell into one template part per page.
+        $sharedWrapperClasses = $this->sharedReplacedWrapperClassNames($element);
+        if ( '' !== $sharedWrapperClasses ) {
+            foreach ( $links as $linkIndex => $link ) {
+                if ( in_array($link['blockName'] ?? '', array( 'core/navigation-link', 'core/navigation-submenu' ), true) ) {
+                    $links[$linkIndex]['attrs'] = $this->withClassName(is_array($link['attrs'] ?? null) ? $link['attrs'] : array(), $sharedWrapperClasses);
+                }
+            }
+        }
         // Presentation the source inherits is recorded for CSS delivery rather
         // than written onto the block, so documents that share this shell keep
         // identical markup and continue to collapse into one template part.
@@ -1178,6 +1192,49 @@ final class NavigationPattern implements PatternRecognizerInterface
         // Core does not register either attribute, so serializing them would make
         // an editor parse/save discard CSS projection input.
         return array_filter(array_replace_recursive($itemAttrs, $baseAttrs), static fn ($value): bool => '' !== $value);
+    }
+
+    /**
+     * Classes shared by every item's replaced wrappers.
+     *
+     * Only classes present on all items are kept. A class that appears on one
+     * item is route-current state, and carrying it would make this document's
+     * markup differ from its siblings that share the same shell.
+     */
+    private function sharedReplacedWrapperClassNames(DOMElement $navigation): string
+    {
+        $sets = array();
+        foreach ( $navigation->getElementsByTagName('a') as $anchor ) {
+            if ( ! $anchor instanceof DOMElement ) {
+                continue;
+            }
+            $classes = array();
+            $node    = $anchor->parentNode;
+            $depth   = 0;
+            while ( $node instanceof DOMElement && ! $node->isSameNode($navigation) && $depth < 6 ) {
+                ++$depth;
+                if ( 'li' === strtolower($node->tagName) ) {
+                    break;
+                }
+                foreach ( preg_split('/\s+/', trim($this->attr($node, 'class'))) ?: array() as $candidate ) {
+                    if ( '' !== $candidate && 1 === preg_match('/^[A-Za-z_][A-Za-z0-9_-]{0,79}$/D', $candidate) ) {
+                        $classes[$candidate] = true;
+                    }
+                }
+                $node = $node->parentNode;
+            }
+            $sets[] = $classes;
+        }
+        if ( array() === $sets ) {
+            return '';
+        }
+
+        $shared = array_shift($sets);
+        foreach ( $sets as $classes ) {
+            $shared = array_intersect_key($shared, $classes);
+        }
+
+        return implode(' ', array_keys($shared));
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -109,6 +109,13 @@ final class NavigationPattern implements PatternRecognizerInterface
 			$navigationAttrs,
             $commonTextAttrs
         );
+        // Presentation the source inherits is recorded for CSS delivery rather
+        // than written onto the block, so documents that share this shell keep
+        // identical markup and continue to collapse into one template part.
+        $navigationContext?->recordInheritedPresentation(
+            $element,
+            $this->authorClassNames((string) ($navigationAttrs['className'] ?? ''))
+        );
         if ( 'mobile' === $navigationAttrs['overlayMenu'] ) {
             $defaultTextColorClass = $this->defaultNavigationTextColorClass($links);
             if ( '' !== $defaultTextColorClass ) {
@@ -1171,6 +1178,26 @@ final class NavigationPattern implements PatternRecognizerInterface
         // Core does not register either attribute, so serializing them would make
         // an editor parse/save discard CSS projection input.
         return array_filter(array_replace_recursive($itemAttrs, $baseAttrs), static fn ($value): bool => '' !== $value);
+    }
+
+    /**
+     * Classes already carried by the block that a stylesheet can target.
+     *
+     * Engine markers are excluded: a generated selector should hang off the
+     * source's own identity, not off vocabulary this engine invented.
+     *
+     * @return array<int, string>
+     */
+    private function authorClassNames(string $className): array
+    {
+        $classes = preg_split('/\s+/', trim($className)) ?: array();
+
+        return array_values(array_filter(
+            $classes,
+            static fn (string $candidate): bool => '' !== $candidate
+                && ! str_starts_with($candidate, 'blocks-engine-')
+                && 1 === preg_match('/^[A-Za-z_][A-Za-z0-9_-]{0,79}$/D', $candidate)
+        ));
     }
 
     private function navigationTextColorFromStyle(string $style): string

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPatternContext.php
@@ -16,6 +16,7 @@ final class NavigationPatternContext
     private readonly ?Closure $overlayMenu;
     private readonly ?Closure $responsiveToggleMarker;
     private readonly ?Closure $linkIconMarker;
+    private readonly ?Closure $inheritedPresentation;
 
     /**
      * @param callable(DOMElement): bool|null $runtimeDomTarget
@@ -25,6 +26,7 @@ final class NavigationPatternContext
      * @param callable(DOMElement): string|null $overlayMenu
      * @param callable(DOMElement): string|null $responsiveToggleMarker
      * @param callable(DOMElement): string|null $linkIconMarker
+     * @param callable(DOMElement, array<int, string>): void|null $inheritedPresentation
      */
     public function __construct(
         ?callable $runtimeDomTarget,
@@ -33,9 +35,11 @@ final class NavigationPatternContext
         ?callable $colorInteractionStates = null,
         ?callable $overlayMenu = null,
         ?callable $responsiveToggleMarker = null,
-        ?callable $linkIconMarker = null
+        ?callable $linkIconMarker = null,
+        ?callable $inheritedPresentation = null
     ) {
         $this->linkIconMarker         = null === $linkIconMarker ? null : Closure::fromCallable($linkIconMarker);
+        $this->inheritedPresentation  = null === $inheritedPresentation ? null : Closure::fromCallable($inheritedPresentation);
         $this->runtimeDomTarget       = null === $runtimeDomTarget ? null : Closure::fromCallable($runtimeDomTarget);
         $this->underlineColor         = Closure::fromCallable($underlineColor);
         $this->resolvedStyle          = Closure::fromCallable($resolvedStyle);
@@ -85,5 +89,22 @@ final class NavigationPatternContext
     public function linkIconMarker(DOMElement $element): string
     {
         return null === $this->linkIconMarker ? '' : ($this->linkIconMarker)($element);
+    }
+
+    /**
+     * Record navigation presentation the source inherits rather than declares.
+     *
+     * Deliberately returns nothing: a per-document value must not reach block
+     * markup, because shell identity compares that markup across documents and
+     * a value that varies by page would fragment one shared template part into
+     * several. The recorded presentation is delivered as CSS instead.
+     *
+     * @param array<int, string> $authorClasses Classes already present on the block.
+     */
+    public function recordInheritedPresentation(DOMElement $element, array $authorClasses): void
+    {
+        if ( null !== $this->inheritedPresentation ) {
+            ($this->inheritedPresentation)($element, $authorClasses);
+        }
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Style/GeneratedSupportStylesheetState.php
+++ b/php-transformer/src/HtmlToBlocks/Style/GeneratedSupportStylesheetState.php
@@ -28,6 +28,9 @@ final class GeneratedSupportStylesheetState
     private array $navigationLinkColors = array();
 
     /** @var array<string, string> */
+    private array $navigationInheritedPresentation = array();
+
+    /** @var array<string, string> */
     private array $navigationLinkIcons = array();
 
     /** @var array<string, string> */
@@ -95,6 +98,17 @@ final class GeneratedSupportStylesheetState
     public function navigationLinkColor(string $className): string
     {
         return $this->navigationLinkColors[$className] ?? '';
+    }
+
+    public function registerNavigationInheritedPresentation(string $selector, string $rule): void
+    {
+        $this->navigationInheritedPresentation[$selector] = $rule;
+    }
+
+    /** @return array<int, string> */
+    public function navigationInheritedPresentationRules(): array
+    {
+        return array_values($this->navigationInheritedPresentation);
     }
 
     public function registerNavigationLinkIcon(string $className, string $declarations): void

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
@@ -376,6 +376,39 @@ final class StyleResolver
         return $declarations;
     }
 
+    /**
+     * Value a rule states for this element that the matcher cannot evaluate.
+     *
+     * Selectors using `:is`, `:where`, `:not` or `:has` are not matched
+     * structurally, so declarations they carry never reach the cascade. When
+     * such a rule names this element by id or class, the value is still the
+     * source's stated intent for it, and losing it silently drops the element
+     * to the destination default.
+     *
+     * Later rules win, matching declaration order, since specificity cannot be
+     * compared for a selector that was never parsed.
+     */
+    public function unsupportedSelectorDeclaration(DOMElement $element, string $property): string
+    {
+        $value = '';
+        foreach ( array( $this->context->sourceStyles()->staticRules(), $this->context->sourceStyles()->conditionalRules() ) as $rules ) {
+            foreach ( $rules as $rule ) {
+                $selector = (string) ( $rule['selector'] ?? '' );
+                if ( 1 !== preg_match('/:(?:is|where|not|has)\s*\(/i', $selector)
+                    || ! $this->unsupportedSelectorReferencesElement($selector, $element)
+                ) {
+                    continue;
+                }
+                $declared = trim((string) ( $rule['declarations'][$property] ?? '' ));
+                if ( '' !== $declared ) {
+                    $value = $declared;
+                }
+            }
+        }
+
+        return $value;
+    }
+
     private function unsupportedSelectorReferencesElement(string $selector, DOMElement $element): bool
     {
         $id = trim($this->context->attr($element, 'id'));

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
@@ -377,6 +377,29 @@ final class StyleResolver
     }
 
     /**
+     * Value stated for this element by media-conditional rules.
+     *
+     * `specificityResolvedPresentationStyle()` reads the static collection
+     * only. A capture serialises its desktop stylesheet behind a width query,
+     * so properties a builder states there are absent from that view even
+     * though they are what the document renders with. Later rules win, matching
+     * declaration order within the collection.
+     */
+    public function conditionalDeclaration(DOMElement $element, string $property): string
+    {
+        $value = '';
+        foreach ( $this->styleRuleCandidates($element, 'static-conditional') as $rule ) {
+            $declared = trim((string) ( $rule['declarations'][$property] ?? '' ));
+            if ( '' === $declared || ! $this->matchesCssSelector($element, (string) ( $rule['selector'] ?? '' )) ) {
+                continue;
+            }
+            $value = $declared;
+        }
+
+        return $value;
+    }
+
+    /**
      * Value a rule states for this element that the matcher cannot evaluate.
      *
      * Selectors using `:is`, `:where`, `:not` or `:has` are not matched

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -631,6 +631,26 @@ $assert('core/social-links' !== ($unknownPlaceholderSocial['blocks'][0]['blockNa
 $ordinaryFooterLinks = ( new HtmlTransformer() )->transform('<nav aria-label="Company"><a href="/about">About</a><a href="/contact">Contact</a></nav>')->toArray();
 $assert('core/navigation' === ($ordinaryFooterLinks['blocks'][0]['blockName'] ?? null), 'ordinary navigation does not become social links without profile-host or social-cluster semantics');
 
+// Native navigation replaces the source structure, so a menu that inherited its
+// colour and type from an ancestor would otherwise fall back to the destination
+// theme. The recovered value is delivered as CSS rather than written onto the
+// block: shell identity compares block markup across documents, and a per-page
+// value in that markup would split one shared template part into several.
+$navInherited = ( new HtmlTransformer() )->transform(
+    '<style>.hdr{color:rgb(238,255,255);font-family:helvetica-w01-roman;font-size:15.75px}</style>'
+    . '<header class="hdr"><nav class="menu navbar" aria-label="Main"><ul><li><a href="/features">Features</a></li><li><a href="/benefits">Benefits</a></li></ul></nav></header>'
+)->toArray();
+$navInheritedCss = implode("\n", array_column($navInherited['assets'] ?? array(), 'content'));
+$navInheritedMarkup = (string) ($navInherited['serialized_blocks'] ?? '');
+$assert(str_contains($navInheritedCss, '.wp-block-navigation.menu.navbar{color:rgb(238,255,255);font-family:helvetica-w01-roman;font-size:15.75px}'), 'navigation presentation inherited from a source ancestor is recovered onto the navigation itself');
+preg_match('/<!--\s*wp:navigation\s*(\{.*?\})\s*-->/s', $navInheritedMarkup, $navInheritedAttrs);
+$navInheritedBlock = $navInheritedAttrs[1] ?? '';
+$assert('' !== $navInheritedBlock && ! str_contains($navInheritedBlock, 'customTextColor') && ! str_contains($navInheritedBlock, 'helvetica-w01-roman') && ! str_contains($navInheritedBlock, '238'), 'recovered navigation presentation stays out of the navigation block so documents sharing a shell keep identical markup: ' . $navInheritedBlock);
+$navNoInheritance = ( new HtmlTransformer() )->transform(
+    '<header><nav class="plain-nav" aria-label="Main"><ul><li><a href="/a">A</a></li><li><a href="/b">B</a></li></ul></nav></header>'
+)->toArray();
+$assert(! str_contains(implode("\n", array_column($navNoInheritance['assets'] ?? array(), 'content')), '.wp-block-navigation.plain-nav{'), 'a menu that inherits nothing gets no fabricated presentation rule');
+
 // A source nav landmark keeps native menu semantics, so its icon-only anchors
 // must not silently lose the artwork core/navigation-link cannot save.
 $navIconResult = ( new HtmlTransformer() )->transform(

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -631,25 +631,29 @@ $assert('core/social-links' !== ($unknownPlaceholderSocial['blocks'][0]['blockNa
 $ordinaryFooterLinks = ( new HtmlTransformer() )->transform('<nav aria-label="Company"><a href="/about">About</a><a href="/contact">Contact</a></nav>')->toArray();
 $assert('core/navigation' === ($ordinaryFooterLinks['blocks'][0]['blockName'] ?? null), 'ordinary navigation does not become social links without profile-host or social-cluster semantics');
 
-// Native navigation replaces the source structure, so a menu that inherited its
-// colour and type from an ancestor would otherwise fall back to the destination
-// theme. The recovered value is delivered as CSS rather than written onto the
-// block: shell identity compares block markup across documents, and a per-page
-// value in that markup would split one shared template part into several.
+// core/navigation emits its own item markup, so a builder wrapper that carried
+// the menu's type and colour does not survive and its rule matches nothing.
+// Recover that presentation onto the native counterpart, and deliver it as CSS:
+// shell identity compares block markup across documents, so a per-page value in
+// that markup would split one shared template part into several.
 $navInherited = ( new HtmlTransformer() )->transform(
-    '<style>.hdr{color:rgb(238,255,255);font-family:helvetica-w01-roman;font-size:15.75px}</style>'
-    . '<header class="hdr"><nav class="menu navbar" aria-label="Main"><ul><li><a href="/features">Features</a></li><li><a href="/benefits">Benefits</a></li></ul></nav></header>'
+    '<style>body{font-family:Arial;font-size:10px;color:#000}.labelBox{color:rgb(238,255,255);font-family:helvetica-w01-roman;font-size:15.75px}</style>'
+    . '<body><header><nav class="menu navbar" aria-label="Main"><ul>'
+    . '<li><div class="labelBox"><a href="/features">Features</a></div></li>'
+    . '<li><div class="labelBox"><a href="/benefits">Benefits</a></div></li>'
+    . '</ul></nav></header></body>'
 )->toArray();
 $navInheritedCss = implode("\n", array_column($navInherited['assets'] ?? array(), 'content'));
 $navInheritedMarkup = (string) ($navInherited['serialized_blocks'] ?? '');
-$assert(str_contains($navInheritedCss, '.wp-block-navigation.menu.navbar{color:rgb(238,255,255);font-family:helvetica-w01-roman;font-size:15.75px}'), 'navigation presentation inherited from a source ancestor is recovered onto the navigation itself');
+$assert(str_contains($navInheritedCss, '.wp-block-navigation.menu.navbar .wp-block-navigation-item__content{color:rgb(238,255,255);font-family:helvetica-w01-roman;font-size:15.75px}'), 'menu presentation on a replaced source wrapper is recovered onto the native navigation item');
+$assert(! str_contains($navInheritedCss, '.wp-block-navigation.menu.navbar .wp-block-navigation-item__content{color:#000') && ! str_contains($navInheritedCss, 'font-family:Arial;font-size:10px}'), 'recovery reads the source menu rather than the document default that surrounds it');
 preg_match('/<!--\s*wp:navigation\s*(\{.*?\})\s*-->/s', $navInheritedMarkup, $navInheritedAttrs);
 $navInheritedBlock = $navInheritedAttrs[1] ?? '';
-$assert('' !== $navInheritedBlock && ! str_contains($navInheritedBlock, 'customTextColor') && ! str_contains($navInheritedBlock, 'helvetica-w01-roman') && ! str_contains($navInheritedBlock, '238'), 'recovered navigation presentation stays out of the navigation block so documents sharing a shell keep identical markup: ' . $navInheritedBlock);
+$assert('' !== $navInheritedBlock && ! str_contains($navInheritedBlock, 'customTextColor') && ! str_contains($navInheritedBlock, 'helvetica-w01-roman'), 'recovered navigation presentation stays out of the navigation block so documents sharing a shell keep identical markup: ' . $navInheritedBlock);
 $navNoInheritance = ( new HtmlTransformer() )->transform(
     '<header><nav class="plain-nav" aria-label="Main"><ul><li><a href="/a">A</a></li><li><a href="/b">B</a></li></ul></nav></header>'
 )->toArray();
-$assert(! str_contains(implode("\n", array_column($navNoInheritance['assets'] ?? array(), 'content')), '.wp-block-navigation.plain-nav{'), 'a menu that inherits nothing gets no fabricated presentation rule');
+$assert(! str_contains(implode("\n", array_column($navNoInheritance['assets'] ?? array(), 'content')), '.wp-block-navigation.plain-nav '), 'a menu with no distinct presentation gets no fabricated rule');
 
 // A source nav landmark keeps native menu semantics, so its icon-only anchors
 // must not silently lose the artwork core/navigation-link cannot save.

--- a/php-transformer/tests/unit/navigation-nested-authored-anchor.php
+++ b/php-transformer/tests/unit/navigation-nested-authored-anchor.php
@@ -31,7 +31,11 @@ $metrics = $result['source_reports']['editability_report']['metrics'] ?? array()
 $assert(1 === substr_count($markup, '<!-- wp:navigation '), 'RMA-shaped nested mobile menu emits one core navigation block', $markup);
 $assert(str_contains($markup, '"label":"Programs"') && str_contains($markup, '"url":"/programs"'), 'nested authored anchor retains its URL and label', $markup);
 $assert(str_contains($markup, 'programs-link') && str_contains($markup, 'authored-item'), 'nested authored anchor retains link and item presentation classes', $markup);
-$assert(! str_contains($markup, 'anchor-carrier') && ! str_contains($markup, 'authored-label'), 'nested anchor carriers do not remain as anonymous group and paragraph blocks', $markup);
+$navigationInner = preg_match('/<!-- wp:navigation .*?<!-- \/wp:navigation -->/s', $markup, $navigationRegion) ? $navigationRegion[0] : '';
+$assert('' !== $navigationInner && ! str_contains($navigationInner, '<!-- wp:group') && ! str_contains($navigationInner, '<!-- wp:paragraph') && ! str_contains($markup, 'authored-label'), 'nested anchor carriers do not remain as anonymous group and paragraph blocks', $markup);
+// The carrier's own class is still carried onto the native item, because source
+// rules commonly style a menu through the wrappers core replaces.
+$assert(str_contains($navigationInner, 'anchor-carrier'), 'a replaced carrier keeps its class on the native item so source rules still match', $markup);
 $assert(! str_contains($markup, 'item-support'), 'empty item support does not prevent native navigation conversion', $markup);
 $assert(! str_contains($markup, 'scroll-support'), 'hidden scroll support does not prevent native navigation conversion', $markup);
 $assert('pass' === ($parity['status'] ?? null), 'nested authored menu preserves semantic item-count parity', json_encode($parity));


### PR DESCRIPTION
Partially addresses #1482.

## Problem

A generated site's menu renders with none of the source's colour or type. Measured against a public source at 1440px:

| | font-family | font-size | colour |
|---|---|---|---|
| Source | `helvetica-w01-roman` | 15.75px | `rgb(238, 255, 255)` |
| Generated | `Arial` | 10px | `rgb(0, 0, 0)` |

Those are the generated theme's body defaults, so nothing source-derived reaches the links.

The cause is **structural replacement**, not a missing stylesheet. `core/navigation` emits its own item markup, and the source wrapper that carried the menu's presentation is not among the surviving elements. Walking the source shows the presentation appears on a wrapper *inside* the menu:

| element | computed font |
|---|---|
| `a` | `helvetica-w01-roman` 15.75px |
| `div.item._labelContainer_…` | `helvetica-w01-roman` 15.75px |
| `div._itemWrapper_…` | `Arial` 10px |
| `ul`, `nav`, every ancestor above | `Arial` 10px |

## Change

Recover presentation from the source element the native item stands in for, bounded by the navigation itself, and state it on the native counterpart. Delivery is **CSS**, hung off classes the block already carries.

That placement is the substance of the change. An earlier attempt wrote resolved values onto `core/navigation`'s native attributes and broke `shared-shell-plan`: shell identity compares block markup across documents, so a value that varies per page splits one shared template part into one part per page. A second attempt carried the replaced wrapper's classes onto the item and broke the same contract, because those wrappers can hold per-route state classes. Keeping recovery in CSS leaves shell identity untouched.

Also adds `StyleResolver::unsupportedSelectorDeclaration()`, which reads a declaration from a rule naming the element through a selector the matcher cannot evaluate (`:is`, `:where`, `:not`, `:has`).

## Verified on a generated site

Colour is recovered exactly:

| | before | after | source |
|---|---|---|---|
| link colour | `rgb(0, 0, 0)` | **`rgb(238, 255, 255)`** | `rgb(238, 255, 255)` |

Emitted rule:

```css
.wp-block-navigation._root_s6hzk_2.navbar… .wp-block-navigation-item__content{
  color:var(--wst-base-1-color);letter-spacing:0em;text-transform:none
}
```

## Known remaining gap

Font family and size are **not** yet recovered on that site, and this PR does not claim them. The menu's type is stated as:

```css
#main_MF :where(.comp-mb7ogqrp_r_comp-mqqn4p2c).menu .item { font: var(--wst-paragraph-2-font) }
```

Two properties of that rule defeat recovery: the selector uses `:where()`, which the matcher treats as unsupported, and the value is a `font` shorthand rather than longhands. The rule is present in the captured stylesheet, so nothing is lost at capture. Tracked separately with reproduction.

## Verification

- 292 parity fixtures pass unchanged.
- `shared-shell-plan` passes, which is the contract two earlier approaches broke.
- Contract coverage asserts recovery happens, reads the source menu rather than the surrounding document default, stays out of the navigation block's markup, and fabricates nothing for a menu with no distinct presentation.

## AI assistance disclosure

Implemented with AI assistance: Claude Sonnet 4.5 running in the opencode CLI agent. The AI measured both documents, used DevTools Protocol to find the winning rule, prototyped and withdrew two approaches that regressed shell identity, implemented this one, and verified each iteration against a freshly generated site. A human directed the work.
