### PR TITLE
Reuse parsed author rule declarations

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/AuthorStyleRuleProjector.php
+++ b/php-transformer/src/HtmlToBlocks/Style/AuthorStyleRuleProjector.php
@@ -33,15 +33,38 @@ final class AuthorStyleRuleProjector
         SourceStyleResolutionState $sourceStyles,
         TransformationEvidenceState $evidence
     ): string {
-        $body = $this->projectResponsiveCanvasMinimumWidth($prelude, $body, $authorStyles, $sourceStyles, $evidence);
-        $body = $this->projectAutoSizedStructuralPercentageHeight($prelude, $body, $authorStyles, $sourceStyles, $evidence);
-        $body = $this->projectSourceContentBoxSizing($prelude, $body, $authorStyles, $sourceStyles);
-        return $this->projectIntrinsicGridRowTracks($prelude, $body, $authorStyles, $sourceStyles);
+        return $this->projectWithDeclarations($prelude, $body, $authorStyles, $sourceStyles, $evidence)['body'];
     }
 
-    private function projectSourceContentBoxSizing(string $prelude, string $body, AuthorStyleAnalysis $authorStyles, SourceStyleResolutionState $sourceStyles): string
-    {
+    /** @return array{body: string, declarations: array<string, string>} */
+    public function projectWithDeclarations(
+        string $prelude,
+        string $body,
+        AuthorStyleAnalysis $authorStyles,
+        SourceStyleResolutionState $sourceStyles,
+        TransformationEvidenceState $evidence
+    ): array {
         $declarations = $this->styleResolver->cssDeclarations($body);
+        $this->acceptProjectedBody($body, $declarations, $this->projectResponsiveCanvasMinimumWidth($prelude, $body, $declarations, $authorStyles, $sourceStyles, $evidence));
+        $this->acceptProjectedBody($body, $declarations, $this->projectAutoSizedStructuralPercentageHeight($prelude, $body, $declarations, $authorStyles, $sourceStyles, $evidence));
+        $this->acceptProjectedBody($body, $declarations, $this->projectSourceContentBoxSizing($prelude, $body, $declarations, $authorStyles, $sourceStyles));
+        $this->acceptProjectedBody($body, $declarations, $this->projectIntrinsicGridRowTracks($prelude, $body, $declarations, $authorStyles, $sourceStyles));
+        return array('body' => $body, 'declarations' => $declarations);
+    }
+
+    /** @param array<string, string> $declarations */
+    private function acceptProjectedBody(string &$body, array &$declarations, string $projected): void
+    {
+        if ( $projected === $body ) {
+            return;
+        }
+        $body = $projected;
+        $declarations = $this->styleResolver->cssDeclarations($body);
+    }
+
+    /** @param array<string, string> $declarations */
+    private function projectSourceContentBoxSizing(string $prelude, string $body, array $declarations, AuthorStyleAnalysis $authorStyles, SourceStyleResolutionState $sourceStyles): string
+    {
         if ( isset($declarations['box-sizing'])
             || ! isset($declarations['width'])
             || ! CssValueInspector::hasDefiniteWidth('width:' . $declarations['width'])
@@ -121,14 +144,15 @@ final class AuthorStyleRuleProjector
         return $this->universalBorderBoxResets[$authorStyles] = $usesBorderBox;
     }
 
+    /** @param array<string, string> $declarations */
     private function projectResponsiveCanvasMinimumWidth(
         string $prelude,
         string $body,
+        array $declarations,
         AuthorStyleAnalysis $authorStyles,
         SourceStyleResolutionState $sourceStyles,
         TransformationEvidenceState $evidence
     ): string {
-        $declarations = $this->styleResolver->cssDeclarations($body);
         $minimumWidth = (string) ($declarations['min-width'] ?? '');
         if ( '' === $minimumWidth ) {
             return $body;
@@ -176,9 +200,9 @@ final class AuthorStyleRuleProjector
         return implode(';', $retained);
     }
 
-    private function projectIntrinsicGridRowTracks(string $prelude, string $body, AuthorStyleAnalysis $authorStyles, SourceStyleResolutionState $sourceStyles): string
+    /** @param array<string, string> $declarations */
+    private function projectIntrinsicGridRowTracks(string $prelude, string $body, array $declarations, AuthorStyleAnalysis $authorStyles, SourceStyleResolutionState $sourceStyles): string
     {
-        $declarations = $this->styleResolver->cssDeclarations($body);
         $rows = (string) ($declarations['grid-template-rows'] ?? '');
         if ( ! $this->gridTemplateRowsContainFractionalTrack($rows) ) {
             return $body;
@@ -526,14 +550,15 @@ final class AuthorStyleRuleProjector
         return $pixels >= 640;
     }
 
+    /** @param array<string, string> $declarations */
     private function projectAutoSizedStructuralPercentageHeight(
         string $prelude,
         string $body,
+        array $declarations,
         AuthorStyleAnalysis $authorStyles,
         SourceStyleResolutionState $sourceStyles,
         TransformationEvidenceState $evidence
     ): string {
-        $declarations = $this->styleResolver->cssDeclarations($body);
         $height = (string) ($declarations['height'] ?? '');
         if ( '100%' !== strtolower(CssValueInspector::withoutImportant($height)) ) {
             return $body;

--- a/php-transformer/src/HtmlToBlocks/Style/AuthorStylesheetProjector.php
+++ b/php-transformer/src/HtmlToBlocks/Style/AuthorStylesheetProjector.php
@@ -22,14 +22,15 @@ final class AuthorStylesheetProjector
         return ( new CssStylesheetTransformer() )->transformStyleRules(
             $stylesheet,
             function (string $prelude, string $body) use ($context): string {
-                $body = $this->ruleBodyProjector->project(
+                $projection = $this->ruleBodyProjector->projectWithDeclarations(
                     $prelude,
                     $body,
                     $context->authorStyles,
                     $context->sourceStyles,
                     $context->evidence
                 );
-                $declarations = $this->styleResolver->cssDeclarations($body);
+                $body = $projection['body'];
+                $declarations = $projection['declarations'];
                 $margins = array_filter($declarations, static fn (string $name): bool => 'margin' === $name || str_starts_with($name, 'margin-'), ARRAY_FILTER_USE_KEY);
                 $imagePrelude = $this->projectAuthorImageSelectorPrelude($prelude, $context);
                 $svgImagePrelude = $this->projectAuthorImageSelectorPrelude($prelude, $context, 'svg', $declarations);


### PR DESCRIPTION
## Summary

- parse each author CSS rule body once for the projection pipeline
- reuse declarations across four geometry checks and the outer stylesheet projection
- refresh declarations only when a projection mutates the rule body

## Performance evidence

The KMR agencies page retained the exact compiled receipt digest before and after (`2b63c0e69b750cf9573dfcc81fd9d785f7929f6aa36c502d988fe471b23961f9`). Across three isolated runs, median page compilation changed from 25.94s on `trunk` to 19.05s with this change, approximately 26.6% faster. Wall-clock values vary with host load; the stable receipt digest establishes output parity.

## Verification

- `composer test`
- `php tests/unit/artifact-author-stylesheet-projection.php`
- `php tests/unit/responsive-canvas-geometry.php`
- `php tests/unit/responsive-footer-geometry.php`
- `php tests/unit/full-bleed-geometry.php`
- 292 parity fixtures and package-install proof pass as part of the complete suite

## AI assistance

GPT-5.6 Sol via OpenCode assisted with profiling duplicate CSS declaration parsing, implementing the focused reuse path, benchmarking the captured KMR page, and running verification.