### PR TITLE
Make runtime script evidence authoritative

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -53,6 +53,8 @@ final class ArtifactCompiler
 
 	private WordPressCompatCss $wordpressCompat;
 
+    private readonly RuntimeScriptEvidenceAnalyzer $runtimeScriptEvidenceAnalyzer;
+
     private ?HtmlTransformerAnalysisCache $htmlTransformerAnalysisCache = null;
 
     /** Observational only: excludes receipt cache hits. */
@@ -64,6 +66,7 @@ final class ArtifactCompiler
     public function __construct(private readonly bool $cacheHtmlAnalysis = true)
     {
         $this->wordpressCompat = new WordPressCompatCss();
+        $this->runtimeScriptEvidenceAnalyzer = new RuntimeScriptEvidenceAnalyzer();
     }
 
     /** @return array<string, int> */
@@ -97,12 +100,6 @@ final class ArtifactCompiler
 
     /** @var array<int, string> */
     private array $scriptContents = array();
-
-    /** @var array<string, array<int, string>> */
-    private array $scriptDomSelectorCache = array();
-
-    /** @var array<string, array<string, bool>> */
-    private array $scriptControlSelectorCache = array();
 
     /** @var array<string,mixed> Optional normalized proof for the current artifact. */
     private array $layoutGeometryProof = array();
@@ -764,7 +761,7 @@ final class ArtifactCompiler
         if ( array() !== $entryBlocks['superseded_selectors'] ) {
             $sourceReports['superseded_selectors'] = $entryBlocks['superseded_selectors'];
         }
-        $sourceReports['runtime_dependency_parity'] = ( new RuntimeDependencyParityReport() )->fromArtifact($normalized['files'], $html, $serializedBlocks, $entryPath, $entryBlocks['runtime_islands'], $referenceReports['asset_references'], $entryBlocks['interaction_candidates'], $entryBlocks['superseded_selectors'], $allGeneratedBlocks);
+        $sourceReports['runtime_dependency_parity'] = ( new RuntimeDependencyParityReport($this->runtimeScriptEvidenceAnalyzer) )->fromArtifact($normalized['files'], $html, $serializedBlocks, $entryPath, $entryBlocks['runtime_islands'], $referenceReports['asset_references'], $entryBlocks['interaction_candidates'], $entryBlocks['superseded_selectors'], $allGeneratedBlocks);
         foreach ($sourceReports['runtime_dependency_parity']['findings'] ?? array() as $finding) {
             if ('runtime_dependency_target_missing' !== ($finding['code'] ?? '') || 'telemetry' === ($finding['script_kind'] ?? '')) {
                 continue;
@@ -3049,12 +3046,12 @@ final class ArtifactCompiler
         $controlSelectors = $this->formControlSelectors($html);
         $statusFeedbackSelectors = $this->formStatusFeedbackSelectors($html);
         foreach ( $this->documentScriptContents($html, $sourcePath, $files) as $script ) {
-            $runtimeControlSelectors = $this->scriptControlRuntimeSelectors($script);
-            foreach ( $this->scriptDomSelectors($script) as $selector ) {
-                if ( $this->isPresentationOnlyScriptSelector($script, $selector) ) {
+            foreach ( $this->runtimeScriptEvidenceAnalyzer->analyze($script)['dependencies'] as $dependency ) {
+                $selector = (string) $dependency['selector'];
+                if ( true === $dependency['presentation_only'] ) {
                     continue;
                 }
-                if ( isset($controlSelectors[$selector]) && ! isset($runtimeControlSelectors[$selector]) ) {
+                if ( isset($controlSelectors[$selector]) && true !== $dependency['control_runtime'] ) {
                     continue;
                 }
                 $selectors[$selector] = true;
@@ -3062,8 +3059,9 @@ final class ArtifactCompiler
         }
 
         foreach ( $this->allScriptContents($files) as $script ) {
-            foreach ( $this->scriptDomSelectors($script) as $selector ) {
-                if ( $this->isPresentationOnlyScriptSelector($script, $selector) ) {
+            foreach ( $this->runtimeScriptEvidenceAnalyzer->analyze($script)['dependencies'] as $dependency ) {
+                $selector = (string) $dependency['selector'];
+                if ( true === $dependency['presentation_only'] ) {
                     continue;
                 }
                 if ( isset($statusFeedbackSelectors[$selector]) ) {
@@ -3086,8 +3084,9 @@ final class ArtifactCompiler
     {
         $selectors = array();
         foreach ( $this->documentScriptContents($html, $sourcePath, $files) as $script ) {
-            foreach ( $this->scriptDomSelectors($script) as $selector ) {
-                if ( str_contains($selector, '[data-') && $this->isPresentationOnlyScriptSelector($script, $selector) ) {
+            foreach ( $this->runtimeScriptEvidenceAnalyzer->analyze($script)['dependencies'] as $dependency ) {
+                $selector = (string) $dependency['selector'];
+                if ( str_contains($selector, '[data-') && true === $dependency['presentation_only'] ) {
                     $selectors[$selector] = true;
                 }
             }
@@ -3161,7 +3160,7 @@ final class ArtifactCompiler
         $selectors = array();
         $scripts = $this->documentScriptContents($html, $sourcePath, $files);
         foreach ( $scripts as $script ) {
-            foreach ( $this->scriptCanvasSelectors($script) as $selector ) {
+            foreach ( $this->runtimeScriptEvidenceAnalyzer->analyze($script)['canvas_selectors'] as $selector ) {
                 if ( isset($canvasSelectors[$selector]) ) {
                     $selectors[$selector] = true;
                 }
@@ -3203,14 +3202,6 @@ final class ArtifactCompiler
         }
 
         return array_keys($selectors);
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    private function scriptCanvasSelectors(string $script): array
-    {
-        return (new RuntimeScriptEvidenceAnalyzer())->analyze($script)['canvas_selectors'];
     }
 
     /**
@@ -3332,80 +3323,6 @@ final class ArtifactCompiler
         }
 
         return $scripts;
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    private function scriptDomSelectors(string $script): array
-    {
-        $cacheKey = hash('sha256', $script);
-        if ( isset($this->scriptDomSelectorCache[$cacheKey]) ) {
-            return $this->scriptDomSelectorCache[$cacheKey];
-        }
-
-        return $this->scriptDomSelectorCache[$cacheKey] = (new RuntimeScriptEvidenceAnalyzer())->analyze($script)['selectors'];
-    }
-
-    private function isPresentationOnlyScriptSelector(string $script, string $selector): bool
-    {
-        if ( $this->isBehavioralRuntimeSelector($selector) ) {
-            return false;
-        }
-
-        $selectorPattern = preg_quote($selector, '/');
-        if ( preg_match_all('/\b(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(?:(?:document|[A-Za-z_$][A-Za-z0-9_$]*)\s*\.\s*)?querySelector(?:All)?\s*\(\s*(["\'])' . $selectorPattern . '\2\s*\)/', $script, $assignments, PREG_SET_ORDER) ) {
-            foreach ($assignments as $assignment) {
-                if (preg_match('/\b' . preg_quote((string) $assignment[1], '/') . '\s*\.\s*(?:addEventListener|appendChild|removeChild|replaceChildren|insertAdjacentHTML|setAttribute|removeAttribute|toggleAttribute|getContext|submit|fetch)\b|\b' . preg_quote((string) $assignment[1], '/') . '\s*\.\s*(?:textContent|innerHTML|outerHTML|value|checked|selectedIndex|hidden|disabled|style|dataset)\b/', $script)) {
-                    return false;
-                }
-            }
-        }
-        if ( ! preg_match_all('/querySelector(?:All)?\s*\(\s*(["\'])' . $selectorPattern . '\1\s*\)([^;]{0,700})/', $script, $matches) ) {
-            return false;
-        }
-
-        foreach ( $matches[2] as $tail ) {
-            if ( preg_match('/\b(?:addEventListener|appendChild|removeChild|replaceChildren|insertAdjacentHTML|innerHTML|outerHTML|textContent|value|checked|selectedIndex|setAttribute|removeAttribute|toggleAttribute|getContext|submit|fetch)\b|\.\s*(?:classList|hidden|disabled|style|dataset)\b/', (string) $tail) ) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private function isBehavioralRuntimeSelector(string $selector): bool
-    {
-        if ( $this->isPresentationalRuntimeSelector($selector) ) {
-            return false;
-        }
-
-        if ( str_contains($selector, '[') || in_array($selector, array('button', 'input', 'select', 'textarea', 'canvas', 'svg'), true) ) {
-            return true;
-        }
-
-        return (bool) preg_match('/(?:^|[^a-z0-9])(?:form|modal|drawer|cart|checkout|search|filter|tab|accordion|slider|carousel|canvas|stage|player|map|app|editor|playground|demo)(?:[^a-z0-9]|$)/i', $selector);
-    }
-
-    private function isPresentationalRuntimeSelector(string $selector): bool
-
-    {
-
-        return RuntimeSelectorVocabulary::isPresentationalAnimation($selector);
-
-    }
-
-    /**
-     * @return array<string, bool>
-     */
-    private function scriptControlRuntimeSelectors(string $script): array
-    {
-        $cacheKey = hash('sha256', $script);
-        if ( isset($this->scriptControlSelectorCache[$cacheKey]) ) {
-            return $this->scriptControlSelectorCache[$cacheKey];
-        }
-
-        return $this->scriptControlSelectorCache[$cacheKey] = array_fill_keys((new RuntimeScriptEvidenceAnalyzer())->analyze($script)['control_selectors'], true);
     }
 
     private function scriptSelectorPattern(): string
@@ -4658,8 +4575,7 @@ final class ArtifactCompiler
         $this->filesByPath = array();
         $this->imageFiles = array();
         $this->scriptContents = array();
-        $this->scriptDomSelectorCache = array();
-        $this->scriptControlSelectorCache = array();
+        $this->runtimeScriptEvidenceAnalyzer->resetCache();
 
         foreach ( $files as $file ) {
             if ( ! is_array($file) ) {

--- a/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
@@ -14,6 +14,16 @@ final class RuntimeDependencyParityReport
 {
     public const SCHEMA = 'blocks-engine/php-transformer/runtime-dependency-parity/v1';
 
+    private readonly RuntimeScriptEvidenceAnalyzer $runtimeScriptEvidenceAnalyzer;
+
+    private readonly bool $ownsRuntimeScriptEvidenceAnalyzer;
+
+    public function __construct(?RuntimeScriptEvidenceAnalyzer $runtimeScriptEvidenceAnalyzer = null)
+    {
+        $this->ownsRuntimeScriptEvidenceAnalyzer = null === $runtimeScriptEvidenceAnalyzer;
+        $this->runtimeScriptEvidenceAnalyzer = $runtimeScriptEvidenceAnalyzer ?? new RuntimeScriptEvidenceAnalyzer();
+    }
+
     /**
      * Tag-only script selectors whose native DOM shape can be behavior-bearing.
      *
@@ -42,6 +52,10 @@ final class RuntimeDependencyParityReport
      */
     public function fromArtifact(array $files, string $sourceHtml, string $generatedHtml, string $sourcePath = '', array $runtimeIslands = array(), array $assetReferences = array(), array $interactionCandidates = array(), array $supersededSelectors = array(), array $generatedBlocks = array()): array
     {
+        if ($this->ownsRuntimeScriptEvidenceAnalyzer) {
+            $this->runtimeScriptEvidenceAnalyzer->resetCache();
+        }
+
         $sourceTargets = $this->sourceTargets($sourceHtml, $sourcePath);
         $generatedTargets = $this->withBlockCommentAnchorTargets(
             $this->withRuntimeIslandTargets($this->htmlTargets($generatedHtml), $runtimeIslands),
@@ -752,7 +766,7 @@ final class RuntimeDependencyParityReport
      */
     private function scriptDependencies(string $script, array $bundleCanvasSelectors = array()): array
     {
-        $evidence = (new RuntimeScriptEvidenceAnalyzer())->analyze($script);
+        $evidence = $this->runtimeScriptEvidenceAnalyzer->analyze($script);
         $dependencies = array();
         foreach ($evidence['dependencies'] as $dependency) {
             if (true === $dependency['presentation_only']) {
@@ -826,14 +840,6 @@ final class RuntimeDependencyParityReport
     private function dataAttributeSelectorsFromCssSelector(string $selector): array
     {
         return RuntimeSelectorVocabulary::dataAttributeSelectorsFromCssSelector($selector);
-    }
-
-    private function isPresentationalRuntimeSelector(string $selector): bool
-
-    {
-
-        return RuntimeSelectorVocabulary::isPresentationalAnimation($selector);
-
     }
 
     /**

--- a/php-transformer/src/ArtifactCompiler/RuntimeScriptEvidenceAnalyzer.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeScriptEvidenceAnalyzer.php
@@ -13,9 +13,22 @@ final class RuntimeScriptEvidenceAnalyzer
 {
     private const MAX_SCRIPT_BYTES = 1048576;
 
+    /** @var array<string, array<string, mixed>> */
+    private array $cache = array();
+
+    public function resetCache(): void
+    {
+        $this->cache = array();
+    }
+
     /** @return array<string, mixed> */
     public function analyze(string $script, string $sourcePath = '', string $scriptPath = ''): array
     {
+        $cacheKey = hash('sha256', $sourcePath . "\0" . $scriptPath . "\0" . $script);
+        if (isset($this->cache[$cacheKey])) {
+            return $this->cache[$cacheKey];
+        }
+
         $originalBytes = strlen($script);
         $truncated = $originalBytes > self::MAX_SCRIPT_BYTES;
         if ($truncated) {
@@ -38,7 +51,7 @@ final class RuntimeScriptEvidenceAnalyzer
             );
         }
 
-        return array(
+        return $this->cache[$cacheKey] = array(
             'schema' => 'blocks-engine/php-transformer/runtime-script-evidence/v1',
             'source_path' => $sourcePath,
             'script_path' => $scriptPath,
@@ -134,17 +147,17 @@ final class RuntimeScriptEvidenceAnalyzer
 
     private function presentationOnly(string $script, string $selector): bool
     {
-        if (!$this->presentational($selector)) return false;
+        if (!RuntimeSelectorVocabulary::isPresentationalAnimation($selector)) return false;
         $quoted = preg_quote($selector, '/');
-        if (preg_match('/querySelector(?:All)?\s*\(\s*(["\'])' . $quoted . '\1\s*\)([^;]{0,700})/', $script, $matches) && preg_match('/\b(?:addEventListener|appendChild|removeChild|replaceChildren|insertAdjacentHTML|innerHTML|outerHTML|textContent|value|checked|selectedIndex|setAttribute|removeAttribute|toggleAttribute|getContext|submit|fetch)\b|\.\s*(?:classList|hidden|disabled|style|dataset)\b/', $matches[2])) return false;
+        if (preg_match_all('/\b(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(?:(?:document|[A-Za-z_$][A-Za-z0-9_$]*)\s*\.\s*)?querySelector(?:All)?\s*\(\s*(["\'])' . $quoted . '\2\s*\)/', $script, $assignments, PREG_SET_ORDER)) {
+            foreach ($assignments as $assignment) {
+                $variable = preg_quote((string) $assignment[1], '/');
+                if (preg_match('/\b' . $variable . '\s*\.\s*(?:addEventListener|appendChild|removeChild|replaceChildren|insertAdjacentHTML|setAttribute|removeAttribute|toggleAttribute|getContext|submit|fetch)\b|\b' . $variable . '\s*\.\s*(?:textContent|innerHTML|outerHTML|value|checked|selectedIndex|classList|hidden|disabled|style|dataset)\b/', $script)) return false;
+            }
+        }
+        if (!preg_match('/querySelector(?:All)?\s*\(\s*(["\'])' . $quoted . '\1\s*\)([^;]{0,700})/', $script, $matches)) return false;
+        if (preg_match('/\b(?:addEventListener|appendChild|removeChild|replaceChildren|insertAdjacentHTML|innerHTML|outerHTML|textContent|value|checked|selectedIndex|setAttribute|removeAttribute|toggleAttribute|getContext|submit|fetch)\b|\.\s*(?:classList|hidden|disabled|style|dataset)\b/', $matches[2])) return false;
         return true;
-    }
-
-    private function presentational(string $selector): bool
-    {
-        preg_match('/(?:\[data-|[.#])([A-Za-z][A-Za-z0-9_-]*)/', $selector, $match);
-        foreach (preg_split('/[^a-z0-9]+/', strtolower($match[1] ?? '')) ?: array() as $token) if (in_array($token, array('animate', 'animation', 'appear', 'count', 'counter', 'delay', 'fade', 'motion', 'parallax', 'reveal', 'scroll', 'stagger', 'transition'), true)) return true;
-        return false;
     }
     private function selectorPattern(): string { return RuntimeSelectorVocabulary::scriptSelectorPattern(); }
     private function canonicalSelector(string $selector): string { $selector = trim($selector); return preg_match('/^(?:([a-z][a-z0-9-]*))?\[(data-[A-Za-z][A-Za-z0-9_-]*)(?:=["\'][^"\']{1,80}["\'])?\]$/', $selector, $match) ? strtolower($match[1] ?? '') . '[' . strtolower($match[2]) . ']' : $selector; }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1762,6 +1762,18 @@ $assert('#live-filter' === ($artifactControlIslands[0]['selector'] ?? ''), 'arti
 $assert(str_contains((string) ($artifactControlIslands[0]['source_snippet'] ?? ''), '<input id="live-filter"'), 'artifact runtime control island preserves source snippet metadata');
 $artifactControlRuntimeReport = $artifactControlSelectors['source_reports']['runtime_dependency_parity'] ?? array();
 $assert('pass' === ($artifactControlRuntimeReport['status'] ?? ''), 'runtime parity does not flag readable static controls as missing runtime targets');
+$artifactNeutralRuntimeSelector = ( new ArtifactCompiler() )->compile(
+    array(
+        'entrypoint' => 'index.html',
+        'files'      => array(
+            'index.html' => '<main><div class="hero-banner"><p>Welcome</p></div><script src="js/app.js"></script></main>',
+            'js/app.js'  => 'document.querySelector(".hero-banner");',
+        ),
+    )
+)->toArray();
+$artifactNeutralRuntimeIslands = $artifactNeutralRuntimeSelector['source_reports']['runtime_islands'] ?? array();
+$assert(1 === count($artifactNeutralRuntimeIslands) && '.hero-banner' === ($artifactNeutralRuntimeIslands[0]['selector'] ?? ''), 'artifact compilation preserves a neutral queried selector identified by shared fail-closed runtime evidence');
+$assert('pass' === ($artifactNeutralRuntimeSelector['source_reports']['runtime_dependency_parity']['status'] ?? ''), 'runtime parity consumes the same neutral selector evidence as artifact compilation');
 $artifactRuntimeAnchor = ( new ArtifactCompiler() )->compile(
     array(
         'entrypoint' => 'index.html',

--- a/php-transformer/tests/unit/runtime-script-evidence-analyzer.php
+++ b/php-transformer/tests/unit/runtime-script-evidence-analyzer.php
@@ -28,5 +28,23 @@ $assert(in_array('#app', $minified['mutation_selectors'], true), 'Minified mutat
 $oversized = $analyzer->analyze(str_repeat('x', 1048577), 'index.html', 'assets/large.js');
 $assert('runtime_script_analysis_truncated' === $oversized['diagnostics'][0]['code'] && true === $oversized['diagnostics'][0]['fail_closed'], 'Oversized scripts emit a deterministic fail-closed diagnostic.');
 
+$presentation = array_column($analyzer->analyze('document.querySelector(".fade-in");')['dependencies'], null, 'selector');
+$assert(true === $presentation['.fade-in']['presentation_only'], 'Canonical unmutated animation selectors remain presentation-only.');
+foreach (array('.hero-banner', '#promo-block', '.cart-drawer') as $selector) {
+    $dependencies = array_column($analyzer->analyze('document.querySelector("' . $selector . '");')['dependencies'], null, 'selector');
+    $assert(false === $dependencies[$selector]['presentation_only'], 'Non-animation selector ' . $selector . ' remains a fail-closed runtime dependency.');
+}
+$assignedMutation = array_column($analyzer->analyze('const target=document.querySelector(".fade-in");target.classList.add("visible");')['dependencies'], null, 'selector');
+$assert(false === $assignedMutation['.fade-in']['presentation_only'], 'Mutation through an assigned selector remains behavioral evidence.');
+$idLookup = array_column($analyzer->analyze('document.getElementById("fade-in");')['dependencies'], null, 'selector');
+$assert(false === $idLookup['#fade-in']['presentation_only'], 'Presentational IDs reached outside querySelector remain fail-closed runtime dependencies.');
+$closestLookup = array_column($analyzer->analyze('target.closest(".fade-in");')['dependencies'], null, 'selector');
+$assert(false === $closestLookup['.fade-in']['presentation_only'], 'Presentational closest selectors remain fail-closed runtime dependencies.');
+
+$cachedScript = 'document.querySelector("#runtime-root");';
+$analyzer->analyze($cachedScript, 'first.html', 'assets/runtime.js');
+$secondOwner = $analyzer->analyze($cachedScript, 'second.html', 'assets/runtime.js');
+$assert('second.html' === $secondOwner['source_path'], 'Memoized evidence keeps ownership-specific cache entries.');
+
 if ($failures) throw new RuntimeException(implode("\n", $failures));
 fwrite(STDOUT, "runtime-script-evidence-analyzer: {$assertions} assertions\n");


### PR DESCRIPTION
## Summary

- reuse one bounded runtime-script evidence analyzer across artifact compilation and dependency parity
- make presentation-only classification canonical and fail-closed, including assigned-variable mutation evidence
- remove the compiler's duplicate selector policy and independent selector caches

This advances the remaining single-analysis and single-policy acceptance criteria from #1464. Production code decreases by 35 lines overall.

## Verification

- `composer test`
- 292 PHP parity fixtures passed
- 385 HTML fixtures: 0 serialized-block hash differences, 0 exceptions
- focused runtime evidence and artifact compilation regressions passed

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode investigated the duplicated runtime evidence paths, implemented the consolidation under Chris Huber's direction, ran the verification suite, and performed a dedicated regression review.