### PR TITLE
Pass WordPress runtime as typed context

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Elements/AuthoredFormControlBlockConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/AuthoredFormControlBlockConverter.php
@@ -7,6 +7,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormContr
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredInputBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredSelectBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use Closure;
 use DOMElement;
 
@@ -19,7 +20,6 @@ final class AuthoredFormControlBlockConverter
      * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(class-string, array<string, mixed>): void                                             $registerGeneratedBlock
      * @param Closure(string): void                                                                         $registerEcho
-     * @param Closure(string): string                                                                       $escapeHtml
      * @param Closure(string): string                                                                       $safeAnchor
      */
     public function __construct(
@@ -29,7 +29,7 @@ final class AuthoredFormControlBlockConverter
         private readonly Closure $createBlock,
         private readonly Closure $registerGeneratedBlock,
         private readonly Closure $registerEcho,
-        private readonly Closure $escapeHtml,
+        private readonly Runtime $runtime,
         private readonly Closure $safeAnchor
     ) {
     }
@@ -57,11 +57,11 @@ final class AuthoredFormControlBlockConverter
                     $optionLabel .= ' (selected)';
                 }
                 ($this->registerEcho)($optionLabel);
-                $optionBlocks[] = ($this->createBlock)('core/list-item', array( 'content' => ($this->escapeHtml)($optionLabel) ), array(), null);
+                $optionBlocks[] = ($this->createBlock)('core/list-item', array( 'content' => $this->runtime->escapeHtml($optionLabel) ), array(), null);
             }
 
             return ($this->createBlock)('core/group', ($this->presentationAttributes)($select), array(
-                ($this->createBlock)('core/paragraph', array( 'content' => ($this->escapeHtml)($label) ), array(), $select),
+                ($this->createBlock)('core/paragraph', array( 'content' => $this->runtime->escapeHtml($label) ), array(), $select),
                 ($this->createBlock)('core/list', array(), $optionBlocks, $select),
             ), $select);
         }

--- a/php-transformer/src/HtmlToBlocks/Elements/RichTextElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/RichTextElementContext.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use Closure;
 use DOMElement;
 
@@ -31,7 +32,6 @@ final class RichTextElementContext
      * @param Closure(DOMElement): bool                                                                      $hasBoxChromeWrapperStyling
      * @param Closure(DOMElement): bool                                                                      $isRuntimeDomTarget
      * @param Closure(string): array<int, array<string, mixed>>                                              $convertText
-     * @param Closure(string): string                                                                        $stripAllTags
      * @param Closure(DOMElement, array<int, array<string, mixed>>, bool): array<int, array<string, mixed>>   $convertChildren
      */
     public function __construct(
@@ -48,7 +48,7 @@ final class RichTextElementContext
         private readonly Closure $hasBoxChromeWrapperStyling,
         private readonly Closure $isRuntimeDomTarget,
         private readonly Closure $convertText,
-        private readonly Closure $stripAllTags,
+        private readonly Runtime $runtime,
         private readonly Closure $convertChildren
     ) {
     }
@@ -142,7 +142,7 @@ final class RichTextElementContext
 
     public function stripAllTags(string $html): string
     {
-        return ($this->stripAllTags)($html);
+        return $this->runtime->stripAllTags($html);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Elements/TextLeafElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/TextLeafElementContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use Closure;
 use DOMElement;
 
@@ -21,8 +22,6 @@ final class TextLeafElementContext
      * @param Closure(DOMElement, array<int, string>, array<int, string>): array<string, mixed> $presentationAttributes
      * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(DOMElement, array<int, string>): string                                  $richTextContent
-     * @param Closure(string): string                                                          $stripAllTags
-     * @param Closure(string): string                                                          $escapeHtml
      * @param Closure(DOMElement, DOMElement): array<string, mixed>                            $codePresentationAttributes
      * @param Closure(DOMElement): string                                                      $codeContent
      * @param Closure(DOMElement, array<int, array<string, mixed>>, bool): array<int, array<string, mixed>> $convertChildren
@@ -32,8 +31,7 @@ final class TextLeafElementContext
         private readonly Closure $presentationAttributes,
         private readonly Closure $createBlock,
         private readonly Closure $richTextContent,
-        private readonly Closure $stripAllTags,
-        private readonly Closure $escapeHtml,
+        private readonly Runtime $runtime,
         private readonly Closure $codePresentationAttributes,
         private readonly Closure $codeContent,
         private readonly Closure $convertChildren
@@ -70,12 +68,12 @@ final class TextLeafElementContext
 
     public function stripAllTags(string $html): string
     {
-        return ($this->stripAllTags)($html);
+        return $this->runtime->stripAllTags($html);
     }
 
     public function escapeHtml(string $text): string
     {
-        return ($this->escapeHtml)($text);
+        return $this->runtime->escapeHtml($text);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -574,7 +574,7 @@ final class HtmlCompilation
             function (string $text): void {
                 $this->transformationEvidence()->recordFormControlEcho($text);
             },
-            fn (string $text): string => $this->runtime->escapeHtml($text),
+            $this->runtime,
             fn (string $id): string => $this->safeAnchor($id)
         );
         $this->pseudoFormAnalyzer = new PseudoFormAnalyzer($this->formControlMetadataBuilder, fn (DOMElement $element): string => $this->elementSelector($element));
@@ -1044,7 +1044,7 @@ final class HtmlCompilation
             fn (DOMElement $element): bool => $this->hasBoxChromeWrapperStyling($element),
             fn (DOMElement $element): bool => $this->runtimeIslands->isRuntimeDomTarget($element),
             fn (string $text): array => $this->convertText($text),
-            fn (string $html): string => $this->runtime->stripAllTags($html),
+            $this->runtime,
             function (DOMElement $element, array &$fallbacks, bool $captureUnsupported): array {
                 return $this->convertChildren($element, $fallbacks, $captureUnsupported);
             }
@@ -1063,8 +1063,7 @@ final class HtmlCompilation
             fn (DOMElement $element, array $excludedProperties, array $excludedGeometryProperties): array => $this->styleResolver->presentationAttributes($element, $excludedProperties, $excludedGeometryProperties),
             fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
             fn (DOMElement $element, array $excludedTags): string => $this->richTextContentWithMaterializedInlineStyles($element, $excludedTags),
-            fn (string $html): string => $this->runtime->stripAllTags($html),
-            fn (string $text): string => $this->runtime->escapeHtml($text),
+            $this->runtime,
             fn (DOMElement $pre, DOMElement $code): array => $this->codePresentationAttributes($pre, $code),
             fn (DOMElement $code): string => $this->codeContent($code),
             function (DOMElement $element, array &$fallbacks, bool $captureUnsupported): array {
@@ -2582,7 +2581,7 @@ final class HtmlCompilation
             ),
             new MarkupPatternContext(
                 fn (DOMElement $sourceElement): string => $this->safeFallbackHtml($sourceElement),
-                fn (string $text): string => $this->runtime->escapeHtml($text)
+                $this->runtime
             ),
             new ButtonPatternContext(
                 fn (DOMElement $anchor): ?array => $this->fileBlockFromAnchor($anchor),
@@ -2599,7 +2598,7 @@ final class HtmlCompilation
             new QuotePatternContext(
                 $this->sourceElementClassifier,
                 fn (DOMElement $sourceElement): string => $this->citationFromElement($sourceElement),
-                fn (string $html): string => $this->runtime->stripAllTags($html)
+                $this->runtime
             ),
             new CodeWindowPatternContext(
                 fn (DOMElement $sourcePre, DOMElement $sourceCode): array => $this->codePresentationAttributes($sourcePre, $sourceCode),
@@ -2654,7 +2653,7 @@ final class HtmlCompilation
             ),
             markupContext: new MarkupPatternContext(
                 fn (DOMElement $sourceElement): string => $this->safeFallbackHtml($sourceElement),
-                fn (string $text): string => $this->runtime->escapeHtml($text)
+                $this->runtime
             ),
             codeWindowContext: new CodeWindowPatternContext(
                 fn (DOMElement $sourcePre, DOMElement $sourceCode): array => $this->codePresentationAttributes($sourcePre, $sourceCode),

--- a/php-transformer/src/HtmlToBlocks/Patterns/MarkupPatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/MarkupPatternContext.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use Closure;
 use DOMElement;
 
@@ -10,14 +11,13 @@ final class MarkupPatternContext
 {
     /**
      * @param Closure(DOMElement): string $safeFallbackHtml
-     * @param Closure(string): string $escapeHtml
      */
     public function __construct(
         private readonly Closure $safeFallbackHtml,
-        private readonly Closure $escapeHtml
+        private readonly Runtime $runtime
     ) {
     }
 
     public function safeFallbackHtml(DOMElement $element): string { return ($this->safeFallbackHtml)($element); }
-    public function escapeHtml(string $text): string { return ($this->escapeHtml)($text); }
+    public function escapeHtml(string $text): string { return $this->runtime->escapeHtml($text); }
 }

--- a/php-transformer/src/HtmlToBlocks/Patterns/QuotePatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/QuotePatternContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use Closure;
 use DOMElement;
 
@@ -11,16 +12,15 @@ final class QuotePatternContext
 {
     /**
      * @param Closure(DOMElement): string $citationFromElement
-     * @param Closure(string): string $stripAllTags
      */
     public function __construct(
         private readonly SourceElementClassifier $sourceElementClassifier,
         private readonly Closure $citationFromElement,
-        private readonly Closure $stripAllTags
+        private readonly Runtime $runtime
     ) {
     }
 
     public function citationFromElement(DOMElement $element): string { return ($this->citationFromElement)($element); }
-    public function stripAllTags(string $html): string { return ($this->stripAllTags)($html); }
+    public function stripAllTags(string $html): string { return $this->runtime->stripAllTags($html); }
     public function isInlineContentElement(string $tagName): bool { return $this->sourceElementClassifier->isInlineContentElement($tagName); }
 }

--- a/php-transformer/tests/unit/authored-form-control-block-converter.php
+++ b/php-transformer/tests/unit/authored-form-control-block-converter.php
@@ -7,6 +7,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\AuthoredFormCon
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormControlMetadataBuilder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredInputBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredSelectBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
 $assertions = 0;
 $failures = array();
@@ -45,7 +46,7 @@ $converter = new AuthoredFormControlBlockConverter(
     static function (string $text) use (&$echoes): void {
         $echoes[] = $text;
     },
-    static fn (string $text): string => htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+    new Runtime(),
     static fn (string $id): string => 'safe-' . $id
 );
 

--- a/php-transformer/tests/unit/pattern-recognizer-registry.php
+++ b/php-transformer/tests/unit/pattern-recognizer-registry.php
@@ -11,6 +11,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\MathPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\MarkupPatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PlaceholderMediaPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\SpacerPattern;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
 $failures = 0;
 $assertSame = static function (mixed $expected, mixed $actual, string $message) use (&$failures): void {
@@ -101,7 +102,7 @@ $directContext = new PatternContext(
     $createBlock,
     markupContext: new MarkupPatternContext(
         static fn (DOMElement $source): string => $source->ownerDocument?->saveHTML($source) ?: '',
-        static fn (string $text): string => htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+        new Runtime()
     )
 );
 $overlap = PatternRecognizerRegistry::createDefault()->firstMatch($elementFromHtml('<div class="placeholder media math" style="aspect-ratio: 16 / 9">$x$</div>'), $directContext);

--- a/php-transformer/tests/unit/readable-form-block-builder.php
+++ b/php-transformer/tests/unit/readable-form-block-builder.php
@@ -59,7 +59,7 @@ $authoredConverter = new AuthoredFormControlBlockConverter(
     static function (string $text) use (&$echoes): void {
         $echoes[] = $text;
     },
-    static fn (string $text): string => htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+    new Runtime(),
     static fn (string $id): string => $id
 );
 $controlConverter = new ReadableFormControlBlockConverter(

--- a/php-transformer/tests/unit/readable-form-control-block-converter.php
+++ b/php-transformer/tests/unit/readable-form-control-block-converter.php
@@ -56,7 +56,7 @@ $authoredConverter = new AuthoredFormControlBlockConverter(
     static function (string $text) use (&$echoes): void {
         $echoes[] = $text;
     },
-    static fn (string $text): string => htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+    new Runtime(),
     static fn (string $id): string => $id
 );
 $converter = new ReadableFormControlBlockConverter(

--- a/php-transformer/tests/unit/rich-text-element-converter.php
+++ b/php-transformer/tests/unit/rich-text-element-converter.php
@@ -15,6 +15,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RichTextElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RichTextElementConverter;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
 $assertions = 0;
 $failures   = array();
@@ -44,7 +45,6 @@ $makeConverter = static function (array $overrides = array()): RichTextElementCo
         'hasBoxChromeWrapperStyling'        => static fn (DOMElement $e): bool => false,
         'isRuntimeDomTarget'                => static fn (DOMElement $e): bool => false,
         'convertText'                       => static fn (string $t): array => '' === $t ? array() : array(array('blockName' => 'core/paragraph', 'attrs' => array('content' => $t))),
-        'stripAllTags'                      => static fn (string $h): string => strip_tags($h),
         'convertChildren'                   => static function (DOMElement $e, array &$f, bool $c): array {
             return array();
         },
@@ -66,7 +66,7 @@ $makeConverter = static function (array $overrides = array()): RichTextElementCo
         $c['hasBoxChromeWrapperStyling'],
         $c['isRuntimeDomTarget'],
         $c['convertText'],
-        $c['stripAllTags'],
+        new Runtime(),
         $c['convertChildren']
     ));
 };
@@ -160,7 +160,6 @@ $assert(null === $emptyParagraph->convert($elementFrom('<p></p>'), 'p', $fallbac
 // Empty rich text that still carries a native SVG image object stays a paragraph.
 $svgOnly = $makeConverter(array(
     'richTextContent'              => static fn (DOMElement $e, array $x): string => '<img src="i.svg">',
-    'stripAllTags'                 => static fn (string $h): string => '',
     'containsNativeSvgImageObject' => static fn (string $c): bool => true,
 ));
 $assert('core/paragraph' === ($svgOnly->convert($elementFrom('<p><svg></svg></p>'), 'p', $fallbacks)->block['blockName'] ?? ''), 'svg-only-paragraph-survives');

--- a/php-transformer/tests/unit/text-leaf-element-converter.php
+++ b/php-transformer/tests/unit/text-leaf-element-converter.php
@@ -15,6 +15,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TextLeafElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TextLeafElementConverter;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
 $assertions = 0;
 $failures   = array();
@@ -37,8 +38,6 @@ $makeConverter = static function (array $overrides = array()): TextLeafElementCo
             'innerBlocks' => $i,
         ),
         'richTextContent'               => static fn (DOMElement $e, array $x): string => (string) $e->textContent,
-        'stripAllTags'                  => static fn (string $h): string => strip_tags($h),
-        'escapeHtml'                    => static fn (string $t): string => htmlspecialchars($t, ENT_QUOTES),
         'firstChildElement'             => static function (DOMElement $e, string $tag): ?DOMElement {
             foreach ($e->childNodes as $child) {
                 if ($child instanceof DOMElement && strtolower($child->tagName) === $tag) {
@@ -61,8 +60,7 @@ $makeConverter = static function (array $overrides = array()): TextLeafElementCo
         $c['presentationAttributes'],
         $c['createBlock'],
         $c['richTextContent'],
-        $c['stripAllTags'],
-        $c['escapeHtml'],
+        new Runtime(),
         $c['codePresentationAttributes'],
         $c['codeContent'],
         $c['convertChildren']


### PR DESCRIPTION
## Summary

- pass the canonical WordPress `Runtime` directly into five rich-text, pattern, and form consumers
- remove six stored escaping/tag-stripping closures and seven compilation wiring adapters
- exercise the consumers against the real runtime instead of test-local PHP substitutes

## Testing

- `composer test` (including 292 parity fixtures and package-install proof)
- 385 serialized-block fixture hashes match `trunk`, with 0 exceptions
- `git diff --check`
- Homeboy architecture audit: 0 introduced findings

## AI assistance

OpenAI gpt-5.6-sol was used through OpenCode to identify the bounded Runtime seam, implement the refactor, update tests, and run verification under human direction.