### PR TITLE
Resolve site-root assets in staged compilation

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -643,7 +643,7 @@ final class ArtifactCompiler
             $runtimeScriptProjections
         );
         $wordpressCompatAsset = $this->wordpressCompat->asset($normalized['files'], $this->themeStaticCss($normalized['files'], false), $this->allScriptContents($normalized['files']));
-        $referenceReports = $this->referenceReports($normalized['files']);
+        $referenceReports = $this->referenceReports($normalized['files'], $entryPath);
         $manifestAssets = $this->assetManifest($normalized['files'], $entryPath, $referenceReports['asset_references'], $html);
         $entryOwnership = is_array($entry) ? $this->fileOwnership($entry) : array('scope' => 'page', 'id' => $entryPath);
         $generatedAssets = $this->generatedAssetsForDocuments($entryBlocks['assets'], $entryOwnership, $compiledHtmlDocuments, $normalized['files']);
@@ -3393,12 +3393,13 @@ final class ArtifactCompiler
      * @param array<int, array<string, mixed>> $files
      * @return array{internal_links: array<int, array<string, mixed>>, asset_references: array<int, array<string, mixed>>, image_references: array<int, array<string, mixed>>}
      */
-    private function referenceReports(array $files): array
+    private function referenceReports(array $files, string $entryPath): array
     {
         return ( new ReferenceAnalyzer() )->referenceReports(
             $files,
             fn (array $file): bool => $this->isLinkableDocument($file),
-            fn (array $asset): bool => $this->isSafeImageAsset($asset)
+            fn (array $asset): bool => $this->isSafeImageAsset($asset),
+            '.' === dirname($entryPath) ? '' : dirname($entryPath)
         );
     }
 

--- a/php-transformer/src/AssetAnalysis/ReferenceAnalyzer.php
+++ b/php-transformer/src/AssetAnalysis/ReferenceAnalyzer.php
@@ -13,7 +13,7 @@ final class ReferenceAnalyzer
      * @param callable(array<string, mixed>): bool|null $isSafeImageAsset
      * @return array{internal_links: array<int, array<string, mixed>>, asset_references: array<int, array<string, mixed>>, image_references: array<int, array<string, mixed>>}
      */
-    public function referenceReports(array $files, ?callable $isLinkableDocument = null, ?callable $isSafeImageAsset = null): array
+    public function referenceReports(array $files, ?callable $isLinkableDocument = null, ?callable $isSafeImageAsset = null, string $siteRoot = ''): array
     {
         $internalLinks = array();
         $assetReferences = array();
@@ -36,7 +36,7 @@ final class ReferenceAnalyzer
                         continue;
                     }
 
-                    $reference = $this->normalizeReferenceCandidate($candidate, $files, $isLinkableDocument, $isSafeImageAsset, $filesByPath);
+                    $reference = $this->normalizeReferenceCandidate($candidate, $files, $isLinkableDocument, $isSafeImageAsset, $filesByPath, $siteRoot);
                     $target = $reference['target'] ?? null;
                     if ( is_array($target) && $this->isLinkableDocument($target, $isLinkableDocument) && 'a' === $candidate['element'] ) {
                         unset($reference['target']);
@@ -60,7 +60,7 @@ final class ReferenceAnalyzer
                         continue;
                     }
 
-                    $reference = $this->normalizeReferenceCandidate($candidate, $files, $isLinkableDocument, $isSafeImageAsset, $filesByPath);
+                    $reference = $this->normalizeReferenceCandidate($candidate, $files, $isLinkableDocument, $isSafeImageAsset, $filesByPath, $siteRoot);
                     $target = $reference['target'] ?? null;
                     if ( is_array($target) && ! $this->isLinkableDocument($target, $isLinkableDocument) ) {
                         unset($reference['target']);
@@ -184,9 +184,12 @@ final class ReferenceAnalyzer
      * @param callable(array<string, mixed>): bool|null $isSafeImageAsset
      * @return array<string, mixed>
      */
-    public function normalizeReferenceCandidate(array $candidate, array $files, ?callable $isLinkableDocument = null, ?callable $isSafeImageAsset = null, ?array $filesByPath = null): array
+    public function normalizeReferenceCandidate(array $candidate, array $files, ?callable $isLinkableDocument = null, ?callable $isSafeImageAsset = null, ?array $filesByPath = null, string $siteRoot = ''): array
     {
-        $resolvedPath = ArtifactPath::resolveRelativePath($candidate['url'], $candidate['source_path']);
+        $root = trim($siteRoot, '/');
+        $resolvedPath = str_starts_with($candidate['url'], '/')
+            ? ArtifactPath::resolveRelativePath(('' === $root ? '' : $root . '/') . ltrim($candidate['url'], '/'))
+            : ArtifactPath::resolveRelativePath($candidate['url'], $candidate['source_path']);
         $target = '' === $resolvedPath ? null : (null === $filesByPath ? $this->findFileByPath($resolvedPath, $files) : ($filesByPath[$resolvedPath] ?? null));
         $reference = array_filter(
             array(

--- a/php-transformer/src/AssetAnalysis/ReferenceAnalyzer.php
+++ b/php-transformer/src/AssetAnalysis/ReferenceAnalyzer.php
@@ -187,9 +187,16 @@ final class ReferenceAnalyzer
     public function normalizeReferenceCandidate(array $candidate, array $files, ?callable $isLinkableDocument = null, ?callable $isSafeImageAsset = null, ?array $filesByPath = null, string $siteRoot = ''): array
     {
         $root = trim($siteRoot, '/');
-        $resolvedPath = str_starts_with($candidate['url'], '/')
-            ? ArtifactPath::resolveRelativePath(('' === $root ? '' : $root . '/') . ltrim($candidate['url'], '/'))
-            : ArtifactPath::resolveRelativePath($candidate['url'], $candidate['source_path']);
+        $resolvedPath = ArtifactPath::resolveRelativePath($candidate['url'], $candidate['source_path']);
+        if (str_starts_with($candidate['url'], '/') && '' !== $root) {
+            $siteRootPath = ArtifactPath::resolveRelativePath($root . '/' . ltrim($candidate['url'], '/'));
+            $siteRootTarget = '' === $siteRootPath ? null : (null === $filesByPath ? $this->findFileByPath($siteRootPath, $files) : ($filesByPath[$siteRootPath] ?? null));
+            // Browser-root assets live beneath the packaged site root; document
+            // links retain their existing artifact-root resolution semantics.
+            if (is_array($siteRootTarget) && ! $this->isLinkableDocument($siteRootTarget, $isLinkableDocument)) {
+                $resolvedPath = $siteRootPath;
+            }
+        }
         $target = '' === $resolvedPath ? null : (null === $filesByPath ? $this->findFileByPath($resolvedPath, $files) : ($filesByPath[$resolvedPath] ?? null));
         $reference = array_filter(
             array(

--- a/php-transformer/src/WordPressSitePlan/AssetReferenceCanonicalizer.php
+++ b/php-transformer/src/WordPressSitePlan/AssetReferenceCanonicalizer.php
@@ -33,7 +33,8 @@ final class AssetReferenceCanonicalizer
         if ('' === trim($reference) || preg_match('~^(?:[a-z][a-z0-9+.-]*:|//|#|\?)~i', $reference)) {
             return null;
         }
-        preg_match('/^([^?#]*)(.*)$/s', $reference, $parts);
+        $decodedReference = html_entity_decode($reference, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        preg_match('/^([^?#]*)(.*)$/s', $decodedReference, $parts);
         $path = $parts[1] ?? '';
         $suffix = $parts[2] ?? '';
         if ('' === $path || preg_match('~%2f|%5c|%2e~i', $path)) {

--- a/php-transformer/src/WordPressSitePlan/AssetReferenceCanonicalizer.php
+++ b/php-transformer/src/WordPressSitePlan/AssetReferenceCanonicalizer.php
@@ -33,7 +33,7 @@ final class AssetReferenceCanonicalizer
         if ('' === trim($reference) || preg_match('~^(?:[a-z][a-z0-9+.-]*:|//|#|\?)~i', $reference)) {
             return null;
         }
-        $decodedReference = html_entity_decode($reference, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $decodedReference = html_entity_decode(str_ireplace('\\u0026', '&', $reference), ENT_QUOTES | ENT_HTML5, 'UTF-8');
         preg_match('/^([^?#]*)(.*)$/s', $decodedReference, $parts);
         $path = $parts[1] ?? '';
         $suffix = $parts[2] ?? '';

--- a/php-transformer/tests/contract/staged-artifact-compilation.php
+++ b/php-transformer/tests/contract/staged-artifact-compilation.php
@@ -83,6 +83,18 @@ $assert(($whole['source_reports']['wordpress_site_plan'] ?? array()) === ($stage
 $assert(!isset($whole['source_reports']['materialization_plan'], $staged['source_reports']['materialization_plan']), 'Whole and staged results remove the superseded projection while preserving their byte-identical canonical plan.');
 $compiledStaged = $compiler->compose($shared, array($compiledPages['contact.html'], $compiledPages['index.html'], $compiledPages['about.html']))->toArray();
 $assert(($whole['source_reports']['wordpress_site_plan'] ?? array()) === ($compiledStaged['source_reports']['wordpress_site_plan'] ?? array()), 'Terminal composition consumes persisted compiled page receipts without changing the canonical site plan.');
+$rootAssetPath = "website/external/Happy Women's Day.jpg";
+$rootAssetUrl = "/external/Happy%20Women's%20Day.jpg";
+$rootAssetArtifact = array('entrypoint' => 'website/index.html', 'files' => array(
+    array('path' => 'website/index.html', 'content' => '<main><h1>Home</h1><img srcset="' . $rootAssetUrl . ' 1x, ' . $rootAssetUrl . ' 2x"></main>'),
+    array('path' => $rootAssetPath, 'content_base64' => base64_encode('root-image'), 'mime_type' => 'image/jpeg', 'metadata' => array('compilation' => array('scope' => 'shared'))),
+));
+$rootAssetShared = $compiler->prepareShared($rootAssetArtifact);
+$rootAssetReceipt = $compiler->compilePage($rootAssetArtifact, $rootAssetShared, 'website/index.html');
+$rootAssetStaged = $compiler->compose($rootAssetShared, array($rootAssetReceipt))->toArray();
+$rootAssetPlan = $rootAssetStaged['source_reports']['wordpress_site_plan'] ?? array();
+$rootAssetSources = array_column($rootAssetPlan['assets'] ?? array(), 'source_path');
+$assert(array() !== $rootAssetPlan && !isset($rootAssetStaged['source_reports']['wordpress_site_plan_diagnostics']) && in_array($rootAssetPath, $rootAssetSources, true), 'Staged compilation resolves percent-encoded site-root srcset references to shared assets beneath the entrypoint root.');
 $manyPages = array();
 for ($index = 0; $index < 50; ++$index) {
     $path = sprintf('pages/page-%02d.html', $index);

--- a/php-transformer/tests/contract/wordpress-site-plan.php
+++ b/php-transformer/tests/contract/wordpress-site-plan.php
@@ -133,6 +133,9 @@ $recipe89Markup = $recipe89Artifact['source_reports']['wordpress_site_plan']['pa
 $assert(!isset($recipe89Artifact['source_reports']['wordpress_site_plan_diagnostics']) && str_contains($recipe89Markup, WordPressSitePlan::TOKEN_PREFIX), 'Fixture 89 recipe-shaped base64 website artifact tokenizes Gutenberg image URLs when the referenced image payload is declared.');
 $stagedCss = (new AssetReferenceCanonicalizer(array(array('source_path' => 'images.squarespace-cdn.com/hero.svg', 'token' => 'asset-0123456789abcdef'))))->content('main { a:url(_external/images.squarespace-cdn.com/hero.svg); b:url(/_external/images.squarespace-cdn.com/hero.svg); }', 'website/style.css');
 $assert(2 === substr_count($stagedCss, WordPressSitePlan::TOKEN_PREFIX . 'asset-0123456789abcdef}}'), 'Transport-prefixed and root-prefixed external CSS URLs canonicalize to matching artifact asset tokens.');
+$entitySrcsetToken = 'asset-fedcba9876543210';
+$entitySrcset = (new AssetReferenceCanonicalizer(array(array('source_path' => "website/external/Happy Women's Day.jpg", 'token' => $entitySrcsetToken)), 'website'))->content('<img srcset="/external/Happy%20Women&#039;s%20Day.jpg 1x">', 'website/index.html');
+$assert(str_contains($entitySrcset, WordPressSitePlan::TOKEN_PREFIX . $entitySrcsetToken . '}} 1x'), 'Entity-escaped srcset paths canonicalize to declared assets without changing candidate descriptors.');
 $escapedStyleCanonicalizer = new AssetReferenceCanonicalizer($plan['reference_tokens']);
 $escapedStyleToken = $escapedStyleCanonicalizer->reference('assets/logo.svg', 'index.html');
 $escapedQuoteStyle = $escapedStyleCanonicalizer->content('<!-- wp:blocks-engine/collection {"content":"<div title=\\"Fish &amp; Chips\\" style=\\"background-image:url(&quot;assets/logo.svg&quot;)\\"></div>"} /-->', 'index.html');

--- a/php-transformer/tests/contract/wordpress-site-plan.php
+++ b/php-transformer/tests/contract/wordpress-site-plan.php
@@ -134,8 +134,10 @@ $assert(!isset($recipe89Artifact['source_reports']['wordpress_site_plan_diagnost
 $stagedCss = (new AssetReferenceCanonicalizer(array(array('source_path' => 'images.squarespace-cdn.com/hero.svg', 'token' => 'asset-0123456789abcdef'))))->content('main { a:url(_external/images.squarespace-cdn.com/hero.svg); b:url(/_external/images.squarespace-cdn.com/hero.svg); }', 'website/style.css');
 $assert(2 === substr_count($stagedCss, WordPressSitePlan::TOKEN_PREFIX . 'asset-0123456789abcdef}}'), 'Transport-prefixed and root-prefixed external CSS URLs canonicalize to matching artifact asset tokens.');
 $entitySrcsetToken = 'asset-fedcba9876543210';
-$entitySrcset = (new AssetReferenceCanonicalizer(array(array('source_path' => "website/external/Happy Women's Day.jpg", 'token' => $entitySrcsetToken)), 'website'))->content('<img srcset="/external/Happy%20Women&#039;s%20Day.jpg 1x">', 'website/index.html');
-$assert(str_contains($entitySrcset, WordPressSitePlan::TOKEN_PREFIX . $entitySrcsetToken . '}} 1x'), 'Entity-escaped srcset paths canonicalize to declared assets without changing candidate descriptors.');
+$entitySrcsetCanonicalizer = new AssetReferenceCanonicalizer(array(array('source_path' => "website/external/Happy Women's Day.jpg", 'token' => $entitySrcsetToken)), 'website');
+$entitySrcset = $entitySrcsetCanonicalizer->content('<img srcset="/external/Happy%20Women&#039;s%20Day.jpg 1x">', 'website/index.html');
+$jsonEntitySrcset = $entitySrcsetCanonicalizer->content('<!-- wp:blocks-engine/responsive-layout {"content":"\\u003cimg srcset=\\u0022/external/Happy%20Women\\u0026#039;s%20Day.jpg 1x\\u0022\\u003e"} /-->', 'website/index.html');
+$assert(str_contains($entitySrcset, WordPressSitePlan::TOKEN_PREFIX . $entitySrcsetToken . '}} 1x') && str_contains($jsonEntitySrcset, WordPressSitePlan::TOKEN_PREFIX . $entitySrcsetToken . '}} 1x'), 'HTML- and JSON-entity-escaped srcset paths canonicalize to declared assets without changing candidate descriptors.');
 $escapedStyleCanonicalizer = new AssetReferenceCanonicalizer($plan['reference_tokens']);
 $escapedStyleToken = $escapedStyleCanonicalizer->reference('assets/logo.svg', 'index.html');
 $escapedQuoteStyle = $escapedStyleCanonicalizer->content('<!-- wp:blocks-engine/collection {"content":"<div title=\\"Fish &amp; Chips\\" style=\\"background-image:url(&quot;assets/logo.svg&quot;)\\"></div>"} /-->', 'index.html');


### PR DESCRIPTION
## Summary

- resolve leading-slash browser references beneath the entrypoint's packaged site root during staged dependency analysis
- limit site-root remapping to declared non-document assets, preserving document-link report semantics
- decode HTML entities before splitting asset path query and fragment components, so companion `srcset` values such as `&#039;` match declared files
- preserve percent-decoded path matching and traversal protections through `ArtifactPath`
- cover staged nested-root assets and entity-escaped responsive references

Closes #1512.

## Verification

- `php tests/contract/staged-artifact-compilation.php`
- `php tests/contract/wordpress-site-plan.php`
- `composer test`
- `composer parity`
- `composer test:packaging`
- `git diff --check`

## AI assistance

OpenAI gpt-5.6-sol and gpt-5.6-terra via OpenCode were used to inspect compiler checkpoints and CI logs, reduce the failures to contracts, implement the owning-layer fixes, and run verification. The changes and evidence were operator-reviewed.