### PR TITLE
Pass remaining session consumers directly

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Elements/FormCompositionPlanner.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FormCompositionPlanner.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\TransformationProvenanceState;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerSession;
 use Closure;
 use DOMElement;
 
@@ -12,14 +12,13 @@ use DOMElement;
 final class FormCompositionPlanner
 {
     /**
-     * @param Closure(): TransformationProvenanceState                                                     $transformationProvenance
      * @param Closure(DOMElement, array<int, array<string, mixed>>&, bool): array<int, array<string, mixed>> $convertChildren
      * @param Closure(DOMElement): array<string, mixed>                                                     $presentationAttributes
      * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(DOMElement, DOMElement): bool                                                         $elementContains
      */
     public function __construct(
-        private readonly Closure $transformationProvenance,
+        private readonly HtmlTransformerSession $session,
         private readonly Closure $convertChildren,
         private readonly Closure $presentationAttributes,
         private readonly Closure $createBlock,
@@ -39,7 +38,7 @@ final class FormCompositionPlanner
         }
 
         $path = $slot->getNodePath();
-        $provenance = ($this->transformationProvenance)();
+        $provenance = $this->session->transformationProvenanceState();
         $token = $provenance->reserveFormControlSlot($path);
         try {
             $children = ($this->convertChildren)($form, $fallbacks, true);

--- a/php-transformer/src/HtmlToBlocks/Elements/FormFallbackFindingContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FormFallbackFindingContext.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackDiagnostic;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerSession;
 use Closure;
 use DOMElement;
 
@@ -10,36 +12,31 @@ use DOMElement;
 final class FormFallbackFindingContext
 {
     /**
-     * @param Closure(): array<int, array<string, mixed>>                                         $stylesheetAssets
-     * @param Closure(): string                                                                    $formLayoutCss
      * @param Closure(DOMElement): array{html: string, bytes: int, truncated: bool}                $boundedFallbackHtml
      * @param Closure(DOMElement): array<int, string>                                               $runtimeDomSelectors
      * @param Closure(DOMElement): array<string, mixed>                                             $sourceContext
      * @param Closure(DOMElement): array<string, mixed>                                             $classifyFallbackSubtree
      * @param Closure(array<string, mixed>, string, array<int, string>): array<string, mixed>       $blockBinding
-     * @param Closure(array<string, mixed>): array<string, mixed>                                   $buildFallbackDiagnostic
      */
     public function __construct(
-        private readonly Closure $stylesheetAssets,
-        private readonly Closure $formLayoutCss,
+        private readonly HtmlTransformerSession $session,
         private readonly Closure $boundedFallbackHtml,
         private readonly Closure $runtimeDomSelectors,
         private readonly Closure $sourceContext,
         private readonly Closure $classifyFallbackSubtree,
-        private readonly Closure $blockBinding,
-        private readonly Closure $buildFallbackDiagnostic
+        private readonly Closure $blockBinding
     ) {
     }
 
     /** @return array<int, array<string, mixed>> */
     public function stylesheetAssets(): array
     {
-        return ($this->stylesheetAssets)();
+        return $this->session->authorStyleAnalysis()->stylesheetAssets();
     }
 
     public function formLayoutCss(): string
     {
-        return ($this->formLayoutCss)();
+        return $this->session->sourceStyleResolutionState()->formLayoutCss();
     }
 
     /** @return array{html: string, bytes: int, truncated: bool} */
@@ -79,6 +76,6 @@ final class FormFallbackFindingContext
     /** @param array<string, mixed> $finding @return array<string, mixed> */
     public function buildFallbackDiagnostic(array $finding): array
     {
-        return ($this->buildFallbackDiagnostic)($finding);
+        return FallbackDiagnostic::build($finding, $this->session->transformationProvenanceState()->fallback());
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Elements/RuntimeResourceElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/RuntimeResourceElementConverter.php
@@ -11,12 +11,11 @@ use DOMElement;
 final class RuntimeResourceElementConverter implements ElementConverter
 {
     /**
-     * @param Closure(): HtmlTransformerSession $session
      * @param Closure(DOMElement): array<string, mixed> $htmlPreservationBlock
      * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement): array<string, mixed> $createBlock
      */
     public function __construct(
-        private readonly Closure $session,
+        private readonly HtmlTransformerSession $session,
         private readonly Closure $htmlPreservationBlock,
         private readonly Closure $createBlock
     ) {
@@ -36,7 +35,7 @@ final class RuntimeResourceElementConverter implements ElementConverter
     /** @return array<string, mixed>|null */
     private function convertCanvas(DOMElement $element): ?array
     {
-        $session = $this->session();
+        $session = $this->session;
         $emitter = $session->fallbackEmitter();
         if ( ! $emitter->isRuntimeCanvasTarget($element) ) {
             return null;
@@ -60,7 +59,7 @@ final class RuntimeResourceElementConverter implements ElementConverter
     /** @param array<int, array<string, mixed>> $fallbacks @return array<string, mixed>|null */
     private function convertScript(DOMElement $element, array &$fallbacks): ?array
     {
-        $session = $this->session();
+        $session = $this->session;
         $emitter = $session->fallbackEmitter();
         $metadata = $emitter->staticScriptMetadata($element);
         if ( null === $metadata ) {
@@ -91,7 +90,7 @@ final class RuntimeResourceElementConverter implements ElementConverter
     /** @param array<int, array<string, mixed>> $fallbacks */
     private function convertTemplate(DOMElement $element, array &$fallbacks): null
     {
-        $session = $this->session();
+        $session = $this->session;
         $session->fallbackEmitter()->captureTemplateFallback($element, $fallbacks, $session->runtimeDomState());
 
         return null;
@@ -133,10 +132,5 @@ final class RuntimeResourceElementConverter implements ElementConverter
             array(),
             $element
         );
-    }
-
-    private function session(): HtmlTransformerSession
-    {
-        return ($this->session)();
     }
 }

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -10,7 +10,6 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerS
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\ReusableComponentState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeBehaviorState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeDomState;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\NavigationProjectionState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeSelectorState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\TransformationEvidenceState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\TransformationProvenanceState;
@@ -123,7 +122,6 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AuthorStylesheetPr
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\LayoutGeometryState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\NavigationStyleProjectionContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\NavigationStyleProjector;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\PresentationResolutionCache;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\RevealAnimationSettler;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssSelectorMatcher;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssSelectorMatchCache;
@@ -583,7 +581,7 @@ final class HtmlCompilation
         $this->runtimeIslands = new RuntimeIslandAnalyzer($this->createRuntimeIslandContext(), $this->pseudoFormAnalyzer);
         $this->blockMaterializer = new BlockMaterializer($this->blockFactory, $this->runtimeIslands);
         $this->runtimeResourceConverter = new RuntimeResourceElementConverter(
-            fn (): HtmlTransformerSession => $this->session,
+            $this->session,
             fn (DOMElement $element): array => $this->htmlPreservationBlock($element),
             fn (string $name, array $attributes, array $innerBlocks, DOMElement $element): array => $this->createBlock($name, $attributes, $innerBlocks, $element)
         );
@@ -620,7 +618,7 @@ final class HtmlCompilation
             fn (string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement)
         );
         $this->formCompositionPlanner = new FormCompositionPlanner(
-            fn (): TransformationProvenanceState => $this->transformationProvenance(),
+            $this->session,
             function (DOMElement $element, array &$fallbacks, bool $captureUnsupported): array {
                 return $this->convertChildren($element, $fallbacks, $captureUnsupported);
             },
@@ -639,14 +637,12 @@ final class HtmlCompilation
         );
         $this->formFallbackFindingBuilder = new FormFallbackFindingBuilder(
             new FormFallbackFindingContext(
-                fn (): array => $this->authorStyles()->stylesheetAssets(),
-                fn (): string => $this->sourceStyles()->formLayoutCss(),
+                $this->session,
                 fn (DOMElement $element): array => $this->boundedFallbackHtml($this->safeFallbackHtml($element)),
                 fn (DOMElement $element): array => $this->runtimeIslands->runtimeDomSelectorsForElement($element),
                 fn (DOMElement $element): array => $this->sourceContext($element),
                 fn (DOMElement $element): array => $this->fallbackEmitter()->classifyFallbackSubtree($element),
-                fn (array $block, string $role, array $supersededRuntimeSelectors): array => $this->blockBinding($block, $role, $supersededRuntimeSelectors),
-                fn (array $finding): array => FallbackDiagnostic::build($finding, $this->transformationProvenance()->fallback())
+                fn (array $block, string $role, array $supersededRuntimeSelectors): array => $this->blockBinding($block, $role, $supersededRuntimeSelectors)
             ),
             $this->formControlMetadataBuilder,
             $this->formSuccessPanelMetadataBuilder,
@@ -1109,11 +1105,6 @@ final class HtmlCompilation
         return $this->session->fallbackEmitter();
     }
 
-    private function presentationResolutionCache(): PresentationResolutionCache
-    {
-        return $this->session->presentationResolutionCache();
-    }
-
     private function generatedBlocks(): GeneratedBlockRegistry
     {
         return $this->session->generatedBlockRegistry()
@@ -1133,11 +1124,6 @@ final class HtmlCompilation
     private function runtimeSelectors(): RuntimeSelectorState
     {
         return $this->session->runtimeSelectorState();
-    }
-
-    private function navigationProjection(): NavigationProjectionState
-    {
-        return $this->session->navigationProjectionState();
     }
 
     private function sourceStyles(): SourceStyleResolutionState

--- a/php-transformer/tests/unit/form-composition-planner.php
+++ b/php-transformer/tests/unit/form-composition-planner.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 require __DIR__ . '/../../vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormCompositionPlanner;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\TransformationProvenanceState;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerSession;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
 $assertions = 0;
 $failures = array();
@@ -25,11 +26,12 @@ $formFrom = static function (string $html): DOMElement {
     throw new RuntimeException('No form parsed');
 };
 
-$provenance = new TransformationProvenanceState();
+$session = new HtmlTransformerSession(new Runtime(), static fn (DOMElement $element): array => array());
+$provenance = $session->transformationProvenanceState();
 $children = array();
 $capturedUnsupported = null;
 $planner = new FormCompositionPlanner(
-    static fn (): TransformationProvenanceState => $provenance,
+    $session,
     static function (DOMElement $form, array &$fallbacks, bool $captureUnsupported) use (&$children, &$capturedUnsupported, $provenance): array {
         $capturedUnsupported = $captureUnsupported;
         $fallbacks[] = array( 'converted' => true );

--- a/php-transformer/tests/unit/form-fallback-finding-builder.php
+++ b/php-transformer/tests/unit/form-fallback-finding-builder.php
@@ -8,6 +8,9 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormFallbackFin
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormFallbackFindingContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormSuccessPanelMetadataBuilder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\PseudoFormAnalyzer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerSession;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AuthorStyleAnalysis;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
 $assertions = 0;
 $failures = array();
@@ -42,9 +45,17 @@ $successBuilder = new FormSuccessPanelMetadataBuilder(
 );
 $pseudoAnalyzer = new PseudoFormAnalyzer($metadataBuilder, $selector);
 $bindingCalls = array();
+$sourceDocument = new DOMDocument();
+$sourceDocument->loadHTML('<?xml encoding="utf-8" ?><body></body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+$sourceBody = $sourceDocument->getElementsByTagName('body')->item(0);
+if ( ! $sourceBody instanceof DOMElement ) {
+    throw new RuntimeException('No source body parsed');
+}
+$session = new HtmlTransformerSession(new Runtime(), static fn (DOMElement $element): array => array());
+$session->installAuthorStyleAnalysis(new AuthorStyleAnalysis('', '', array(), $sourceBody));
+$session->transformationProvenanceState()->installFallback(array( 'provenance' => 'fixture' ));
 $context = new FormFallbackFindingContext(
-    static fn (): array => array(),
-    static fn (): string => '',
+    $session,
     static fn (DOMElement $element): array => array( 'html' => '<safe-form>', 'bytes' => 11, 'truncated' => true ),
     static fn (DOMElement $element): array => array( '#existing-runtime' ),
     static fn (DOMElement $element): array => array( 'source' => 'fixture' ),
@@ -52,8 +63,7 @@ $context = new FormFallbackFindingContext(
     static function (array $block, string $role, array $selectors) use (&$bindingCalls): array {
         $bindingCalls[] = compact('block', 'role', 'selectors');
         return array( 'role' => $role, 'selectors' => $selectors, 'blockName' => $block['blockName'] ?? '' );
-    },
-    static fn (array $finding): array => array_merge(array( 'provenance' => 'fixture' ), $finding)
+    }
 );
 $builder = new FormFallbackFindingBuilder($context, $metadataBuilder, $successBuilder, $pseudoAnalyzer);
 

--- a/php-transformer/tests/unit/runtime-resource-element-converter.php
+++ b/php-transformer/tests/unit/runtime-resource-element-converter.php
@@ -42,7 +42,7 @@ $session->fallbackEmitter()->configure(array(), array(), $selectors);
 
 $preserved = 0;
 $converter = new RuntimeResourceElementConverter(
-    static fn (): HtmlTransformerSession => $session,
+    $session,
     static function (DOMElement $element) use (&$preserved): array {
         ++$preserved;
         return array( 'blockName' => 'core/html', 'attrs' => array( 'content' => 'preserved:' . $element->tagName ) );


### PR DESCRIPTION
## Summary
- pass `HtmlTransformerSession` directly to runtime resources and form composition/fallback consumers
- remove the final five lazy closures whose only purpose was forwarding run-scoped state
- delete two session-forwarding methods made unreachable by the typed context migration

## Verification
- `composer test` (includes 292 parity fixtures)
- 385 serialized-block fixture hashes: 0 differences, 0 exceptions
- HTML-to-blocks closure fields: 278 -> 273
- callback-context closure fields: 239 -> 236
- 12 net lines removed
- `git diff --check`
- Homeboy architecture audit: no introduced findings (`0e2ce08e-f9ca-42ad-8b35-2b53942b08a5`)

## AI Assistance
OpenAI GPT-5.6 Sol was used through OpenCode to inspect the remaining session seams, implement the refactor, adapt focused tests, and run verification. Chris directed the scope and reviewed the evidence.