### PR TITLE
Traverse reveal animation CSS once

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/CssStylesheetTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssStylesheetTransformer.php
@@ -54,7 +54,18 @@ final class CssStylesheetTransformer
      */
     public function visitStyleRules(string $stylesheet, callable $visitStyleRule): void
     {
-        $this->visitRules($stylesheet, $visitStyleRule, array());
+        $this->visitRules($stylesheet, $visitStyleRule, null, array());
+    }
+
+    /**
+     * Visit style rules and keyframes during one stylesheet traversal.
+     *
+     * @param callable(string, string, list<string>): void $visitStyleRule
+     * @param callable(string, string): void $visitKeyframes
+     */
+    public function visitStyleAndKeyframeRules(string $stylesheet, callable $visitStyleRule, callable $visitKeyframes): void
+    {
+        $this->visitRules($stylesheet, $visitStyleRule, $visitKeyframes, array());
     }
 
     /**
@@ -70,7 +81,7 @@ final class CssStylesheetTransformer
      */
     public function visitKeyframeRules(string $stylesheet, callable $visitKeyframes): void
     {
-        $this->visitKeyframeRulesIn($stylesheet, $visitKeyframes);
+        $this->visitRules($stylesheet, static function (): void {}, $visitKeyframes, array());
     }
 
     /**
@@ -191,8 +202,8 @@ final class CssStylesheetTransformer
         return $output;
     }
 
-    /** @param callable(string, string, list<string>): void $visitStyleRule @param list<string> $ancestors */
-    private function visitRules(string $css, callable $visitStyleRule, array $ancestors): void
+    /** @param callable(string, string, list<string>): void $visitStyleRule @param callable(string, string): void|null $visitKeyframes @param list<string> $ancestors */
+    private function visitRules(string $css, callable $visitStyleRule, ?callable $visitKeyframes, array $ancestors): void
     {
         $offset = 0;
         $length = strlen($css);
@@ -208,44 +219,20 @@ final class CssStylesheetTransformer
             }
             $prelude = substr($css, $offset, $boundary - $offset);
             $body = substr($css, $boundary + 1, $blockEnd - $boundary - 1);
-            if ($this->isAtRule($prelude) && $this->walksNestedRules($prelude)) {
-                $nested = $ancestors;
-                $nested[] = trim($prelude);
-                $this->visitRules($body, $visitStyleRule, $nested);
-            } elseif ($this->isStylePrelude($prelude)) {
-                $visitStyleRule($prelude, $body, $ancestors);
-            }
-            $offset = $blockEnd + 1;
-        }
-    }
-
-    /** @param callable(string, string): void $visitKeyframes */
-    private function visitKeyframeRulesIn(string $css, callable $visitKeyframes): void
-    {
-        $offset = 0;
-        $length = strlen($css);
-        while ( $offset < $length ) {
-            $boundary = $this->nextRuleBoundary($css, $offset);
-            if ( null === $boundary || ';' === $css[ $boundary ] ) {
-                $offset = null === $boundary ? $length : $boundary + 1;
-                continue;
-            }
-            $blockEnd = $this->matchingBrace($css, $boundary);
-            if ( null === $blockEnd ) {
-                return;
-            }
-            $prelude = substr($css, $offset, $boundary - $offset);
-            $body = substr($css, $boundary + 1, $blockEnd - $boundary - 1);
-            if ( $this->isAtRule($prelude) ) {
+            if ($this->isAtRule($prelude)) {
                 $name = self::atRuleName($prelude);
-                if ( 'keyframes' === $name || str_ends_with($name, '-keyframes') ) {
+                if (null !== $visitKeyframes && ('keyframes' === $name || str_ends_with($name, '-keyframes'))) {
                     $animationName = self::keyframesAnimationName($prelude);
-                    if ( '' !== $animationName ) {
+                    if ('' !== $animationName) {
                         $visitKeyframes($animationName, $body);
                     }
-                } elseif ( $this->walksNestedRules($prelude) ) {
-                    $this->visitKeyframeRulesIn($body, $visitKeyframes);
+                } elseif ($this->walksNestedRules($prelude)) {
+                    $nested = $ancestors;
+                    $nested[] = trim($prelude);
+                    $this->visitRules($body, $visitStyleRule, $visitKeyframes, $nested);
                 }
+            } elseif ($this->isStylePrelude($prelude)) {
+                $visitStyleRule($prelude, $body, $ancestors);
             }
             $offset = $blockEnd + 1;
         }

--- a/php-transformer/src/HtmlToBlocks/Style/RevealAnimationSettler.php
+++ b/php-transformer/src/HtmlToBlocks/Style/RevealAnimationSettler.php
@@ -96,30 +96,40 @@ final class RevealAnimationSettler
         if ( 1 !== preg_match('/(?:^|[;{\s])animation(?:-[a-z-]+)?\s*:/i', $css) ) {
             return array();
         }
-        $keyframes = $this->keyframeBoundaryStates($css);
+        $keyframes = array();
+        $candidates = array();
+        $settled = array();
+        $transformer = new CssStylesheetTransformer();
+        $transformer->visitStyleAndKeyframeRules(
+            $css,
+            function (string $prelude, string $body) use (&$candidates): void {
+                if ( false !== stripos($body, 'animation') ) {
+                    $candidates[] = array($prelude, $this->declarations($body));
+                }
+            },
+            function (string $name, string $body) use ($transformer, &$keyframes): void {
+                $keyframes[$name] = $this->keyframeBoundaryState($transformer, $body, $keyframes[$name] ?? array('start' => array(), 'end' => array()));
+            }
+        );
         if ( array() === $keyframes ) {
             return array();
         }
 
-        $settled = array();
-        ( new CssStylesheetTransformer() )->visitStyleRules(
-            $css,
-            function (string $prelude, string $body) use ($keyframes, &$settled): void {
-                $endState = $this->suspendedRevealEndState($this->declarations($body), $keyframes);
-                if ( null === $endState ) {
-                    return;
+        foreach ( $candidates as [ $prelude, $declarations ] ) {
+            $endState = $this->suspendedRevealEndState($declarations, $keyframes);
+            if ( null === $endState ) {
+                continue;
+            }
+            foreach ( CssStylesheetTransformer::splitSelectorList($prelude) ?? array() as $selector ) {
+                $selector = $this->settleableSelector($selector);
+                if ( '' === $selector ) {
+                    continue;
                 }
-                foreach ( CssStylesheetTransformer::splitSelectorList($prelude) ?? array() as $selector ) {
-                    $selector = $this->settleableSelector($selector);
-                    if ( '' === $selector ) {
-                        continue;
-                    }
-                    foreach ( $endState as $property => $value ) {
-                        $settled[$selector][$property] = $value;
-                    }
+                foreach ( $endState as $property => $value ) {
+                    $settled[$selector][$property] = $value;
                 }
             }
-        );
+        }
 
         ksort($settled, SORT_STRING);
         $rules = array();
@@ -283,38 +293,29 @@ final class RevealAnimationSettler
      * Index every `@keyframes` rule by name, keeping the declarations of its
      * first and last offsets.
      *
-     * @return array<string, array{start: array<string, string>, end: array<string, string>}>
+     * @param array{start: array<string, string>, end: array<string, string>} $frames
+     * @return array{start: array<string, string>, end: array<string, string>}
      */
-    private function keyframeBoundaryStates(string $css): array
+    private function keyframeBoundaryState(CssStylesheetTransformer $transformer, string $body, array $frames): array
     {
-        $transformer = new CssStylesheetTransformer();
-        $keyframes = array();
-        $transformer->visitKeyframeRules(
-            $css,
-            function (string $name, string $body) use ($transformer, &$keyframes): void {
-                $frames = $keyframes[ $name ] ?? array( 'start' => array(), 'end' => array() );
-                $transformer->visitStyleRules(
-                    $body,
-                    function (string $prelude, string $declarationBlock) use (&$frames): void {
-                        $declarations = $this->declarations($declarationBlock);
-                        if ( array() === $declarations ) {
-                            return;
-                        }
-                        foreach ( CssStylesheetTransformer::splitSelectorList($prelude) ?? array() as $offset ) {
-                            $offset = strtolower(trim($offset));
-                            if ( 'from' === $offset || '0%' === $offset ) {
-                                $frames['start'] = array_merge($frames['start'], $declarations);
-                            } elseif ( 'to' === $offset || '100%' === $offset ) {
-                                $frames['end'] = array_merge($frames['end'], $declarations);
-                            }
-                        }
+        $transformer->visitStyleRules(
+            $body,
+            function (string $prelude, string $declarationBlock) use (&$frames): void {
+                $declarations = $this->declarations($declarationBlock);
+                if ( array() === $declarations ) {
+                    return;
+                }
+                foreach ( CssStylesheetTransformer::splitSelectorList($prelude) ?? array() as $offset ) {
+                    $offset = strtolower(trim($offset));
+                    if ( 'from' === $offset || '0%' === $offset ) {
+                        $frames['start'] = array_merge($frames['start'], $declarations);
+                    } elseif ( 'to' === $offset || '100%' === $offset ) {
+                        $frames['end'] = array_merge($frames['end'], $declarations);
                     }
-                );
-                $keyframes[ $name ] = $frames;
+                }
             }
         );
-
-        return $keyframes;
+        return $frames;
     }
 
     /** @return array<string, string> */

--- a/php-transformer/tests/unit/css-stylesheet-transformer.php
+++ b/php-transformer/tests/unit/css-stylesheet-transformer.php
@@ -33,6 +33,26 @@ $transformer->transform($css, static function (string $prelude, string $body, ar
 });
 $assert(array( '@media screen', '@supports (display: grid)' ) === ($conditions['.before'] ?? null), 'transform callbacks receive the enclosing at-rule stack');
 
+$visitedStyles = array();
+$visitedKeyframes = array();
+$transformer->visitStyleAndKeyframeRules(
+    '@media screen { .before { animation: fade 1s } @-webkit-keyframes fade { from { opacity:0 } } } .after { color:red }',
+    static function (string $prelude, string $body, array $ancestors) use (&$visitedStyles): void {
+        $visitedStyles[] = array(trim($prelude), trim($body), $ancestors);
+    },
+    static function (string $name, string $body) use (&$visitedKeyframes): void {
+        $visitedKeyframes[] = array($name, trim($body));
+    }
+);
+$assert(
+    array(
+        array('.before', 'animation: fade 1s', array('@media screen')),
+        array('.after', 'color:red', array()),
+    ) === $visitedStyles
+    && array(array('fade', 'from { opacity:0 }')) === $visitedKeyframes,
+    'combined visitor reports nested style rules and vendor-prefixed keyframes'
+);
+
 // 5: commas inside nested syntax are not selector-list separators.
 $parts = CssStylesheetTransformer::splitSelectorList(':is(.a,.b), :not([data-x="a,b"]), [title="x,y"]');
 $assert(array( ':is(.a,.b)', ' :not([data-x="a,b"])', ' [title="x,y"]' ) === $parts, 'selector lists split only on top-level commas');


### PR DESCRIPTION
## Summary

- visit style rules and keyframes through one shared stylesheet traversal
- collect animation candidates during that traversal and resolve them after all keyframes are indexed
- preserve nested at-rule and vendor-prefixed keyframe behavior with direct regression coverage

## Performance

On the 1,397,466-byte projected stylesheet from the KMR agencies import, five isolated runs produced:

- baseline median: 618.2 ms
- candidate median: 350.3 ms
- reduction: 43.3%
- output hash remained identical: `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945`

## Verification

- `composer test`
- 292 PHP transformer parity fixtures
- package install proof
- focused stylesheet transformer and reveal-animation tests

## AI assistance

GPT-5.6 Sol was used through OpenCode to inspect the duplicate traversal, implement the shared visitor, add regression coverage, and run parity and performance verification. The changes and benchmark output were reviewed locally before opening this PR.