### PR TITLE
Render captured boundaries in the block editor

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Generators/ResponsiveLayoutBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/Generators/ResponsiveLayoutBlockGenerator.php
@@ -30,15 +30,23 @@ final class ResponsiveLayoutBlockGenerator
     public function assets(string $blockName): array
     {
         $script = <<<'JS'
-( function( blocks, blockEditor, components, element ) {
+( function( blocks, blockEditor, components, element, ServerSideRender ) {
     var createElement = element.createElement;
     function edit( props ) {
-        if ( ! props.isSelected ) { return createElement( 'div', blockEditor.useBlockProps( { style: { display: 'none' } } ) ); }
-        return createElement( 'div', blockEditor.useBlockProps(), createElement( components.TextareaControl, {
-            label: 'Captured layout HTML',
-            value: props.attributes.content || '',
-            onChange: function( content ) { props.setAttributes( { content: content } ); }
-        } ) );
+        var inspector = props.isSelected ? createElement( blockEditor.InspectorControls, {},
+            createElement( components.PanelBody, { title: 'Captured layout HTML' },
+                createElement( components.TextareaControl, {
+                    label: 'HTML',
+                    value: props.attributes.content || '',
+                    onChange: function( content ) { props.setAttributes( { content: content } ); }
+                } )
+            )
+        ) : null;
+        return createElement( element.Fragment, {}, inspector,
+            createElement( 'div', blockEditor.useBlockProps(),
+                createElement( ServerSideRender, { block: '__BLOCK_NAME__', attributes: props.attributes } )
+            )
+        );
     }
     blocks.registerBlockType( '__BLOCK_NAME__', {
         attributes: { content: { type: 'string', default: '', role: 'content' } },
@@ -46,7 +54,7 @@ final class ResponsiveLayoutBlockGenerator
         edit: edit,
         save: function() { return null; }
     } );
-} )( window.wp.blocks, window.wp.blockEditor, window.wp.components, window.wp.element );
+} )( window.wp.blocks, window.wp.blockEditor, window.wp.components, window.wp.element, window.wp.serverSideRender );
 JS;
 
         return array( 'index.js' => str_replace('__BLOCK_NAME__', $blockName, $script) );
@@ -60,7 +68,7 @@ JS;
             'block_json' => $this->blockJson($namespace),
             'renderer' => self::RENDERER,
             'assets' => $this->assets($namespace . '/' . self::LOCAL_NAME),
-            'script_dependencies' => array( 'index.js' => array( 'wp-blocks', 'wp-block-editor', 'wp-components', 'wp-element' ) ),
+            'script_dependencies' => array( 'index.js' => array( 'wp-blocks', 'wp-block-editor', 'wp-components', 'wp-element', 'wp-server-side-render' ) ),
         );
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Generators/ResponsiveLayoutBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/Generators/ResponsiveLayoutBlockGenerator.php
@@ -44,7 +44,7 @@ final class ResponsiveLayoutBlockGenerator
         ) : null;
         return createElement( element.Fragment, {}, inspector,
             createElement( 'div', blockEditor.useBlockProps(),
-                createElement( ServerSideRender, { block: '__BLOCK_NAME__', attributes: props.attributes } )
+                createElement( ServerSideRender, { block: '__BLOCK_NAME__', attributes: props.attributes, httpMethod: 'POST' } )
             )
         );
     }

--- a/php-transformer/src/HtmlToBlocks/Generators/ResponsiveMediaBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/Generators/ResponsiveMediaBlockGenerator.php
@@ -31,15 +31,23 @@ final class ResponsiveMediaBlockGenerator
     public function assets(string $blockName): array
     {
         $script = <<<'JS'
-( function( blocks, blockEditor, components, element ) {
+( function( blocks, blockEditor, components, element, ServerSideRender ) {
     var createElement = element.createElement;
     function edit( props ) {
-        if ( ! props.isSelected ) { return createElement( 'div', blockEditor.useBlockProps( { style: { display: 'none' } } ) ); }
-        return createElement( 'div', blockEditor.useBlockProps(), createElement( components.TextareaControl, {
-            label: 'Captured media or layout HTML',
-            value: props.attributes.content || '',
-            onChange: function( content ) { props.setAttributes( { content: content } ); }
-        } ) );
+        var inspector = props.isSelected ? createElement( blockEditor.InspectorControls, {},
+            createElement( components.PanelBody, { title: 'Captured media HTML' },
+                createElement( components.TextareaControl, {
+                    label: 'HTML',
+                    value: props.attributes.content || '',
+                    onChange: function( content ) { props.setAttributes( { content: content } ); }
+                } )
+            )
+        ) : null;
+        return createElement( element.Fragment, {}, inspector,
+            createElement( 'div', blockEditor.useBlockProps(),
+                createElement( ServerSideRender, { block: '__BLOCK_NAME__', attributes: props.attributes } )
+            )
+        );
     }
     blocks.registerBlockType( '__BLOCK_NAME__', {
         attributes: { content: { type: 'string', default: '', role: 'content' }, kind: { type: 'string', default: 'media' } },
@@ -47,7 +55,7 @@ final class ResponsiveMediaBlockGenerator
         edit: edit,
         save: function() { return null; }
     } );
-} )( window.wp.blocks, window.wp.blockEditor, window.wp.components, window.wp.element );
+} )( window.wp.blocks, window.wp.blockEditor, window.wp.components, window.wp.element, window.wp.serverSideRender );
 JS;
 
         return array( 'index.js' => str_replace('__BLOCK_NAME__', $blockName, $script) );
@@ -61,7 +69,7 @@ JS;
             'block_json' => $this->blockJson($namespace),
             'renderer' => self::RENDERER,
             'assets' => $this->assets($namespace . '/' . self::LOCAL_NAME),
-            'script_dependencies' => array( 'index.js' => array( 'wp-blocks', 'wp-block-editor', 'wp-components', 'wp-element' ) ),
+            'script_dependencies' => array( 'index.js' => array( 'wp-blocks', 'wp-block-editor', 'wp-components', 'wp-element', 'wp-server-side-render' ) ),
         );
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Generators/ResponsiveMediaBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/Generators/ResponsiveMediaBlockGenerator.php
@@ -45,7 +45,7 @@ final class ResponsiveMediaBlockGenerator
         ) : null;
         return createElement( element.Fragment, {}, inspector,
             createElement( 'div', blockEditor.useBlockProps(),
-                createElement( ServerSideRender, { block: '__BLOCK_NAME__', attributes: props.attributes } )
+                createElement( ServerSideRender, { block: '__BLOCK_NAME__', attributes: props.attributes, httpMethod: 'POST' } )
             )
         );
     }

--- a/php-transformer/tests/unit/responsive-media-block.php
+++ b/php-transformer/tests/unit/responsive-media-block.php
@@ -21,12 +21,12 @@ $assert('ssi-example/responsive-media' === ($definition['block_json']['name'] ??
 $assert(false === ($definition['block_json']['supports']['html'] ?? null), 'the companion disables raw HTML editing');
 $assert('file:./index.js' === ($definition['block_json']['editorScript'] ?? null), 'the companion declares its editor script');
 $assert(!isset($definition['block_json']['render']), 'the companion metadata does not reference a producer-authored render asset');
-$assert(array('wp-blocks', 'wp-block-editor', 'wp-components', 'wp-element') === ($definition['script_dependencies']['index.js'] ?? null), 'the companion declares editor dependencies');
+$assert(array('wp-blocks', 'wp-block-editor', 'wp-components', 'wp-element', 'wp-server-side-render') === ($definition['script_dependencies']['index.js'] ?? null), 'the companion declares editor dependencies');
 $assert(ResponsiveMediaBlockGenerator::RENDERER === ($definition['renderer'] ?? null) && !isset($definition['render']), 'the companion delegates runtime rendering through an audited identifier without producer-authored PHP');
 $payload = ( new CompanionPluginPayload() )->fromBlockTypes(array(), array(), array(), array($definition));
 $assert(ResponsiveMediaBlockGenerator::RENDERER === ($payload['blocks'][0]['renderer'] ?? null) && !isset($payload['blocks'][0]['render']), 'the audited renderer identifier survives companion payload normalization');
 $editor = (string) ($definition['assets']['index.js'] ?? '');
-$assert(str_contains($editor, "registerBlockType( 'ssi-example/responsive-media'") && str_contains($editor, '! props.isSelected') && str_contains($editor, "display: 'none'") && str_contains($editor, 'TextareaControl') && str_contains($editor, 'save: function() { return null; }') && !str_contains($editor, 'RawHTML'), 'the editor hides the captured HTML control until its block is deliberately selected');
+$assert(str_contains($editor, "registerBlockType( 'ssi-example/responsive-media'") && str_contains($editor, 'ServerSideRender') && str_contains($editor, 'InspectorControls') && str_contains($editor, 'TextareaControl') && str_contains($editor, 'save: function() { return null; }') && !str_contains($editor, "display: 'none'") && !str_contains($editor, 'RawHTML'), 'the editor presents an audited preview and keeps captured HTML controls in the inspector');
 $editorSchemaRunner = <<<'JS'
 const vm = require( 'node:vm' );
 let settings;
@@ -47,7 +47,8 @@ $assert('string' === ($definition['block_json']['attributes']['kind']['type'] ??
 $layoutDefinition = ( new ResponsiveLayoutBlockGenerator() )->definition('ssi-example');
 $assert('ssi-example/responsive-layout' === ($layoutDefinition['block_json']['name'] ?? null), 'one namespaced responsive-layout block type is defined');
 $layoutEditor = (string) ($layoutDefinition['assets']['index.js'] ?? '');
-$assert(str_contains($layoutEditor, '! props.isSelected') && str_contains($layoutEditor, "display: 'none'") && !str_contains($layoutEditor, 'RawHTML'), 'responsive layout hides its captured HTML control until deliberately selected');
+$assert(str_contains($layoutEditor, 'ServerSideRender') && str_contains($layoutEditor, 'InspectorControls') && str_contains($layoutEditor, 'TextareaControl') && !str_contains($layoutEditor, "display: 'none'") && !str_contains($layoutEditor, 'RawHTML'), 'responsive layout presents an audited preview and keeps captured HTML controls in the inspector');
+$assert(array('wp-blocks', 'wp-block-editor', 'wp-components', 'wp-element', 'wp-server-side-render') === ($layoutDefinition['script_dependencies']['index.js'] ?? null), 'responsive layout declares its preview dependency');
 $assert(array('content') === array_keys($layoutDefinition['block_json']['attributes'] ?? array()), 'responsive layout declares a dedicated content-only schema');
 $assert(ResponsiveLayoutBlockGenerator::RENDERER === ($layoutDefinition['renderer'] ?? null), 'responsive layout delegates rendering through its producer-owned capability');
 $layoutEditorAttributes = json_decode((string) shell_exec('node -e ' . escapeshellarg($editorSchemaRunner) . ' ' . escapeshellarg(base64_encode($layoutEditor))), true);

--- a/php-transformer/tests/unit/responsive-media-block.php
+++ b/php-transformer/tests/unit/responsive-media-block.php
@@ -26,7 +26,7 @@ $assert(ResponsiveMediaBlockGenerator::RENDERER === ($definition['renderer'] ?? 
 $payload = ( new CompanionPluginPayload() )->fromBlockTypes(array(), array(), array(), array($definition));
 $assert(ResponsiveMediaBlockGenerator::RENDERER === ($payload['blocks'][0]['renderer'] ?? null) && !isset($payload['blocks'][0]['render']), 'the audited renderer identifier survives companion payload normalization');
 $editor = (string) ($definition['assets']['index.js'] ?? '');
-$assert(str_contains($editor, "registerBlockType( 'ssi-example/responsive-media'") && str_contains($editor, 'ServerSideRender') && str_contains($editor, 'InspectorControls') && str_contains($editor, 'TextareaControl') && str_contains($editor, 'save: function() { return null; }') && !str_contains($editor, "display: 'none'") && !str_contains($editor, 'RawHTML'), 'the editor presents an audited preview and keeps captured HTML controls in the inspector');
+$assert(str_contains($editor, "registerBlockType( 'ssi-example/responsive-media'") && str_contains($editor, 'ServerSideRender') && str_contains($editor, "httpMethod: 'POST'") && str_contains($editor, 'InspectorControls') && str_contains($editor, 'TextareaControl') && str_contains($editor, 'save: function() { return null; }') && !str_contains($editor, "display: 'none'") && !str_contains($editor, 'RawHTML'), 'the editor presents an audited preview over POST and keeps captured HTML controls in the inspector');
 $editorSchemaRunner = <<<'JS'
 const vm = require( 'node:vm' );
 let settings;
@@ -47,7 +47,7 @@ $assert('string' === ($definition['block_json']['attributes']['kind']['type'] ??
 $layoutDefinition = ( new ResponsiveLayoutBlockGenerator() )->definition('ssi-example');
 $assert('ssi-example/responsive-layout' === ($layoutDefinition['block_json']['name'] ?? null), 'one namespaced responsive-layout block type is defined');
 $layoutEditor = (string) ($layoutDefinition['assets']['index.js'] ?? '');
-$assert(str_contains($layoutEditor, 'ServerSideRender') && str_contains($layoutEditor, 'InspectorControls') && str_contains($layoutEditor, 'TextareaControl') && !str_contains($layoutEditor, "display: 'none'") && !str_contains($layoutEditor, 'RawHTML'), 'responsive layout presents an audited preview and keeps captured HTML controls in the inspector');
+$assert(str_contains($layoutEditor, 'ServerSideRender') && str_contains($layoutEditor, "httpMethod: 'POST'") && str_contains($layoutEditor, 'InspectorControls') && str_contains($layoutEditor, 'TextareaControl') && !str_contains($layoutEditor, "display: 'none'") && !str_contains($layoutEditor, 'RawHTML'), 'responsive layout presents an audited preview over POST and keeps captured HTML controls in the inspector');
 $assert(array('wp-blocks', 'wp-block-editor', 'wp-components', 'wp-element', 'wp-server-side-render') === ($layoutDefinition['script_dependencies']['index.js'] ?? null), 'responsive layout declares its preview dependency');
 $assert(array('content') === array_keys($layoutDefinition['block_json']['attributes'] ?? array()), 'responsive layout declares a dedicated content-only schema');
 $assert(ResponsiveLayoutBlockGenerator::RENDERER === ($layoutDefinition['renderer'] ?? null), 'responsive layout delegates rendering through its producer-owned capability');


### PR DESCRIPTION
## Summary

- render generated responsive layout and media blocks through WordPress server-side rendering in Gutenberg
- keep captured HTML editing in the selected block inspector
- declare the server-side-render script dependency

Fixes #1518.

## Verification

- `php php-transformer/tests/unit/responsive-media-block.php`
- `php php-transformer/tests/contract/staged-artifact-compilation.php`
- `php php-transformer/tests/contract/wordpress-site-plan.php`
- `php php-transformer/tests/contract/run.php`
- `git diff --check`

## AI assistance

OpenAI gpt-5.6-sol via OpenCode was used to reproduce the blank Gutenberg canvas against a real imported site, implement the generated editor contract change, and run the focused and full PHP transformer contracts. The implementation and verification were operator-reviewed.