### PR TITLE
Project nested button label styles onto native links

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -3257,65 +3257,12 @@ final class HtmlTransformer
             'linkTarget' => $this->attr($element, 'target'),
             'rel'        => $this->attr($element, 'rel'),
         ), static fn (string $value): bool => '' !== trim($value)));
-        $attrs = $this->withButtonLabelTextPresentation($attrs, $element, $label);
-
         return $this->createBlock(
             'core/buttons',
             array(),
             array( $this->createBlock('core/button', $attrs, array(), $element) ),
             $element
         );
-    }
-
-    /**
-     * Take a button's text presentation from the element that renders the text.
-     *
-     * Builders commonly wrap a button's label in its own element, styling that
-     * element for the text while the button root carries the box. core/button
-     * renders the label inside the link itself, so reading only the root paints
-     * the text with the box's colour: a light label on a dark control arrives
-     * as dark text, because the root states the dark value the label overrode.
-     *
-     * @param array<string, mixed> $attrs
-     * @return array<string, mixed>
-     */
-    private function withButtonLabelTextPresentation(array $attrs, DOMElement $element, string $label): array
-    {
-        if ( '' === trim($label) ) {
-            return $attrs;
-        }
-
-        $labelElement = null;
-        foreach ( $element->getElementsByTagName('*') as $candidate ) {
-            if ( ! $candidate instanceof DOMElement ) {
-                continue;
-            }
-            if ( trim($this->runtime->stripAllTags($this->innerHtml($candidate))) === trim($label) ) {
-                // Document order descends, so the last match is the innermost
-                // element still holding the whole label.
-                $labelElement = $candidate;
-            }
-        }
-        if ( ! $labelElement instanceof DOMElement ) {
-            return $attrs;
-        }
-
-        $labelStyle = $this->styleResolver->presentationAttributes($labelElement)['style'] ?? array();
-        if ( ! is_array($labelStyle) ) {
-            return $attrs;
-        }
-
-        $labelColor = trim((string) ( $labelStyle['color']['text'] ?? '' ));
-        if ( '' !== $labelColor ) {
-            $attrs['style']['color']['text'] = $labelColor;
-        }
-        foreach ( is_array($labelStyle['typography'] ?? null) ? $labelStyle['typography'] : array() as $property => $value ) {
-            if ( is_scalar($value) && '' !== trim((string) $value) ) {
-                $attrs['style']['typography'][$property] = $value;
-            }
-        }
-
-        return $attrs;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Style/SourceBlockAttributeProjector.php
+++ b/php-transformer/src/HtmlToBlocks/Style/SourceBlockAttributeProjector.php
@@ -149,6 +149,17 @@ final class SourceBlockAttributeProjector
             if ( '' !== $controlMarker && '' !== $presentationPath && $presentationPath !== $logicalControlPath ) {
                 $context->selectorProjections->installButtonPresentationMarker($presentationPath, $controlMarker);
             }
+            // The element that renders the label is styled separately from the
+            // control that boxes it, and core/button renders the label inside
+            // the link. Register it too, so rules written for the label reach
+            // the link instead of leaving the box's own colour to paint text.
+            if ( '' !== $controlMarker ) {
+                foreach ( self::buttonLabelPaths($sourceElement, $logicalControl, (string) ($attrs['text'] ?? '')) as $labelPath ) {
+                    if ( $labelPath !== $logicalControlPath && $labelPath !== $presentationPath ) {
+                        $context->selectorProjections->installButtonPresentationMarker($labelPath, $controlMarker);
+                    }
+                }
+            }
         }
         if ( 'core/button' === $name && $hasNativeButtonStyle && '' === $context->selectorProjections->controlMarker($logicalControlPath) ) {
             $nativeButtonMarker = $hasNativeButtonColor
@@ -159,6 +170,40 @@ final class SourceBlockAttributeProjector
             self::registerButtonWidth($attrs, $nativeButtonMarker, $context, $this->generatedStyleProjector);
         }
         return $attrs;
+    }
+
+    /**
+     * Paths of the elements that render a button's visible label.
+     *
+     * @return array<int, string>
+     */
+    private static function buttonLabelPaths(DOMElement $sourceElement, ?DOMElement $logicalControl, string $label): array
+    {
+        $label = trim(html_entity_decode(strip_tags($label), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
+        if ( '' === $label ) {
+            return array();
+        }
+
+        $paths = array();
+        foreach ( array( $sourceElement, $logicalControl ) as $host ) {
+            if ( ! $host instanceof DOMElement ) {
+                continue;
+            }
+            foreach ( $host->getElementsByTagName('*') as $candidate ) {
+                if ( ! $candidate instanceof DOMElement ) {
+                    continue;
+                }
+                if ( trim($candidate->textContent ?? '') !== $label ) {
+                    continue;
+                }
+                $path = $candidate->getNodePath() ?? '';
+                if ( '' !== $path ) {
+                    $paths[$path] = true;
+                }
+            }
+        }
+
+        return array_keys($paths);
     }
 
     /** @param array<string, mixed> $attrs */

--- a/php-transformer/src/HtmlToBlocks/Style/SourceBlockAttributeProjector.php
+++ b/php-transformer/src/HtmlToBlocks/Style/SourceBlockAttributeProjector.php
@@ -119,6 +119,7 @@ final class SourceBlockAttributeProjector
         SourceBlockAttributeProjectionContext $context
     ): array {
         $logicalControlPath = $logicalControl->getNodePath() ?? '';
+        $presentationPath = $sourceElement->getNodePath() ?? '';
         $nativeButtonTextAlignment = '';
         $hasNativeButtonColor = false;
         $hasNativeButtonStyle = false;
@@ -129,6 +130,15 @@ final class SourceBlockAttributeProjector
                 'a' === strtolower($logicalControl->tagName) && ($sourceElement === $logicalControl || $sourceElement->parentNode === $logicalControl)
             );
             $attrs = $nativeButtonProjection['attrs'];
+            if ( $this->buttonLabelHasAuthoredColor($sourceElement, $logicalControl, (string) ($attrs['text'] ?? ''), $presentationPath, $logicalControlPath) ) {
+                unset($attrs['style']['color']['text']);
+                if ( array() === ($attrs['style']['color'] ?? null) ) {
+                    unset($attrs['style']['color']);
+                }
+                if ( array() === ($attrs['style'] ?? null) ) {
+                    unset($attrs['style']);
+                }
+            }
             $nativeButtonTextAlignment = $nativeButtonProjection['text_alignment'];
             $hasNativeButtonColor = $nativeButtonProjection['color_changed'];
             $hasNativeButtonStyle = '' !== $nativeButtonTextAlignment || $hasNativeButtonColor;
@@ -145,7 +155,6 @@ final class SourceBlockAttributeProjector
                     self::registerButtonWidth($attrs, $controlMarker, $context, $this->generatedStyleProjector);
                 }
             }
-            $presentationPath = $sourceElement->getNodePath() ?? '';
             if ( '' !== $controlMarker && '' !== $presentationPath && $presentationPath !== $logicalControlPath ) {
                 $context->selectorProjections->installButtonPresentationMarker($presentationPath, $controlMarker);
             }
@@ -204,6 +213,37 @@ final class SourceBlockAttributeProjector
         }
 
         return array_keys($paths);
+    }
+
+    private function buttonLabelHasAuthoredColor(
+        DOMElement $sourceElement,
+        ?DOMElement $logicalControl,
+        string $label,
+        string $presentationPath,
+        string $logicalControlPath
+    ): bool
+    {
+        $paths = array_fill_keys(self::buttonLabelPaths($sourceElement, $logicalControl, $label), true);
+        if ( array() === $paths ) {
+            return false;
+        }
+        foreach ( array( $sourceElement, $logicalControl ) as $host ) {
+            if ( ! $host instanceof DOMElement ) {
+                continue;
+            }
+            foreach ( $host->getElementsByTagName('*') as $candidate ) {
+                $candidatePath = $candidate instanceof DOMElement ? ($candidate->getNodePath() ?? '') : '';
+                if ( $candidate instanceof DOMElement
+                    && $candidatePath !== $presentationPath
+                    && $candidatePath !== $logicalControlPath
+                    && isset($paths[$candidatePath])
+                    && array() !== $this->styleResolver->authorDeclaredPropertyValues($candidate, array( 'color' ))
+                ) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /** @param array<string, mixed> $attrs */

--- a/php-transformer/tests/unit/author-selector-semantics.php
+++ b/php-transformer/tests/unit/author-selector-semantics.php
@@ -192,7 +192,7 @@ $assert(str_contains($navCtaMarkup, 'blocks-engine-control-') && str_contains($n
 
 $nestedLabelButton = $transform('<style>.contact{display:inline-flex;padding:9px 20px;border-radius:999px;background:#001b2e;color:#000}.contact-label{color:#eeffff;font:400 15.75px/1 helvetica}</style><a class="contact" href="#contact"><span class="contact-label">Contacts</span></a>');
 $nestedLabelButtonCss = $css($nestedLabelButton);
-$assert(str_contains($nestedLabelButtonCss, '> :where(.wp-block-button__link){color:#eeffff;font:400 15.75px/1 helvetica}') && 'pass' === ($nestedLabelButton['source_reports']['wp_block_validity']['status'] ?? ''), 'removed button label selectors project their text presentation onto the native link');
+$assert(str_contains($nestedLabelButtonCss, '> :where(.wp-block-button__link){color:#eeffff;font:400 15.75px/1 helvetica}') && ! str_contains($nestedLabelButtonCss, 'color:#000!important') && 'pass' === ($nestedLabelButton['source_reports']['wp_block_validity']['status'] ?? ''), 'removed button label selectors own native link text presentation without a root-colour override');
 
 $controlMargin = $transform('<style>.nav-cta{margin-left:24px;font-family:monospace}</style><main><a class="nav-cta" href="#cta" style="display:inline-flex;padding:9px 20px;background:#e8a020">Get Early Access</a></main>');
 $controlMarginCss = $css($controlMargin);

--- a/php-transformer/tests/unit/author-selector-semantics.php
+++ b/php-transformer/tests/unit/author-selector-semantics.php
@@ -190,6 +190,10 @@ $navCtaMarkup = (string) ($navCta['serialized_blocks'] ?? '');
 $navCtaCss = $css($navCta);
 $assert(str_contains($navCtaMarkup, 'blocks-engine-control-') && str_contains($navCtaCss, '> :where(.wp-block-button__link){display:inline-flex') && str_contains($navCtaCss, 'font-family:monospace') && str_contains($navCtaCss, 'padding:9px 20px') && str_contains($navCtaCss, 'background:#e8a020') && str_contains($navCtaCss, ':hover{background:#f0ac22}') && str_contains($navCtaCss, ':focus{outline:2px solid #fff}') && 'pass' === ($navCta['source_reports']['wp_block_validity']['status'] ?? ''), 'class-bearing source anchors project compound, typography, paint, and pseudo-state selectors onto valid core/button links');
 
+$nestedLabelButton = $transform('<style>.contact{display:inline-flex;padding:9px 20px;border-radius:999px;background:#001b2e;color:#000}.contact-label{color:#eeffff;font:400 15.75px/1 helvetica}</style><a class="contact" href="#contact"><span class="contact-label">Contacts</span></a>');
+$nestedLabelButtonCss = $css($nestedLabelButton);
+$assert(str_contains($nestedLabelButtonCss, '> :where(.wp-block-button__link){color:#eeffff;font:400 15.75px/1 helvetica}') && 'pass' === ($nestedLabelButton['source_reports']['wp_block_validity']['status'] ?? ''), 'removed button label selectors project their text presentation onto the native link');
+
 $controlMargin = $transform('<style>.nav-cta{margin-left:24px;font-family:monospace}</style><main><a class="nav-cta" href="#cta" style="display:inline-flex;padding:9px 20px;background:#e8a020">Get Early Access</a></main>');
 $controlMarginCss = $css($controlMargin);
 $controlMarginOuterClass = (string) ($controlMargin['blocks'][0]['attrs']['className'] ?? '');


### PR DESCRIPTION
## Summary

- project selectors for removed button-label descendants onto the native `core/button` link
- let an authored nested-label colour own the link instead of overriding it with the source root's colour
- retain the existing generated paint protection when the nested element is already the selected button surface

## Why

Builders commonly style a button's label separately from its box. After conversion, `core/button` removes that label element. The box selector was projected, but the label selector had no native target, so theme/default text presentation or the box's colour won.

This was visible in the Nimbus header: the source label was Helvetica 15.75px in `rgb(238,255,255)`, while the native link rendered Arial 10px in black.

## Verification

- Added a contract for a dark button root with a light, separately styled nested label.
- Full `composer test` passes, including 292 parity fixtures and package install proof.
- Fresh URL import passes mechanical validation: 864 native blocks, zero fallback/core HTML/freeform/invalid blocks.
- Fresh browser measurements match both source variants exactly:
  - header: Helvetica 15.75px, `rgb(238,255,255)`
  - footer: Helvetica 15.75px, `rgb(0,0,0)`
- Navigation typography and single-region painting from #1496 remain unchanged.

## AI assistance disclosure

Implemented with AI assistance from OpenAI GPT-5.6-sol using the OpenCode coding tool. The AI traced the source and generated CSS cascades, implemented the selector-path projection, added regression coverage, and ran the full test and fresh-import verification workflow under human direction.