### PR TITLE
Give the runtime selector vocabulary one owner

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -87,6 +87,7 @@
       "php tests/unit/subtree-classifier.php",
       "php tests/unit/source-element-classifier.php",
       "php tests/unit/source-dom.php",
+      "php tests/unit/runtime-selector-vocabulary.php",
       "php tests/unit/custom-block-generator.php",
       "php tests/unit/description-list-block.php",
       "php tests/unit/css-value-splitter.php",

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
 
+use Automattic\BlocksEngine\PhpTransformer\Support\RuntimeSelectorVocabulary;
 use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\CssUrlRewriter;
 use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\ReferenceAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionReportProjection;
@@ -46,7 +47,6 @@ final class ArtifactCompiler
      *
      * @var array<int, string>
      */
-    private const RUNTIME_TAG_SELECTORS = array( 'button', 'input', 'select', 'textarea', 'ul', 'ol', 'li' );
 
 	/** @var array<string, string> */
 	private array $themeStaticCssCache = array();
@@ -3485,49 +3485,15 @@ final class ArtifactCompiler
      */
     private function dataAttributeSelectorsFromCssSelector(string $selector): array
     {
-        $selectors = array();
-        if ( preg_match_all('/(?:^|[\s>+~,])([a-z][a-z0-9-]*)?\[(data-[A-Za-z][A-Za-z0-9_-]*)(?:\s*[*^$|~]?=\s*(?:"[^"]{0,120}"|\'[^\']{0,120}\'|[^\]\s"\']{1,120}))?\]/', $selector, $matches, PREG_SET_ORDER) ) {
-            foreach ( $matches as $match ) {
-                $selector = strtolower((string) ($match[1] ?? '')) . '[' . strtolower((string) $match[2]) . ']';
-                if ( ! $this->isPresentationalRuntimeSelector($selector) ) {
-                    $selectors[$selector] = true;
-                }
-            }
-        }
-        if ( preg_match_all('/\[(data-[A-Za-z][A-Za-z0-9_-]*)(?:\s*[*^$|~]?=\s*(?:"[^"]{0,120}"|\'[^\']{0,120}\'|[^\]\s"\']{1,120}))?\]/', $selector, $matches) ) {
-            foreach ( $matches[1] as $attribute ) {
-                $selector = '[' . strtolower((string) $attribute) . ']';
-                if ( ! $this->isPresentationalRuntimeSelector($selector) ) {
-                    $selectors[$selector] = true;
-                }
-            }
-        }
-
-        return array_keys($selectors);
+        return RuntimeSelectorVocabulary::dataAttributeSelectorsFromCssSelector($selector);
     }
 
     private function isPresentationalRuntimeSelector(string $selector): bool
+
     {
-        $name = '';
-        if ( preg_match('/\[(data-[A-Za-z][A-Za-z0-9_-]*)/', $selector, $match) ) {
-            $name = substr(strtolower((string) $match[1]), 5);
-        } elseif ( preg_match('/^(?:[a-z][a-z0-9-]*\.|\.)([A-Za-z][A-Za-z0-9_-]*)$/', $selector, $match) ) {
-            $name = strtolower((string) $match[1]);
-        } elseif ( preg_match('/^#([A-Za-z][A-Za-z0-9_-]*)$/', $selector, $match) ) {
-            $name = strtolower((string) $match[1]);
-        }
 
-        if ( '' === $name ) {
-            return false;
-        }
+        return RuntimeSelectorVocabulary::isPresentationalAnimation($selector);
 
-        foreach ( preg_split('/[^a-z0-9]+/', $name) ?: array() as $token ) {
-            if ( in_array($token, array( 'animate', 'animation', 'appear', 'count', 'counter', 'delay', 'fade', 'motion', 'parallax', 'reveal', 'scroll', 'stagger', 'transition' ), true) ) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**
@@ -3580,9 +3546,11 @@ final class ArtifactCompiler
     }
 
     private function scriptSelectorPattern(): string
+
     {
-        $name = '[A-Za-z][A-Za-z0-9_-]*';
-        return '(?:[#.]' . $name . '|' . $name . '\\.' . $name . '|\\[data-' . $name . '(?:=["\'][^"\']{1,80}["\'])?\\]|' . $name . '\\[data-' . $name . '(?:=["\'][^"\']{1,80}["\'])?\\]|canvas|svg|' . implode('|', self::RUNTIME_TAG_SELECTORS) . ')';
+
+        return RuntimeSelectorVocabulary::scriptSelectorPattern();
+
     }
 
     private function canonicalRuntimeSelector(string $selector): string

--- a/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
 
+use Automattic\BlocksEngine\PhpTransformer\Support\RuntimeSelectorVocabulary;
 use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionFindingContract;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
 use Automattic\BlocksEngine\PhpTransformer\Support\DeterministicRowDeduplicator;
@@ -18,7 +19,6 @@ final class RuntimeDependencyParityReport
      *
      * @var array<int, string>
      */
-    private const RUNTIME_TAG_SELECTORS = array( 'button', 'input', 'select', 'textarea', 'ul', 'ol', 'li' );
 
     /**
      * Acceptable disposition for a missing-DOM-target finding whose selector the
@@ -582,7 +582,7 @@ final class RuntimeDependencyParityReport
                 $targets[$selector] = array_filter(array('tag' => $tag, 'source_path' => $sourcePath, 'attribute' => $attribute, 'src' => $src), static fn (string $value): bool => '' !== $value);
                 $targets[$tag . $selector] = array_filter(array('tag' => $tag, 'source_path' => $sourcePath, 'attribute' => $attribute, 'src' => $src), static fn (string $value): bool => '' !== $value);
             }
-            if ( in_array($tag, array_merge(array('canvas', 'svg'), self::RUNTIME_TAG_SELECTORS), true) ) {
+            if ( in_array($tag, array_merge(array('canvas', 'svg'), RuntimeSelectorVocabulary::RUNTIME_TAG_SELECTORS), true) ) {
                 $targets[$tag] = array_filter(array('tag' => $tag, 'source_path' => $sourcePath, 'src' => $src), static fn (string $value): bool => '' !== $value);
             }
         }
@@ -672,7 +672,7 @@ final class RuntimeDependencyParityReport
                         $targets['selectors'][$tag . $selector] = true;
                     }
                 }
-                if ( in_array($tag, array_merge(array('canvas', 'svg'), self::RUNTIME_TAG_SELECTORS), true) ) {
+                if ( in_array($tag, array_merge(array('canvas', 'svg'), RuntimeSelectorVocabulary::RUNTIME_TAG_SELECTORS), true) ) {
                     $targets['selectors'][$tag] = true;
                 }
             }
@@ -823,97 +823,17 @@ final class RuntimeDependencyParityReport
     /**
      * @return array<int, string>
      */
-    private function scriptDataAttributeSelectors(string $script): array
-    {
-        $selectors = array();
-        if ( ! preg_match_all('/(?:querySelector(?:All)?|closest)\s*\(\s*(["\'`])(.{1,240}?)\1\s*\)/s', $script, $calls, PREG_SET_ORDER) ) {
-            return array();
-        }
-
-        foreach ( $calls as $call ) {
-            foreach ( $this->dataAttributeSelectorsFromCssSelector((string) $call[2]) as $selector ) {
-                $selectors[$selector] = true;
-            }
-        }
-
-        return array_keys($selectors);
-    }
-
-    /**
-     * @return array<int, string>
-     */
     private function dataAttributeSelectorsFromCssSelector(string $selector): array
     {
-        $selectors = array();
-        if ( preg_match_all('/(?:^|[\s>+~,])([a-z][a-z0-9-]*)?\[(data-[A-Za-z][A-Za-z0-9_-]*)(?:\s*[*^$|~]?=\s*(?:"[^"]{0,120}"|\'[^\']{0,120}\'|[^\]\s"\']{1,120}))?\]/', $selector, $matches, PREG_SET_ORDER) ) {
-            foreach ( $matches as $match ) {
-                $selector = strtolower((string) ($match[1] ?? '')) . '[' . strtolower((string) $match[2]) . ']';
-                if ( ! $this->isPresentationalRuntimeSelector($selector) ) {
-                    $selectors[$selector] = true;
-                }
-            }
-        }
-        if ( preg_match_all('/\[(data-[A-Za-z][A-Za-z0-9_-]*)(?:\s*[*^$|~]?=\s*(?:"[^"]{0,120}"|\'[^\']{0,120}\'|[^\]\s"\']{1,120}))?\]/', $selector, $matches) ) {
-            foreach ( $matches[1] as $attribute ) {
-                $selector = '[' . strtolower((string) $attribute) . ']';
-                if ( ! $this->isPresentationalRuntimeSelector($selector) ) {
-                    $selectors[$selector] = true;
-                }
-            }
-        }
-
-        return array_keys($selectors);
+        return RuntimeSelectorVocabulary::dataAttributeSelectorsFromCssSelector($selector);
     }
 
     private function isPresentationalRuntimeSelector(string $selector): bool
+
     {
-        $name = '';
-        if ( preg_match('/\[(data-[A-Za-z][A-Za-z0-9_-]*)/', $selector, $match) ) {
-            $name = substr(strtolower((string) $match[1]), 5);
-        } elseif ( preg_match('/^(?:[a-z][a-z0-9-]*\.|\.)([A-Za-z][A-Za-z0-9_-]*)$/', $selector, $match) ) {
-            $name = strtolower((string) $match[1]);
-        } elseif ( preg_match('/^#([A-Za-z][A-Za-z0-9_-]*)$/', $selector, $match) ) {
-            $name = strtolower((string) $match[1]);
-        }
 
-        if ( '' === $name ) {
-            return false;
-        }
+        return RuntimeSelectorVocabulary::isPresentationalAnimation($selector);
 
-        foreach ( preg_split('/[^a-z0-9]+/', $name) ?: array() as $token ) {
-            if ( in_array($token, array( 'animate', 'animation', 'appear', 'count', 'counter', 'delay', 'fade', 'motion', 'parallax', 'reveal', 'scroll', 'stagger', 'transition' ), true) ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function isPresentationOnlyScriptSelector(string $script, string $selector): bool
-    {
-        if ( ! $this->isPresentationalRuntimeSelector($selector) ) {
-            return false;
-        }
-
-        $selectorPattern = preg_quote($selector, '/');
-        if ( preg_match_all('/\b(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(?:(?:document|[A-Za-z_$][A-Za-z0-9_$]*)\s*\.\s*)?querySelector(?:All)?\s*\(\s*(["\'])' . $selectorPattern . '\2\s*\)/', $script, $assignments, PREG_SET_ORDER) ) {
-            foreach ($assignments as $assignment) {
-                if (preg_match('/\b' . preg_quote((string) $assignment[1], '/') . '\s*\.\s*(?:addEventListener|appendChild|removeChild|replaceChildren|insertAdjacentHTML|setAttribute|removeAttribute|toggleAttribute|getContext|submit|fetch)\b|\b' . preg_quote((string) $assignment[1], '/') . '\s*\.\s*(?:textContent|innerHTML|outerHTML|value|checked|selectedIndex|hidden|disabled|style|dataset)\b/', $script)) {
-                    return false;
-                }
-            }
-        }
-        if ( ! preg_match_all('/querySelector(?:All)?\s*\(\s*(["\'])' . $selectorPattern . '\1\s*\)([^;]{0,700})/', $script, $matches) ) {
-            return false;
-        }
-
-        foreach ( $matches[2] as $tail ) {
-            if ( preg_match('/\b(?:addEventListener|appendChild|removeChild|replaceChildren|insertAdjacentHTML|innerHTML|outerHTML|textContent|value|checked|selectedIndex|setAttribute|removeAttribute|toggleAttribute|getContext|submit|fetch)\b|\.\s*(?:classList|hidden|disabled|style|dataset)\b/', (string) $tail) ) {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     /**
@@ -933,154 +853,12 @@ final class RuntimeDependencyParityReport
         return '' !== $src && $src === $this->normalizeScriptPath($scriptPath);
     }
 
-    /**
-     * @return array<string, bool>
-     */
-    private function scriptControlRuntimeSelectors(string $script): array
-    {
-        $selectors = array();
-        $runtimeUsePattern = '\.\s*(?:addEventListener|value|checked|selectedIndex|selectedOptions|options|files|validity|setCustomValidity|focus|select|click|dispatchEvent)\b';
-
-        if ( preg_match_all('/document\s*\.\s*getElementById\s*\(\s*(["\'])([A-Za-z][A-Za-z0-9_-]*)\1\s*\)\s*(?:\.\s*[^;\n]*)?' . $runtimeUsePattern . '/', $script, $matches) ) {
-            foreach ( $matches[2] as $id ) {
-                $selectors['#' . (string) $id] = true;
-            }
-        }
-        if ( preg_match_all('/document\s*\.\s*querySelector(?:All)?\s*\(\s*(["\'])(' . $this->scriptSelectorPattern() . ')\1\s*\)\s*(?:\.\s*[^;\n]*)?' . $runtimeUsePattern . '/', $script, $matches) ) {
-            foreach ( $matches[2] as $selector ) {
-                $selectors[(string) $selector] = true;
-            }
-        }
-        if ( preg_match_all('/(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*document\s*\.\s*getElementById\s*\(\s*(["\'])([A-Za-z][A-Za-z0-9_-]*)\2\s*\)/', $script, $assignments, PREG_SET_ORDER) ) {
-            foreach ( $assignments as $assignment ) {
-                if ( preg_match('/\b' . preg_quote((string) $assignment[1], '/') . '\s*' . $runtimeUsePattern . '/', $script) ) {
-                    $selectors['#' . (string) $assignment[3]] = true;
-                }
-            }
-        }
-        if ( preg_match_all('/(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*document\s*\.\s*querySelector(?:All)?\s*\(\s*(["\'])(' . $this->scriptSelectorPattern() . ')\2\s*\)/', $script, $assignments, PREG_SET_ORDER) ) {
-            foreach ( $assignments as $assignment ) {
-                if ( preg_match('/\b' . preg_quote((string) $assignment[1], '/') . '\s*' . $runtimeUsePattern . '/', $script) ) {
-                    $selectors[(string) $assignment[3]] = true;
-                }
-            }
-        }
-
-        return $selectors;
-    }
-
-    /**
-     * @return array<string, bool>
-     */
-    private function scriptCanvasSelectors(string $script): array
-    {
-        $selectors = array();
-        $getContextPattern = '\.\s*getContext\s*\(';
-
-        if ( preg_match_all('/document\s*\.\s*getElementById\s*\(\s*(["\'])([A-Za-z][A-Za-z0-9_-]*)\1\s*\)\s*' . $getContextPattern . '/', $script, $matches) ) {
-            foreach ( $matches[2] as $id ) {
-                $selectors['#' . (string) $id] = true;
-            }
-        }
-
-        if ( preg_match_all('/document\s*\.\s*querySelector\s*\(\s*(["\'])(' . $this->scriptSelectorPattern() . ')\1\s*\)\s*' . $getContextPattern . '/', $script, $matches) ) {
-            foreach ( $matches[2] as $selector ) {
-                $selectors[(string) $selector] = true;
-            }
-        }
-
-        if ( preg_match_all('/(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*document\s*\.\s*getElementById\s*\(\s*(["\'])([A-Za-z][A-Za-z0-9_-]*)\2\s*\)/', $script, $assignments, PREG_SET_ORDER) ) {
-            foreach ( $assignments as $assignment ) {
-                if ( preg_match('/\b' . preg_quote((string) $assignment[1], '/') . '\s*' . $getContextPattern . '/', $script) ) {
-                    $selectors['#' . (string) $assignment[3]] = true;
-                }
-            }
-        }
-
-        if ( preg_match_all('/(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*document\s*\.\s*querySelector\s*\(\s*(["\'])(' . $this->scriptSelectorPattern() . ')\2\s*\)/', $script, $assignments, PREG_SET_ORDER) ) {
-            foreach ( $assignments as $assignment ) {
-                if ( preg_match('/\b' . preg_quote((string) $assignment[1], '/') . '\s*' . $getContextPattern . '/', $script) ) {
-                    $selectors[(string) $assignment[3]] = true;
-                }
-            }
-        }
-
-        return $selectors;
-    }
-
     private function scriptSelectorPattern(): string
+
     {
-        $name = '[A-Za-z][A-Za-z0-9_-]*';
-        return '(?:[#.]' . $name . '|' . $name . '\\.' . $name . '|\\[data-' . $name . '(?:=["\'][^"\']{1,80}["\'])?\\]|' . $name . '\\[data-' . $name . '(?:=["\'][^"\']{1,80}["\'])?\\]|canvas|svg|' . implode('|', self::RUNTIME_TAG_SELECTORS) . ')';
-    }
 
-    private function canonicalRuntimeSelector(string $selector): string
-    {
-        $selector = trim($selector);
-        if ( preg_match('/^(?:([a-z][a-z0-9-]*))?\[(data-[A-Za-z][A-Za-z0-9_-]*)(?:=["\'][^"\']{1,80}["\'])?\]$/', $selector, $match) ) {
-            return strtolower((string) ($match[1] ?? '')) . '[' . strtolower((string) $match[2]) . ']';
-        }
+        return RuntimeSelectorVocabulary::scriptSelectorPattern();
 
-        return $selector;
-    }
-
-    private function selectorKind(string $selector): string
-    {
-        if ( str_starts_with($selector, '#') ) {
-            return 'id';
-        }
-        if ( str_starts_with($selector, '.') ) {
-            return 'class';
-        }
-        if ( str_contains($selector, '[') ) {
-            return 'attribute';
-        }
-
-        return 'element';
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    private function scriptScopedElementSelectors(string $script, string $tag): array
-    {
-        $selectors = array();
-        if ( ! preg_match_all('/(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*document\s*\.\s*(?:getElementById\s*\(\s*(["\'])([A-Za-z][A-Za-z0-9_-]*)\2\s*\)|querySelector\s*\(\s*(["\'])(' . $this->scriptSelectorPattern() . ')\4\s*\))/', $script, $roots, PREG_SET_ORDER) ) {
-            return array();
-        }
-
-        foreach ( $roots as $root ) {
-            if ( preg_match('/\b' . preg_quote((string) $root[1], '/') . '\s*\.\s*querySelector\s*\(\s*(["\'])' . preg_quote($tag, '/') . '\1\s*\)\s*\.\s*(?:addEventListener|setAttribute|appendChild|classList|style|getContext)\b/', $script) ) {
-                $selectors[] = $tag;
-                continue;
-            }
-            if ( preg_match_all('/(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*\b' . preg_quote((string) $root[1], '/') . '\s*\.\s*querySelector\s*\(\s*(["\'])' . preg_quote($tag, '/') . '\2\s*\)/', $script, $children, PREG_SET_ORDER) ) {
-                foreach ( $children as $child ) {
-                    if ( preg_match('/\b' . preg_quote((string) $child[1], '/') . '\s*\.\s*(?:addEventListener|setAttribute|appendChild|classList|style|getContext)\b/', $script) ) {
-                        $selectors[] = $tag;
-                    }
-                }
-            }
-        }
-
-        return array_values(array_unique($selectors));
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    private function scriptAppendedRootSelectors(string $script): array
-    {
-        $selectors = array();
-        if ( preg_match_all('/(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*document\s*\.\s*(?:getElementById\s*\(\s*(["\'])([A-Za-z][A-Za-z0-9_-]*)\2\s*\)|querySelector\s*\(\s*(["\'])(' . $this->scriptSelectorPattern() . ')\4\s*\))/', $script, $roots, PREG_SET_ORDER) ) {
-            foreach ( $roots as $root ) {
-                if ( preg_match('/\b' . preg_quote((string) $root[1], '/') . '\s*\.\s*appendChild\s*\(/', $script) ) {
-                    $selectors[] = '' !== (string) ($root[3] ?? '') ? '#' . (string) $root[3] : (string) $root[5];
-                }
-            }
-        }
-
-        return array_values(array_unique($selectors));
     }
 
     /**
@@ -1089,48 +867,6 @@ final class RuntimeDependencyParityReport
     private function isFormControlTarget(array $target): bool
     {
         return in_array((string) ($target['tag'] ?? ''), array('button', 'input', 'select', 'textarea'), true);
-    }
-
-    /**
-     * @return array<string, array<int, string>>
-     */
-    private function eventsBySelector(string $script): array
-    {
-        $events = array();
-        if ( preg_match_all('/document\s*\.\s*getElementById\s*\(\s*(["\'])([A-Za-z][A-Za-z0-9_-]*)\1\s*\)\s*\.\s*addEventListener\s*\(\s*(["\'])([A-Za-z][A-Za-z0-9_-]*)\3/', $script, $matches) ) {
-            foreach ( $matches[2] as $index => $id ) {
-                $events['#' . (string) $id][] = (string) $matches[4][$index];
-            }
-        }
-        if ( preg_match_all('/document\s*\.\s*querySelector(?:All)?\s*\(\s*(["\'])([#.][A-Za-z][A-Za-z0-9_-]*)\1\s*\)\s*\.\s*addEventListener\s*\(\s*(["\'])([A-Za-z][A-Za-z0-9_-]*)\3/', $script, $matches) ) {
-            foreach ( $matches[2] as $index => $selector ) {
-                $events[(string) $selector][] = (string) $matches[4][$index];
-            }
-        }
-        if ( preg_match_all('/(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*document\s*\.\s*getElementById\s*\(\s*(["\'])([A-Za-z][A-Za-z0-9_-]*)\2\s*\)/', $script, $assignments, PREG_SET_ORDER) ) {
-            foreach ( $assignments as $assignment ) {
-                if ( preg_match_all('/\b' . preg_quote((string) $assignment[1], '/') . '\s*\.\s*addEventListener\s*\(\s*(["\'])([A-Za-z][A-Za-z0-9_-]*)\1/', $script, $matches) ) {
-                    foreach ( $matches[2] as $event ) {
-                        $events['#' . (string) $assignment[3]][] = (string) $event;
-                    }
-                }
-            }
-        }
-        if ( preg_match_all('/(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*document\s*\.\s*querySelector(?:All)?\s*\(\s*(["\'])([#.][A-Za-z][A-Za-z0-9_-]*)\2\s*\)/', $script, $assignments, PREG_SET_ORDER) ) {
-            foreach ( $assignments as $assignment ) {
-                if ( preg_match_all('/\b' . preg_quote((string) $assignment[1], '/') . '\s*\.\s*addEventListener\s*\(\s*(["\'])([A-Za-z][A-Za-z0-9_-]*)\1/', $script, $matches) ) {
-                    foreach ( $matches[2] as $event ) {
-                        $events[(string) $assignment[3]][] = (string) $event;
-                    }
-                }
-            }
-        }
-
-        foreach ( $events as $selector => $selectorEvents ) {
-            $events[$selector] = array_values(array_unique($selectorEvents));
-        }
-
-        return $events;
     }
 
     /**

--- a/php-transformer/src/ArtifactCompiler/RuntimeScriptEvidenceAnalyzer.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeScriptEvidenceAnalyzer.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
 
+use Automattic\BlocksEngine\PhpTransformer\Support\RuntimeSelectorVocabulary;
+
 /**
  * Bounded, side-effect-free evidence extraction for one runtime script.
  * Consumers decide whether a fact requires DOM preservation or a diagnostic.
@@ -10,7 +12,6 @@ namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
 final class RuntimeScriptEvidenceAnalyzer
 {
     private const MAX_SCRIPT_BYTES = 1048576;
-    private const RUNTIME_TAG_SELECTORS = array('button', 'input', 'select', 'textarea', 'ul', 'ol', 'li');
 
     /** @return array<string, mixed> */
     public function analyze(string $script, string $sourcePath = '', string $scriptPath = ''): array
@@ -145,8 +146,7 @@ final class RuntimeScriptEvidenceAnalyzer
         foreach (preg_split('/[^a-z0-9]+/', strtolower($match[1] ?? '')) ?: array() as $token) if (in_array($token, array('animate', 'animation', 'appear', 'count', 'counter', 'delay', 'fade', 'motion', 'parallax', 'reveal', 'scroll', 'stagger', 'transition'), true)) return true;
         return false;
     }
-
-    private function selectorPattern(): string { $name = '[A-Za-z][A-Za-z0-9_-]*'; return '(?:[#.]' . $name . '|' . $name . '\\.' . $name . '|\\[data-' . $name . '(?:=["\'][^"\']{1,80}["\'])?\\]|' . $name . '\\[data-' . $name . '(?:=["\'][^"\']{1,80}["\'])?\\]|canvas|svg|' . implode('|', self::RUNTIME_TAG_SELECTORS) . ')'; }
+    private function selectorPattern(): string { return RuntimeSelectorVocabulary::scriptSelectorPattern(); }
     private function canonicalSelector(string $selector): string { $selector = trim($selector); return preg_match('/^(?:([a-z][a-z0-9-]*))?\[(data-[A-Za-z][A-Za-z0-9_-]*)(?:=["\'][^"\']{1,80}["\'])?\]$/', $selector, $match) ? strtolower($match[1] ?? '') . '[' . strtolower($match[2]) . ']' : $selector; }
     private function selectorKind(string $selector): string { return str_starts_with($selector, '#') ? 'id' : (str_starts_with($selector, '.') ? 'class' : (str_contains($selector, '[') ? 'attribute' : 'element')); }
     /** @return array<int, string> */

--- a/php-transformer/src/HtmlToBlocks/Classification/SourceElementClassifier.php
+++ b/php-transformer/src/HtmlToBlocks/Classification/SourceElementClassifier.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification;
 
+use Automattic\BlocksEngine\PhpTransformer\Support\RuntimeSelectorVocabulary;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\InlineContentElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\ShellLandmarkPolicy;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
@@ -373,27 +374,11 @@ final class SourceElementClassifier
     }
 
     public function isPresentationalAnimationSelector(string $selector): bool
+
     {
-        $name = '';
-        if ( preg_match('/\[(data-[A-Za-z][A-Za-z0-9_-]*)/', $selector, $match) ) {
-            $name = substr(strtolower((string) $match[1]), 5);
-        } elseif ( preg_match('/^(?:[a-z][a-z0-9-]*\.|\.)([A-Za-z][A-Za-z0-9_-]*)$/', $selector, $match) ) {
-            $name = strtolower((string) $match[1]);
-        } elseif ( preg_match('/^#([A-Za-z][A-Za-z0-9_-]*)$/', $selector, $match) ) {
-            $name = strtolower((string) $match[1]);
-        }
 
-        if ( '' === $name ) {
-            return false;
-        }
+        return RuntimeSelectorVocabulary::isPresentationalAnimation($selector);
 
-        foreach ( preg_split('/[^a-z0-9]+/', $name) ?: array() as $token ) {
-            if ( in_array($token, array( 'animate', 'animation', 'appear', 'count', 'counter', 'delay', 'fade', 'motion', 'parallax', 'reveal', 'scroll', 'stagger', 'transition' ), true) ) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     public function hasDirectMediaChild(DOMElement $element): bool

--- a/php-transformer/src/Support/RuntimeSelectorVocabulary.php
+++ b/php-transformer/src/Support/RuntimeSelectorVocabulary.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\Support;
+
+/**
+ * Shared vocabulary for reasoning about runtime CSS selectors.
+ *
+ * Answers the selector-level questions the artifact compiler, the runtime
+ * dependency parity report, and source-element classification all ask: which
+ * selector shapes a captured script can plausibly target, which data-attribute
+ * selectors a CSS selector declares, and whether a selector names presentation
+ * (an animation or scroll effect) rather than behavior.
+ *
+ * These are pure functions of their arguments and are static for the same
+ * reason {@see SourceDom} is: a caller needs no instance, no constructor
+ * argument, and no injected closure to reach one. The vocabulary previously
+ * existed as three independent copies of the same 13-token list across two
+ * namespaces, which is how the copies were free to disagree.
+ */
+final class RuntimeSelectorVocabulary
+{
+    /** Element selectors a captured runtime script may legitimately target. */
+    public const RUNTIME_TAG_SELECTORS = array( 'button', 'input', 'select', 'textarea', 'ul', 'ol', 'li' );
+
+    /**
+     * Selector shapes recognized inside captured script source.
+     */
+    public static function scriptSelectorPattern(): string
+    {
+        $name = '[A-Za-z][A-Za-z0-9_-]*';
+        return '(?:[#.]' . $name . '|' . $name . '\\.' . $name . '|\\[data-' . $name . '(?:=["\'][^"\']{1,80}["\'])?\\]|' . $name . '\\[data-' . $name . '(?:=["\'][^"\']{1,80}["\'])?\\]|canvas|svg|' . implode('|', self::RUNTIME_TAG_SELECTORS) . ')';
+    }
+
+    /**
+     * Whether a selector names presentation rather than behavior.
+     *
+     * Only a whole class selector, a whole id selector, or a data-attribute
+     * selector is considered. A compound or descendant selector names a
+     * position in a document rather than an effect, so it is not presentational
+     * on the strength of one of its parts.
+     */
+    public static function isPresentationalAnimation(string $selector): bool
+    {
+        $name = '';
+        if ( preg_match('/\[(data-[A-Za-z][A-Za-z0-9_-]*)/', $selector, $match) ) {
+            $name = substr(strtolower((string) $match[1]), 5);
+        } elseif ( preg_match('/^(?:[a-z][a-z0-9-]*\.|\.)([A-Za-z][A-Za-z0-9_-]*)$/', $selector, $match) ) {
+            $name = strtolower((string) $match[1]);
+        } elseif ( preg_match('/^#([A-Za-z][A-Za-z0-9_-]*)$/', $selector, $match) ) {
+            $name = strtolower((string) $match[1]);
+        }
+
+        if ( '' === $name ) {
+            return false;
+        }
+
+        foreach ( preg_split('/[^a-z0-9]+/', $name) ?: array() as $token ) {
+            if ( in_array($token, array( 'animate', 'animation', 'appear', 'count', 'counter', 'delay', 'fade', 'motion', 'parallax', 'reveal', 'scroll', 'stagger', 'transition' ), true) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Behavioral data-attribute selectors declared by a CSS selector.
+     *
+     * Note: the second scan deliberately runs against the reassigned $selector
+     * rather than the original argument, preserving the behavior of the three
+     * copies this replaces. That reassignment looks accidental and is worth a
+     * separate, deliberate look; it is not changed here so this stays a move.
+     *
+     * @return array<int, string>
+     */
+    public static function dataAttributeSelectorsFromCssSelector(string $selector): array
+    {
+        $selectors = array();
+        if ( preg_match_all('/(?:^|[\s>+~,])([a-z][a-z0-9-]*)?\[(data-[A-Za-z][A-Za-z0-9_-]*)(?:\s*[*^$|~]?=\s*(?:"[^"]{0,120}"|\'[^\']{0,120}\'|[^\]\s"\']{1,120}))?\]/', $selector, $matches, PREG_SET_ORDER) ) {
+            foreach ( $matches as $match ) {
+                $selector = strtolower((string) ($match[1] ?? '')) . '[' . strtolower((string) $match[2]) . ']';
+                if ( ! self::isPresentationalAnimation($selector) ) {
+                    $selectors[$selector] = true;
+                }
+            }
+        }
+        if ( preg_match_all('/\[(data-[A-Za-z][A-Za-z0-9_-]*)(?:\s*[*^$|~]?=\s*(?:"[^"]{0,120}"|\'[^\']{0,120}\'|[^\]\s"\']{1,120}))?\]/', $selector, $matches) ) {
+            foreach ( $matches[1] as $attribute ) {
+                $selector = '[' . strtolower((string) $attribute) . ']';
+                if ( ! self::isPresentationalAnimation($selector) ) {
+                    $selectors[$selector] = true;
+                }
+            }
+        }
+
+        return array_keys($selectors);
+    }
+}

--- a/php-transformer/tests/unit/runtime-selector-vocabulary.php
+++ b/php-transformer/tests/unit/runtime-selector-vocabulary.php
@@ -1,0 +1,125 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Unit tests for the shared runtime selector vocabulary (#242).
+ *
+ * Plain-PHP test script in the style of tests/unit/source-dom.php — no PHPUnit.
+ *
+ * This vocabulary existed as three independent copies of the same 13-token
+ * list across two namespaces, which is how the copies were free to disagree.
+ * The cases below pin the contract those copies were meant to share, with
+ * particular attention to the selector shapes on which they had already
+ * diverged.
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\Support\RuntimeSelectorVocabulary;
+
+$failures = 0;
+$passes   = 0;
+
+$assert = static function (bool $condition, string $message) use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . PHP_EOL);
+};
+
+// --- presentational selectors: the whole-selector rule ----------------------
+
+$assert(RuntimeSelectorVocabulary::isPresentationalAnimation('.fade-in'), 'a class naming an effect is presentational');
+$assert(RuntimeSelectorVocabulary::isPresentationalAnimation('#reveal-hero'), 'an id naming an effect is presentational');
+$assert(RuntimeSelectorVocabulary::isPresentationalAnimation('[data-scroll]'), 'a data attribute naming an effect is presentational');
+$assert(RuntimeSelectorVocabulary::isPresentationalAnimation('div.parallax'), 'a tag-qualified class is presentational');
+$assert(RuntimeSelectorVocabulary::isPresentationalAnimation('.STAGGER'), 'token matching is case-insensitive');
+
+$assert(! RuntimeSelectorVocabulary::isPresentationalAnimation('.cart-drawer'), 'a behavioral class is not presentational');
+$assert(! RuntimeSelectorVocabulary::isPresentationalAnimation('.hero-banner'), 'an unrelated class is not presentational');
+$assert(! RuntimeSelectorVocabulary::isPresentationalAnimation(''), 'an empty selector is not presentational');
+$assert(! RuntimeSelectorVocabulary::isPresentationalAnimation('.fadein'), 'an unsplit token does not match the vocabulary');
+
+// The selector must name an effect as a whole. A compound or descendant
+// selector names a position in a document, so it is not presentational on the
+// strength of one of its parts. Each of these returned true in at least one of
+// the copies this vocabulary replaces.
+$assert(! RuntimeSelectorVocabulary::isPresentationalAnimation('.wrap .fade-in'), 'a descendant selector is not presentational');
+$assert(! RuntimeSelectorVocabulary::isPresentationalAnimation('div.fade-in > span'), 'a child-combinator selector is not presentational');
+$assert(! RuntimeSelectorVocabulary::isPresentationalAnimation('.fade-in.extra'), 'a multi-class selector is not presentational');
+$assert(! RuntimeSelectorVocabulary::isPresentationalAnimation('section#scroll-top'), 'a tag-qualified id is not presentational');
+
+// --- data-attribute selectors ----------------------------------------------
+
+$assert(
+    RuntimeSelectorVocabulary::dataAttributeSelectorsFromCssSelector('[data-modal]') === array('[data-modal]'),
+    'a bare data-attribute selector is reported'
+);
+$assert(
+    RuntimeSelectorVocabulary::dataAttributeSelectorsFromCssSelector('button[data-cart]') === array('button[data-cart]', '[data-cart]'),
+    'a tag-qualified data-attribute selector reports both the qualified and bare forms'
+);
+
+// The two scans below pin behavior that is preserved, not endorsed. The second
+// scan runs against the reassigned $selector rather than the original argument,
+// so a selector carrying more than one data attribute reports only the first
+// and never sees the rest. Pinned here so that correcting it is a deliberate,
+// visible change rather than a silent one.
+$assert(
+    RuntimeSelectorVocabulary::dataAttributeSelectorsFromCssSelector('form[data-checkout] .row[data-total]')
+        === array('form[data-checkout]', '[data-checkout]'),
+    'a second data attribute in the same selector is currently not reported'
+);
+$assert(
+    RuntimeSelectorVocabulary::dataAttributeSelectorsFromCssSelector('[data-MODAL]') === array('[data-modal]'),
+    'attribute names are lowercased'
+);
+$assert(
+    RuntimeSelectorVocabulary::dataAttributeSelectorsFromCssSelector('[data-modal="open"]') === array('[data-modal]'),
+    'an attribute value is not part of the reported selector'
+);
+$assert(
+    RuntimeSelectorVocabulary::dataAttributeSelectorsFromCssSelector('[data-reveal]') === array(),
+    'a presentational data attribute is excluded'
+);
+$assert(
+    RuntimeSelectorVocabulary::dataAttributeSelectorsFromCssSelector('.no-attributes-here') === array(),
+    'a selector without data attributes reports nothing'
+);
+
+// --- script selector pattern ------------------------------------------------
+
+$pattern = RuntimeSelectorVocabulary::scriptSelectorPattern();
+$matches = static fn (string $candidate): bool => 1 === preg_match('/^' . $pattern . '$/', $candidate);
+
+$assert($matches('.promo'), 'a class selector is a script selector shape');
+$assert($matches('#promo'), 'an id selector is a script selector shape');
+$assert($matches('[data-modal]'), 'a data-attribute selector is a script selector shape');
+$assert($matches('button'), 'a runtime tag is a script selector shape');
+$assert($matches('canvas'), 'canvas is a script selector shape');
+$assert(! $matches('div'), 'a non-runtime tag is not a script selector shape');
+
+$assert(
+    in_array('button', RuntimeSelectorVocabulary::RUNTIME_TAG_SELECTORS, true)
+        && ! in_array('div', RuntimeSelectorVocabulary::RUNTIME_TAG_SELECTORS, true),
+    'the runtime tag list names interactive elements only'
+);
+
+// --- statelessness ----------------------------------------------------------
+
+$first = RuntimeSelectorVocabulary::isPresentationalAnimation('.fade-in');
+RuntimeSelectorVocabulary::dataAttributeSelectorsFromCssSelector('[data-cart]');
+$assert(
+    $first === RuntimeSelectorVocabulary::isPresentationalAnimation('.fade-in'),
+    'answers do not drift across calls'
+);
+
+echo 'Runtime selector vocabulary tests: ' . $passes . ' passed' . PHP_EOL;
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, 'Runtime selector vocabulary tests: ' . $failures . ' FAILED' . PHP_EOL);
+    exit(1);
+}


### PR DESCRIPTION
Workstream 1 slice for #242. Follows #1495.

First slice of this arc to land in `ArtifactCompiler/`, which was the second-largest file in the package and untouched so far.

## Dead code, and what was hiding in it

`RuntimeDependencyParityReport` (1,196 lines) is reachable from outside through exactly one method — `fromArtifact()`, called once by `ArtifactCompiler` and three times by the contract suite. **Nine of its methods were never called by anything**, inside the file or out: 223 lines of unreachable code.

Four of those nine were copies that had already drifted from their `ArtifactCompiler` twins. One is worth naming.

`isPresentationOnlyScriptSelector` had a **byte-identical 20-line body** in both files — same two regexes, same assignment-tracking loop, same tail scan. Only the guard differed:

```php
// ArtifactCompiler
if ( $this->isBehavioralRuntimeSelector($selector) ) { return false; }

// RuntimeDependencyParityReport
if ( ! $this->isPresentationalRuntimeSelector($selector) ) { return false; }
```

Those are equivalent only if *behavioral ≡ ¬presentational*. It isn't — `isBehavioralRuntimeSelector` additionally requires a bracket, a form tag, or a behavioral vocabulary match. Run through reflection before deletion:

| selector | ArtifactCompiler | ParityReport | |
|---|---|---|---|
| `.hero-banner` | `true` | `false` | **disagree** |
| `.fade-in` | `true` | `true` | |
| `.cart-drawer` | `false` | `false` | |
| `#promo-block` | `true` | `false` | **disagree** |
| `.stat-tile` | `true` | `false` | **disagree** |

Being precise: because the copy was unreachable, this never produced a wrong answer for a user. It was a loaded gun, not a firing one. Deleting it is pure subtraction, and the suite stays green — which is also what confirms the reachability analysis.

## One vocabulary, written three times

What remained was a single 13-token presentational vocabulary (`animate, animation, appear, count, counter, delay, fade, motion, parallax, reveal, scroll, stagger, transition`) implemented three times across two namespaces, plus three identical copies of `RUNTIME_TAG_SELECTORS` and three of the script selector pattern.

Notably one of the three was `SourceElementClassifier::isPresentationalAnimationSelector` — byte-identical, different name, extracted by #1485 without either of us noticing it had twins in `ArtifactCompiler/`.

It now lives in `Support\RuntimeSelectorVocabulary` as statics, same shape and rationale as `SourceDom`. `ArtifactCompiler`, `RuntimeDependencyParityReport`, `SourceElementClassifier`, and `RuntimeScriptEvidenceAnalyzer` all read from it.

## What I deliberately did not fix

**`RuntimeScriptEvidenceAnalyzer::presentational()` stays as-is.** It is a fourth implementation that parses selectors with one loose unanchored regex instead of three anchored alternatives, and it genuinely disagrees with the canonical version:

| selector | canonical | evidence analyzer |
|---|---|---|
| `div.fade-in > span` | `false` | `true` |
| `.fade-in.extra` | `false` | `true` |
| `section#scroll-top` | `false` | `true` |

Unlike the dead copy, `analyze()` is **live** — four call sites. So reconciling this is a behavior change with real output consequences, not a move, and it belongs in its own PR with its own parity evidence.

**`dataAttributeSelectorsFromCssSelector` keeps a quirk.** It reassigns `$selector` inside its first loop, so the second scan runs against the last-built candidate rather than the original argument. The visible effect is that a selector carrying more than one data attribute reports only the first:

```
form[data-checkout] .row[data-total]  =>  ['form[data-checkout]', '[data-checkout]']
```

`[data-total]` is never seen. I nearly "cleaned this up" while extracting — renaming the shadowed variable would have silently changed behavior. It is preserved verbatim, commented at the source, and pinned by a test labelled as preserved-not-endorsed so that correcting it is a deliberate, visible diff.

## Proof

**No behavior change.** `serializedBlocks` SHA-256 for all 385 fixture HTML files, before and after: **385 compared, 0 differing, 0 throwing.**

**Suite.** `composer test` exit 0, including 292 parity fixtures and the package install proof.

**New coverage.** `tests/unit/runtime-selector-vocabulary.php` — 28 assertions, registered in `test:unit`. They pin the whole-selector rule that the copies disagreed on: `.wrap .fade-in`, `div.fade-in > span`, `.fade-in.extra`, and `section#scroll-top` are all **not** presentational, each of which returned `true` in at least one copy. Verified to have teeth by mutation — un-anchoring the class pattern and dropping a token fails 2 assertions; reverting restores 28.

## Result

`ArtifactCompiler`: 5,583 → 5,550. `RuntimeDependencyParityReport`: 1,196 → 932 (−22%). `RuntimeSelectorVocabulary`: 99 lines. Net **−331 / +245** across 7 files.

## AI assistance disclosure

Researched and implemented with AI assistance: Claude Sonnet 4.5 running in the opencode CLI agent, operated by @chubes4. The AI found the duplication by scanning normalised method bodies package-wide, proved both divergences through reflection before touching them, established reachability for the dead methods, performed the extraction, caught the `$selector` reassignment trap, wrote the tests, and ran the corpus-hash and mutation verification. Chris Huber directed the target selection and is responsible for the scope and final change.
