### PR TITLE
Pass source classifier as typed context

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Elements/ButtonElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/ButtonElementContext.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Closure;
 use DOMElement;
 
@@ -10,8 +11,8 @@ use DOMElement;
 final class ButtonElementContext
 {
     public function __construct(
+        private readonly SourceElementClassifier $sourceElementClassifier,
         private readonly Closure $isReplacedSearchClusterControl,
-        private readonly Closure $isImageCarrierButton,
         private readonly Closure $convertChildren,
         private readonly Closure $presentationAttributes,
         private readonly Closure $createBlock,
@@ -26,7 +27,7 @@ final class ButtonElementContext
 
     public function isImageCarrierButton(DOMElement $element): bool
     {
-        return ($this->isImageCarrierButton)($element);
+        return $this->sourceElementClassifier->isImageCarrierButton($element);
     }
 
     /** @param array<int, array<string, mixed>> $fallbacks @return array<int, array<string, mixed>> */

--- a/php-transformer/src/HtmlToBlocks/Elements/ButtonLinkDispatchContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/ButtonLinkDispatchContext.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Closure;
 use DOMElement;
 
@@ -22,10 +23,10 @@ final class ButtonLinkDispatchContext
      * @param Closure(DOMElement, array<int, string>, array<int, string>): array<string, mixed>               $presentationAttributes
      * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(string): string                                                                        $safeLinkUrl
-     * @param Closure(DOMElement): bool                                                                      $hasBlockContentChildren
      * @param Closure(DOMElement): array<string, mixed>                                                      $structuralPresentationDeclarations
      */
     public function __construct(
+        private readonly SourceElementClassifier $sourceElementClassifier,
         private readonly Closure $isRuntimeDomTarget,
         private readonly Closure $recordRuntimeControlIsland,
         private readonly Closure $htmlPreservationBlock,
@@ -36,7 +37,6 @@ final class ButtonLinkDispatchContext
         private readonly Closure $presentationAttributes,
         private readonly Closure $createBlock,
         private readonly Closure $safeLinkUrl,
-        private readonly Closure $hasBlockContentChildren,
         private readonly Closure $structuralPresentationDeclarations
     ) {
     }
@@ -122,7 +122,7 @@ final class ButtonLinkDispatchContext
 
     public function hasBlockContentChildren(DOMElement $element): bool
     {
-        return ($this->hasBlockContentChildren)($element);
+        return $this->sourceElementClassifier->hasBlockContentChildren($element);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Elements/DescriptionListElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/DescriptionListElementContext.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Closure;
 use DOMElement;
 
@@ -20,9 +21,9 @@ final class DescriptionListElementContext
      * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(DOMElement): string $richTextContent
      * @param Closure(string): bool $hasVisibleText
-     * @param Closure(DOMElement): bool $hasBlockContentChildren
      */
     public function __construct(
+        private readonly SourceElementClassifier $sourceElementClassifier,
         private readonly Closure $descriptionListBlock,
         private readonly Closure $metadataGridBlock,
         private readonly Closure $definitionListItems,
@@ -32,8 +33,7 @@ final class DescriptionListElementContext
         private readonly Closure $convertChildren,
         private readonly Closure $createBlock,
         private readonly Closure $richTextContent,
-        private readonly Closure $hasVisibleText,
-        private readonly Closure $hasBlockContentChildren
+        private readonly Closure $hasVisibleText
     ) {
     }
 
@@ -96,6 +96,6 @@ final class DescriptionListElementContext
 
     public function hasBlockContentChildren(DOMElement $element): bool
     {
-        return ($this->hasBlockContentChildren)($element);
+        return $this->sourceElementClassifier->hasBlockContentChildren($element);
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Elements/InlineContentElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/InlineContentElementContext.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Closure;
 use DOMElement;
 
@@ -21,7 +22,6 @@ final class InlineContentElementContext
      * @param Closure(DOMElement, array<int, array<string, mixed>>&, bool): array<int, array<string, mixed>> $convertChildren
      * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(DOMElement): string $richTextMarker
-     * @param Closure(DOMElement): bool $hasBlockContentChildren
      * @param Closure(DOMElement): array<string, string> $richTextInlineVisualDeclarations
      * @param Closure(DOMElement): ?string $dynamicTextContent
      * @param Closure(DOMElement, string): ?DOMElement $ancestorElement
@@ -30,6 +30,7 @@ final class InlineContentElementContext
      * @param Closure(DOMElement): array<string, mixed> $emptyVisualSpacerBlock
      */
     public function __construct(
+        private readonly SourceElementClassifier $sourceElementClassifier,
         private readonly Closure $recognizePatterns,
         private readonly Closure $isRuntimeDomTarget,
         private readonly Closure $htmlPreservationBlock,
@@ -41,7 +42,6 @@ final class InlineContentElementContext
         private readonly Closure $convertChildren,
         private readonly Closure $createBlock,
         private readonly Closure $richTextMarker,
-        private readonly Closure $hasBlockContentChildren,
         private readonly Closure $richTextInlineVisualDeclarations,
         private readonly Closure $dynamicTextContent,
         private readonly Closure $ancestorElement,
@@ -68,7 +68,7 @@ final class InlineContentElementContext
     /** @param array<string, mixed> $attributes @param array<int, array<string, mixed>> $innerBlocks @return array<string, mixed> */
     public function createBlock(string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array { return ($this->createBlock)($name, $attributes, $innerBlocks, $sourceElement); }
     public function richTextMarker(DOMElement $element): string { return ($this->richTextMarker)($element); }
-    public function hasBlockContentChildren(DOMElement $element): bool { return ($this->hasBlockContentChildren)($element); }
+    public function hasBlockContentChildren(DOMElement $element): bool { return $this->sourceElementClassifier->hasBlockContentChildren($element); }
     /** @return array<string, string> */
     public function richTextInlineVisualDeclarations(DOMElement $element): array { return ($this->richTextInlineVisualDeclarations)($element); }
     public function dynamicTextContent(DOMElement $element): ?string { return ($this->dynamicTextContent)($element); }

--- a/php-transformer/src/HtmlToBlocks/Elements/RuntimeIslandContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/RuntimeIslandContext.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackEmitter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerSession;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeDomState;
@@ -23,17 +24,14 @@ final class RuntimeIslandContext
      * @param Closure(DOMElement): array<int, array<string, mixed>>           $requiredScriptsForElement
      * @param Closure(string): ?DOMElement                                    $preservedHtmlRootElement
      * @param Closure(DOMElement): bool                                       $hasWorkspaceSurface
-     * @param Closure(string): bool                                           $isInlineContentElement
-     * @param Closure(string): bool                                           $isPresentationalAnimationSelector
      */
     public function __construct(
         private readonly HtmlTransformerSession $session,
+        private readonly SourceElementClassifier $sourceElementClassifier,
         private readonly Closure $descendantElements,
         private readonly Closure $requiredScriptsForElement,
         private readonly Closure $preservedHtmlRootElement,
-        private readonly Closure $hasWorkspaceSurface,
-        private readonly Closure $isInlineContentElement,
-        private readonly Closure $isPresentationalAnimationSelector
+        private readonly Closure $hasWorkspaceSurface
     ) {
     }
 
@@ -80,11 +78,11 @@ final class RuntimeIslandContext
 
     public function isInlineContentElement(string $tagName): bool
     {
-        return ($this->isInlineContentElement)($tagName);
+        return $this->sourceElementClassifier->isInlineContentElement($tagName);
     }
 
     public function isPresentationalAnimationSelector(string $selector): bool
     {
-        return ($this->isPresentationalAnimationSelector)($selector);
+        return $this->sourceElementClassifier->isPresentationalAnimationSelector($selector);
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Elements/SvgElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/SvgElementContext.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Closure;
 use DOMElement;
 
@@ -14,18 +15,17 @@ final class SvgElementContext
      * @param Closure(DOMElement): bool $isRuntimeDomTarget
      * @param Closure(DOMElement): string $sanitizeMarkup
      * @param Closure(string): bool $isSafeContent
-     * @param Closure(DOMElement): bool $isVisualLayerElement
      * @param Closure(DOMElement): bool $hasDrawableContent
      * @param Closure(DOMElement): array<string, mixed> $presentationAttributes
      * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(DOMElement, array<int, array<string, mixed>>&): void $captureFallback
      */
     public function __construct(
+        private readonly SourceElementClassifier $sourceElementClassifier,
         private readonly Closure $isInertHiddenStorage,
         private readonly Closure $isRuntimeDomTarget,
         private readonly Closure $sanitizeMarkup,
         private readonly Closure $isSafeContent,
-        private readonly Closure $isVisualLayerElement,
         private readonly Closure $hasDrawableContent,
         private readonly Closure $presentationAttributes,
         private readonly Closure $createBlock,
@@ -55,7 +55,7 @@ final class SvgElementContext
 
     public function isVisualLayerElement(DOMElement $element): bool
     {
-        return ($this->isVisualLayerElement)($element);
+        return $this->sourceElementClassifier->isVisualLayerElement($element);
     }
 
     public function hasDrawableContent(DOMElement $element): bool

--- a/php-transformer/src/HtmlToBlocks/Elements/TextLeafElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/TextLeafElementContext.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Closure;
 use DOMElement;
 
@@ -24,10 +25,10 @@ final class TextLeafElementContext
      * @param Closure(string): string                                                          $escapeHtml
      * @param Closure(DOMElement, DOMElement): array<string, mixed>                            $codePresentationAttributes
      * @param Closure(DOMElement): string                                                      $codeContent
-     * @param Closure(DOMElement): bool                                                        $hasBlockContentChildren
      * @param Closure(DOMElement, array<int, array<string, mixed>>, bool): array<int, array<string, mixed>> $convertChildren
      */
     public function __construct(
+        private readonly SourceElementClassifier $sourceElementClassifier,
         private readonly Closure $presentationAttributes,
         private readonly Closure $createBlock,
         private readonly Closure $richTextContent,
@@ -35,7 +36,6 @@ final class TextLeafElementContext
         private readonly Closure $escapeHtml,
         private readonly Closure $codePresentationAttributes,
         private readonly Closure $codeContent,
-        private readonly Closure $hasBlockContentChildren,
         private readonly Closure $convertChildren
     ) {
     }
@@ -93,7 +93,7 @@ final class TextLeafElementContext
 
     public function hasBlockContentChildren(DOMElement $element): bool
     {
-        return ($this->hasBlockContentChildren)($element);
+        return $this->sourceElementClassifier->hasBlockContentChildren($element);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -496,8 +496,8 @@ final class HtmlCompilation
         $this->stylesheetAnalysisComposer = new StylesheetAnalysisComposer($this->styleResolver, $this->analysisCache);
         $this->authorSelectorSemanticPreparer = new AuthorSelectorSemanticPreparer(
             new AuthorSelectorSemanticContext(
+                $this->sourceElementClassifier,
                 fn (DOMElement $element): bool => $this->isDirectChildOfAuthorOwnedLayout($element),
-                fn (string $tagName): bool => $this->sourceElementClassifier->isInlineContentElement($tagName),
                 fn (DOMElement $element): bool => $this->isStructuralListItem($element),
                 fn (DOMElement $element): bool => $this->requiresIndependentSemanticWrapper($element),
                 fn (DOMElement $element): bool => $this->requiresStandaloneInlineLayoutLeaf($element),
@@ -527,11 +527,11 @@ final class HtmlCompilation
             $this->runtime
         );
         $svgConverter = new SvgElementConverter(new SvgElementContext(
+            $this->sourceElementClassifier,
             fn (DOMElement $element): bool => $this->isInertHiddenSvgStorage($element),
             fn (DOMElement $element): bool => $this->runtimeIslands->isRuntimeDomTarget($element),
             fn (DOMElement $element): string => $this->sanitizeInlineSvgMarkup($element),
             fn (string $html): bool => $this->isSafeSvgContent($html),
-            fn (DOMElement $element): bool => $this->sourceElementClassifier->isVisualLayerElement($element),
             fn (DOMElement $element): bool => $this->svgHasDrawableContent($element),
             fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
             fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
@@ -540,6 +540,7 @@ final class HtmlCompilation
             }
         ), $this->svgMaterializer);
         $inlineContentConverter = new InlineContentElementConverter(new InlineContentElementContext(
+            $this->sourceElementClassifier,
             fn (DOMElement $element, array &$fallbacks, array $patterns): ?array => $this->recognizePatterns($element, $fallbacks, $patterns),
             fn (DOMElement $element): bool => $this->runtimeIslands->isRuntimeDomTarget($element),
             fn (DOMElement $element): array => $this->htmlPreservationBlock($element),
@@ -551,7 +552,6 @@ final class HtmlCompilation
             fn (DOMElement $element, array &$fallbacks, bool $captureUnsupported): array => $this->convertChildren($element, $fallbacks, $captureUnsupported),
             fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
             fn (DOMElement $element): string => $this->richTextMarkerForElement($element),
-            fn (DOMElement $element): bool => $this->sourceElementClassifier->hasBlockContentChildren($element),
             fn (DOMElement $element): array => $this->richTextInlineVisualDeclarations($element),
             fn (DOMElement $element): ?string => $this->dynamicTextContent($element),
             fn (DOMElement $element, string $tagName): ?DOMElement => $this->ancestorElement($element, $tagName),
@@ -665,8 +665,8 @@ final class HtmlCompilation
         ));
         $this->buttonLinkDispatcher = new ButtonLinkDispatcher($this->createButtonLinkDispatchContext());
         $buttonConverter = new ButtonElementConverter(new ButtonElementContext(
+            $this->sourceElementClassifier,
             fn (DOMElement $element): bool => $this->searchBlockConverter->isReplacedSearchClusterControl($element),
-            fn (DOMElement $element): bool => $this->sourceElementClassifier->isImageCarrierButton($element),
             function (DOMElement $element, array &$fallbacks, bool $captureUnsupported): array {
                 return $this->convertChildren($element, $fallbacks, $captureUnsupported);
             },
@@ -746,6 +746,7 @@ final class HtmlCompilation
             fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement)
         ));
         $descriptionListConverter = new DescriptionListElementConverter(new DescriptionListElementContext(
+            $this->sourceElementClassifier,
             fn (DOMElement $element): ?array => $this->descriptionListBlockFromElement($element),
             fn (DOMElement $element): ?array => $this->metadataGridBlockFromElement($element),
             fn (DOMElement $element): array => $this->definitionListItems($element),
@@ -757,8 +758,7 @@ final class HtmlCompilation
             },
             fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
             fn (DOMElement $element): string => $this->richTextContentWithMaterializedInlineStyles($element),
-            fn (string $html): bool => '' !== trim($this->runtime->stripAllTags($html)),
-            fn (DOMElement $element): bool => $this->sourceElementClassifier->hasBlockContentChildren($element)
+            fn (string $html): bool => '' !== trim($this->runtime->stripAllTags($html))
         ));
         $this->structuralContentConverters = new OrderedElementConverterRegistry(array(
             $inlineContentConverter,
@@ -913,10 +913,9 @@ final class HtmlCompilation
     {
         return new SvgMaterializationContext(
             $this->session,
+            $this->sourceElementClassifier,
             fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null, ?DOMElement $logicalSourceElement = null): array
                 => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement, $logicalSourceElement),
-            fn (string $tagName): bool => $this->sourceElementClassifier->isInlineContentElement($tagName),
-            fn (DOMElement $element): bool => $this->sourceElementClassifier->isVisualLayerElement($element),
             fn (DOMElement $element): ?string => $this->reusableComponentFingerprintFor($element),
             fn (DOMElement $element): string => $this->safeFallbackHtml($element),
             fn (DOMElement $element): string => $this->sanitizeInlineSvgMarkup($element)
@@ -955,6 +954,7 @@ final class HtmlCompilation
     private function createButtonLinkDispatchContext(): ButtonLinkDispatchContext
     {
         return new ButtonLinkDispatchContext(
+            $this->sourceElementClassifier,
             fn (DOMElement $element): bool => $this->runtimeIslands->isRuntimeDomTarget($element),
             function (DOMElement $element): void {
                 $this->formRuntimeIslandRecorder->recordControl($element);
@@ -973,7 +973,6 @@ final class HtmlCompilation
             fn (DOMElement $element, array $excludedProperties, array $excludedGeometryProperties): array => $this->styleResolver->presentationAttributes($element, $excludedProperties, $excludedGeometryProperties),
             fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
             fn (string $href): string => $this->safeLinkUrl($href),
-            fn (DOMElement $element): bool => $this->sourceElementClassifier->hasBlockContentChildren($element),
             fn (DOMElement $element): array => $this->styleResolver->structuralPresentationDeclarations($element)
         );
     }
@@ -983,12 +982,11 @@ final class HtmlCompilation
     {
         return new RuntimeIslandContext(
             $this->session,
+            $this->sourceElementClassifier,
             fn (DOMElement $element): iterable => $this->descendantElements($element),
             fn (DOMElement $element): array => $this->requiredScriptsForElement($element),
             fn (string $html): ?DOMElement => $this->preservedHtmlRootElement($html),
-            fn (DOMElement $element): bool => $this->hasWorkspaceSurface($element),
-            fn (string $tagName): bool => $this->sourceElementClassifier->isInlineContentElement($tagName),
-            fn (string $selector): bool => $this->sourceElementClassifier->isPresentationalAnimationSelector($selector)
+            fn (DOMElement $element): bool => $this->hasWorkspaceSurface($element)
         );
     }
 
@@ -1061,6 +1059,7 @@ final class HtmlCompilation
     private function createTextLeafElementContext(): TextLeafElementContext
     {
         return new TextLeafElementContext(
+            $this->sourceElementClassifier,
             fn (DOMElement $element, array $excludedProperties, array $excludedGeometryProperties): array => $this->styleResolver->presentationAttributes($element, $excludedProperties, $excludedGeometryProperties),
             fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
             fn (DOMElement $element, array $excludedTags): string => $this->richTextContentWithMaterializedInlineStyles($element, $excludedTags),
@@ -1068,7 +1067,6 @@ final class HtmlCompilation
             fn (string $text): string => $this->runtime->escapeHtml($text),
             fn (DOMElement $pre, DOMElement $code): array => $this->codePresentationAttributes($pre, $code),
             fn (DOMElement $code): string => $this->codeContent($code),
-            fn (DOMElement $element): bool => $this->sourceElementClassifier->hasBlockContentChildren($element),
             function (DOMElement $element, array &$fallbacks, bool $captureUnsupported): array {
                 return $this->convertChildren($element, $fallbacks, $captureUnsupported);
             }
@@ -2599,9 +2597,9 @@ final class HtmlCompilation
                 )
             ),
             new QuotePatternContext(
+                $this->sourceElementClassifier,
                 fn (DOMElement $sourceElement): string => $this->citationFromElement($sourceElement),
-                fn (string $html): string => $this->runtime->stripAllTags($html),
-                fn (string $inlineTagName): bool => $this->sourceElementClassifier->isInlineContentElement($inlineTagName)
+                fn (string $html): string => $this->runtime->stripAllTags($html)
             ),
             new CodeWindowPatternContext(
                 fn (DOMElement $sourcePre, DOMElement $sourceCode): array => $this->codePresentationAttributes($sourcePre, $sourceCode),

--- a/php-transformer/src/HtmlToBlocks/Patterns/QuotePatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/QuotePatternContext.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Closure;
 use DOMElement;
 
@@ -11,16 +12,15 @@ final class QuotePatternContext
     /**
      * @param Closure(DOMElement): string $citationFromElement
      * @param Closure(string): string $stripAllTags
-     * @param Closure(string): bool $isInlineContentElement
      */
     public function __construct(
+        private readonly SourceElementClassifier $sourceElementClassifier,
         private readonly Closure $citationFromElement,
-        private readonly Closure $stripAllTags,
-        private readonly Closure $isInlineContentElement
+        private readonly Closure $stripAllTags
     ) {
     }
 
     public function citationFromElement(DOMElement $element): string { return ($this->citationFromElement)($element); }
     public function stripAllTags(string $html): string { return ($this->stripAllTags)($html); }
-    public function isInlineContentElement(string $tagName): bool { return ($this->isInlineContentElement)($tagName); }
+    public function isInlineContentElement(string $tagName): bool { return $this->sourceElementClassifier->isInlineContentElement($tagName); }
 }

--- a/php-transformer/src/HtmlToBlocks/Style/AuthorSelectorSemanticContext.php
+++ b/php-transformer/src/HtmlToBlocks/Style/AuthorSelectorSemanticContext.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Closure;
 use DOMElement;
 
@@ -11,15 +12,14 @@ final class AuthorSelectorSemanticContext
 {
     /**
      * @param Closure(DOMElement): bool        $isDirectChildOfAuthorOwnedLayout
-     * @param Closure(string): bool            $isInlineContentElement
      * @param Closure(DOMElement): bool        $isStructuralListItem
      * @param Closure(DOMElement): bool        $requiresIndependentSemanticWrapper
      * @param Closure(DOMElement): bool        $requiresInlineLayoutCarrier
      * @param Closure(DOMElement): bool        $isRepresentableTable
      */
     public function __construct(
+        private readonly SourceElementClassifier $sourceElementClassifier,
         private readonly Closure $isDirectChildOfAuthorOwnedLayout,
-        private readonly Closure $isInlineContentElement,
         private readonly Closure $isStructuralListItem,
         private readonly Closure $requiresIndependentSemanticWrapper,
         private readonly Closure $requiresInlineLayoutCarrier,
@@ -33,7 +33,7 @@ final class AuthorSelectorSemanticContext
 
     public function isInlineContentElement(string $tagName): bool
     {
-        return ($this->isInlineContentElement)($tagName);
+        return $this->sourceElementClassifier->isInlineContentElement($tagName);
     }
 
     public function isStructuralListItem(DOMElement $element): bool

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationContext.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationContext.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\AssetMaterializationState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerSession;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\TransformationEvidenceState;
@@ -21,17 +22,14 @@ final class SvgMaterializationContext
 {
     /**
      * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement, ?DOMElement): array<string, mixed> $createBlock
-     * @param Closure(string): bool                                                                $isInlineContentElement
-     * @param Closure(DOMElement): bool                                                            $isVisualLayerElement
      * @param Closure(DOMElement): ?string                                                         $reusableComponentFingerprintFor
      * @param Closure(DOMElement): string                                                          $safeFallbackHtml
      * @param Closure(DOMElement): string                                                          $sanitizeInlineSvgMarkup
      */
     public function __construct(
         private readonly HtmlTransformerSession $session,
+        private readonly SourceElementClassifier $sourceElementClassifier,
         private readonly Closure $createBlock,
-        private readonly Closure $isInlineContentElement,
-        private readonly Closure $isVisualLayerElement,
         private readonly Closure $reusableComponentFingerprintFor,
         private readonly Closure $safeFallbackHtml,
         private readonly Closure $sanitizeInlineSvgMarkup
@@ -55,12 +53,12 @@ final class SvgMaterializationContext
 
     public function isInlineContentElement(string $tagName): bool
     {
-        return ($this->isInlineContentElement)($tagName);
+        return $this->sourceElementClassifier->isInlineContentElement($tagName);
     }
 
     public function isVisualLayerElement(DOMElement $element): bool
     {
-        return ($this->isVisualLayerElement)($element);
+        return $this->sourceElementClassifier->isVisualLayerElement($element);
     }
 
     public function layoutGeometry(): LayoutGeometryState

--- a/php-transformer/tests/unit/button-element-converter.php
+++ b/php-transformer/tests/unit/button-element-converter.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 require __DIR__ . '/../../vendor/autoload.php';
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonElementConverter;
 
@@ -16,25 +17,22 @@ $assert = static function (bool $condition, string $label) use (&$assertions, &$
 };
 
 $document = new DOMDocument();
-$document->loadHTML('<?xml encoding="utf-8" ?><body><button>Go</button><div></div></body>', LIBXML_NOERROR | LIBXML_NOWARNING);
+$document->loadHTML('<?xml encoding="utf-8" ?><body><button>Go</button><button><img src="x"></button><div></div></body>', LIBXML_NOERROR | LIBXML_NOWARNING);
 $button = $document->getElementsByTagName('button')->item(0);
+$imageButton = $document->getElementsByTagName('button')->item(1);
 $div = $document->getElementsByTagName('div')->item(0);
-if ( ! $button instanceof DOMElement || ! $div instanceof DOMElement ) {
+if ( ! $button instanceof DOMElement || ! $imageButton instanceof DOMElement || ! $div instanceof DOMElement ) {
     throw new RuntimeException('Fixture elements not parsed');
 }
 
 $mode = 'generic';
-$imageCalls = 0;
 $genericCalls = 0;
 $captureUnsupported = null;
 $genericBlock = array( 'blockName' => 'core/buttons' );
 $converter = new ButtonElementConverter(new ButtonElementContext(
+    new SourceElementClassifier(),
     static function (DOMElement $element) use (&$mode): bool {
         return 'search' === $mode;
-    },
-    static function (DOMElement $element) use (&$mode, &$imageCalls): bool {
-        ++$imageCalls;
-        return in_array($mode, array( 'image', 'empty-image' ), true);
     },
     static function (DOMElement $element, array &$fallbacks, bool $capture) use (&$mode, &$captureUnsupported): array {
         $captureUnsupported = $capture;
@@ -55,22 +53,22 @@ $converter = new ButtonElementConverter(new ButtonElementContext(
 $fallbacks = array();
 
 $unhandled = $converter->convert($div, 'div', $fallbacks);
-$assert(! $unhandled->handled && 0 === $imageCalls && 0 === $genericCalls, 'non-button-unhandled');
+$assert(! $unhandled->handled && 0 === $genericCalls, 'non-button-unhandled');
 
 $mode = 'search';
 $search = $converter->convert($button, 'button', $fallbacks);
 $assert($search->handled && null === $search->block, 'replaced-search-control-suppressed');
-$assert(0 === $imageCalls && 0 === $genericCalls, 'search-short-circuits-later-routes');
+$assert(0 === $genericCalls, 'search-short-circuits-later-routes');
 
 $mode = 'image';
-$image = $converter->convert($button, 'button', $fallbacks);
+$image = $converter->convert($imageButton, 'button', $fallbacks);
 $assert('core/group' === ($image->block['blockName'] ?? ''), 'image-carrier-becomes-group');
 $assert('carrier' === ($image->block['attrs']['className'] ?? '') && 'core/image' === ($image->block['innerBlocks'][0]['blockName'] ?? ''), 'image-carrier-content-preserved');
 $assert(true === $captureUnsupported && 1 === count($fallbacks), 'image-children-forward-fallback-state');
 $assert(0 === $genericCalls, 'image-carrier-short-circuits-generic-button');
 
 $mode = 'empty-image';
-$emptyImage = $converter->convert($button, 'button', $fallbacks);
+$emptyImage = $converter->convert($imageButton, 'button', $fallbacks);
 $assert('core/buttons' === ($emptyImage->block['blockName'] ?? '') && 1 === $genericCalls, 'empty-image-carrier-falls-through');
 
 $mode = 'generic';

--- a/php-transformer/tests/unit/button-link-dispatcher.php
+++ b/php-transformer/tests/unit/button-link-dispatcher.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 require __DIR__ . '/../../vendor/autoload.php';
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispatchContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispatcher;
 
@@ -55,13 +56,13 @@ $makeDispatcher = static function (array $overrides = array()): ButtonLinkDispat
         'attr'             => static fn (DOMElement $e, string $n): string => $e->getAttribute($n),
         'outerHtml'        => static fn (DOMElement $e): string => $e->ownerDocument->saveHTML($e),
         'safeLinkUrl'      => static fn (string $h): string => str_starts_with($h, 'javascript:') ? '' : $h,
-        'hasBlockChildren' => static fn (DOMElement $e): bool => false,
         'mergeClassNames'  => static fn (string $a, string $b): string => trim($a . ' ' . $b),
         'structural'       => static fn (DOMElement $e): array => array(),
     );
     $c = array_merge($defaults, $overrides);
 
     return new ButtonLinkDispatcher(new ButtonLinkDispatchContext(
+        new SourceElementClassifier(),
         $c['isRuntimeTarget'],
         $c['recordIsland'],
         $c['preserve'],
@@ -72,7 +73,6 @@ $makeDispatcher = static function (array $overrides = array()): ButtonLinkDispat
         $c['presentation'],
         $c['createBlock'],
         $c['safeLinkUrl'],
-        $c['hasBlockChildren'],
         $c['structural']
     ));
 };

--- a/php-transformer/tests/unit/inline-content-element-converter.php
+++ b/php-transformer/tests/unit/inline-content-element-converter.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 require __DIR__ . '/../../vendor/autoload.php';
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\InlineContentElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\InlineContentElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolver;
@@ -29,6 +30,7 @@ $elementFrom = static function (string $html): DOMElement {
 
 $state = (object) array( 'mode' => 'plain' );
 $context = new InlineContentElementContext(
+    new SourceElementClassifier(),
     static fn (DOMElement $element, array &$fallbacks, array $patterns): ?array => 'social' === $state->mode ? array( 'blockName' => 'core/social-links' ) : null,
     static fn (DOMElement $element): bool => 'runtime' === $state->mode,
     static fn (DOMElement $element): array => array( 'blockName' => 'core/html' ),
@@ -45,7 +47,6 @@ $context = new InlineContentElementContext(
         'sourceTag' => $sourceElement?->tagName,
     ),
     static fn (DOMElement $element): string => '',
-    static fn (DOMElement $element): bool => false,
     static fn (DOMElement $element): array => array(),
     static fn (DOMElement $element): ?string => null,
     static fn (DOMElement $element, string $tagName): ?DOMElement => null,

--- a/php-transformer/tests/unit/list-element-converters.php
+++ b/php-transformer/tests/unit/list-element-converters.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 require __DIR__ . '/../../vendor/autoload.php';
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\DescriptionListElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\DescriptionListElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ListElementContext;
@@ -73,6 +74,7 @@ $assert('grid-list' === ($grid['attrs']['className'] ?? ''), 'css-grid-list-attr
 
 $state->mode = 'native';
 $descriptionContext = new DescriptionListElementContext(
+    new SourceElementClassifier(),
     static fn (DOMElement $element): ?array => 'description' === $state->mode ? array( 'blockName' => 'blocks-engine/description-list' ) : null,
     static fn (DOMElement $element): ?array => 'metadata' === $state->mode ? array( 'blockName' => 'core/group', 'attrs' => array( 'metadata' => true ) ) : null,
     static fn (DOMElement $element): array => 'items' === $state->mode ? array( array( 'blockName' => 'core/list-item' ) ) : array(),
@@ -82,8 +84,7 @@ $descriptionContext = new DescriptionListElementContext(
     static fn (DOMElement $element, array &$fallbacks, bool $capture): array => 'empty' === $state->mode ? array() : array( array( 'blockName' => 'core/paragraph' ) ),
     $createBlock,
     static fn (DOMElement $element): string => $element->textContent ?? '',
-    static fn (string $text): bool => '' !== trim(strip_tags($text)),
-    static fn (DOMElement $element): bool => 'block-detail' === $state->mode
+    static fn (string $text): bool => '' !== trim(strip_tags($text))
 );
 $descriptionConverter = new DescriptionListElementConverter($descriptionContext);
 $assert($descriptionConverter->handles('dl') && $descriptionConverter->handles('dt') && $descriptionConverter->handles('dd') && ! $descriptionConverter->handles('ul'), 'description-handles-tags');

--- a/php-transformer/tests/unit/runtime-island-analyzer.php
+++ b/php-transformer/tests/unit/runtime-island-analyzer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 require __DIR__ . '/../../vendor/autoload.php';
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormControlMetadataBuilder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\PseudoFormAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeIslandAnalyzer;
@@ -80,8 +81,6 @@ $makeAnalyzer = static function (array $domSelectors = array(), array $presentat
         'requiredScripts'  => static fn (DOMElement $e): array => array(),
         'preservedRoot'    => static fn (string $h): ?DOMElement => null,
         'hasWorkspace'     => static fn (DOMElement $e): bool => false,
-        'isInline'         => static fn (string $t): bool => in_array($t, array('span', 'em', 'strong', 'a'), true),
-        'isPresentational' => static fn (string $s): bool => in_array($s, $presentationalSelectors, true),
         'dedupe'           => static fn (array $rows): array => array_values($rows),
     );
     $c = array_merge($defaults, $overrides);
@@ -92,12 +91,11 @@ $makeAnalyzer = static function (array $domSelectors = array(), array $presentat
     $pseudoFormAnalyzer = new PseudoFormAnalyzer($metadataBuilder, $c['islandSelector']);
     return new RuntimeIslandAnalyzer(new RuntimeIslandContext(
         $session,
+        new SourceElementClassifier(),
         $c['descendants'],
         $c['requiredScripts'],
         $c['preservedRoot'],
-        $c['hasWorkspace'],
-        $c['isInline'],
-        $c['isPresentational']), $pseudoFormAnalyzer);
+        $c['hasWorkspace']), $pseudoFormAnalyzer);
 };
 
 // An id or class named by a runtime selector is a DOM target.
@@ -111,8 +109,8 @@ $assert($byClass->isRuntimeDomTarget($elementFrom('<div class="a widget b"></div
 // A selector that is only presentational animation evidence does not make the
 // element a runtime target. This is the distinction that keeps CSS-animated
 // decoration out of runtime-island preservation.
-$presentational = $makeAnalyzer(array('#mount'), array('#mount'));
-$assert(! $presentational->isRuntimeDomTarget($elementFrom('<div id="mount"></div>')), 'presentational-only-selector-is-not-runtime-target');
+$presentational = $makeAnalyzer(array('.fade'), array('.fade'));
+$assert(! $presentational->isRuntimeDomTarget($elementFrom('<div class="fade"></div>')), 'presentational-only-selector-is-not-runtime-target');
 
 // Bounded selector grammar: shapes the analyzer will accept as runtime evidence.
 $grammar = $makeAnalyzer();

--- a/php-transformer/tests/unit/svg-element-converter.php
+++ b/php-transformer/tests/unit/svg-element-converter.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 require __DIR__ . '/../../vendor/autoload.php';
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\SvgElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\SvgElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\SvgElementMaterializer;
@@ -29,11 +30,11 @@ $elementFrom = static function (string $html): DOMElement {
 $state = (object) array( 'mode' => 'block' );
 $fallbackCaptures = 0;
 $context = new SvgElementContext(
+    new SourceElementClassifier(),
     static fn (DOMElement $element): bool => 'inert' === $state->mode,
     static fn (DOMElement $element): bool => str_starts_with($state->mode, 'runtime-'),
     static fn (DOMElement $element): string => '<svg viewbox="0 0 1 1"></svg>',
     static fn (string $html): bool => 'runtime-safe' === $state->mode,
-    static fn (DOMElement $element): bool => 'visual' === $state->mode,
     static fn (DOMElement $element): bool => str_starts_with($state->mode, 'drawable-'),
     static fn (DOMElement $element): array => array( 'className' => 'visual-svg' ),
     static fn (string $name, array $attrs, array $innerBlocks, ?DOMElement $source): array => array(
@@ -110,7 +111,7 @@ $drawable = $converter->convert($svg, 'svg', $fallbacks)->block;
 $assert('core/image' === ($drawable['blockName'] ?? ''), 'decorative-drawable-block');
 
 $state->mode = 'visual';
-$visual = $converter->convert($svg, 'svg', $fallbacks)->block;
+$visual = $converter->convert($elementFrom('<svg class="decorative"><path d="M0 0"></path></svg>'), 'svg', $fallbacks)->block;
 $assert('core/group' === ($visual['blockName'] ?? '') && 'visual-svg' === ($visual['attrs']['className'] ?? ''), 'visual-layer-carrier');
 
 $state->mode = 'decorative-empty';

--- a/php-transformer/tests/unit/text-leaf-element-converter.php
+++ b/php-transformer/tests/unit/text-leaf-element-converter.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 require __DIR__ . '/../../vendor/autoload.php';
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TextLeafElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TextLeafElementConverter;
 
@@ -48,7 +49,6 @@ $makeConverter = static function (array $overrides = array()): TextLeafElementCo
         },
         'codePresentationAttributes'    => static fn (DOMElement $pre, DOMElement $code): array => array('code' => true),
         'codeContent'                   => static fn (DOMElement $c): string => (string) $c->textContent,
-        'hasBlockContentChildren'       => static fn (DOMElement $e): bool => false,
         'convertChildren'               => static function (DOMElement $e, array &$f, bool $c): array {
             return array();
         },
@@ -57,6 +57,7 @@ $makeConverter = static function (array $overrides = array()): TextLeafElementCo
     $c = array_merge($defaults, $overrides);
 
     return new TextLeafElementConverter(new TextLeafElementContext(
+        new SourceElementClassifier(),
         $c['presentationAttributes'],
         $c['createBlock'],
         $c['richTextContent'],
@@ -64,7 +65,6 @@ $makeConverter = static function (array $overrides = array()): TextLeafElementCo
         $c['escapeHtml'],
         $c['codePresentationAttributes'],
         $c['codeContent'],
-        $c['hasBlockContentChildren'],
         $c['convertChildren']
     ));
 };
@@ -134,7 +134,6 @@ $assert(array('margin-left', 'margin-right') === $seenGeometry, 'hr-excludes-hor
 // A marquee with block children groups them; a single child with no
 // presentation attributes is hoisted rather than wrapped.
 $marqueeConverter = $makeConverter(array(
-    'hasBlockContentChildren' => static fn (DOMElement $e): bool => true,
     'convertChildren'         => static function (DOMElement $e, array &$f, bool $c): array {
         return array(array('blockName' => 'core/paragraph'), array('blockName' => 'core/image'));
     },
@@ -144,7 +143,6 @@ $assert('core/group' === ($grouped['blockName'] ?? ''), 'marquee-with-children-g
 $assert(2 === count($grouped['innerBlocks'] ?? array()), 'marquee-group-keeps-children');
 
 $singleChild = $makeConverter(array(
-    'hasBlockContentChildren' => static fn (DOMElement $e): bool => true,
     'convertChildren'         => static function (DOMElement $e, array &$f, bool $c): array {
         return array(array('blockName' => 'core/image'));
     },


### PR DESCRIPTION
## Summary

- pass the shared `SourceElementClassifier` directly into 10 conversion contexts
- remove 12 classifier-forwarding closures, reducing callback-context fields from 236 to 224
- update focused unit tests to exercise the canonical classifier against representative DOM elements

## Testing

- `composer test` (including 292 parity fixtures)
- 385 serialized-block fixture hashes match `trunk`, with 0 exceptions
- `git diff --check`
- Homeboy architecture audit: no findings

## AI assistance

OpenAI gpt-5.6-sol was used through OpenCode to implement the refactor, update tests, and run verification.