### PR TITLE
Make HTML the direct Markdown interchange

### DIFF
--- a/php-transformer/README.md
+++ b/php-transformer/README.md
@@ -15,7 +15,7 @@ For local WordPress consumers, the same directory can also be installed as a plu
 PHP Transformer owns reusable transformation primitives:
 
 - HTML to parsed WordPress block arrays.
-- Markdown, HTML, and blocks conversion through a block-array pivot.
+- Markdown, HTML, and blocks conversion with HTML as the canonical interchange contract. Markdown converts directly to and from HTML; block conversions compose across that HTML boundary.
 - Generated website artifact normalization.
 - Serializable block output, document output, asset manifests, diagnostics, fallbacks, and provenance.
 - Generic per-call context and provenance metadata for downstream wrappers.
@@ -40,8 +40,9 @@ Consumers should treat these classes and interface as the public entrypoints for
 - `Contract\TransformerResult` - stable result envelope. Use `toArray()` for complete compatibility boundaries or `toWordPressSitePlanView()` for bounded WordPress materialization handoffs.
 - `AssetAnalysis\SrcsetParser` - parses, lists, and rewrites `srcset` candidates while preserving URL-internal commas and descriptors.
 - `HtmlToBlocks\HtmlTransformer` - converts supported HTML elements into WordPress block arrays and serialized block markup. Unsupported top-level HTML is reported in `fallbacks`.
-- `FormatBridge\FormatBridge` - normalizes and converts declared `html`, `markdown`, and serialized `blocks` content through `convertResult()`. Markdown support is optional: the adapter registers only when `league/commonmark` + `league/html-to-markdown` are loadable (vendored copies may omit them and `FormatBridge/MarkdownAdapter.php` entirely), otherwise markdown conversion fails cleanly as `unsupported_source_format` and `supportedFormats()` omits `markdown`.
+- `FormatBridge\FormatBridge` - normalizes and converts declared `html`, `markdown`, and serialized `blocks` content through `convertResult()`, using HTML as the direct interchange contract for Markdown. Markdown support is optional: the adapter registers only when `league/commonmark` + `league/html-to-markdown` are loadable (vendored copies may omit them and `FormatBridge/MarkdownAdapter.php` entirely), otherwise markdown conversion fails cleanly as `unsupported_source_format` and `supportedFormats()` omits `markdown`.
 - `FormatBridge\FormatAdapterInterface` - adapter contract for adding formats to `FormatBridge` when a consumer genuinely needs a package-level extension point.
+- `FormatBridge\HtmlInterchangeAdapterInterface` - optional adapter capability for direct conversion across the canonical HTML boundary without a lossy block round trip.
 - `ArtifactCompiler\ArtifactCompiler` - normalizes generated website artifact bundles into the shared result envelope, including block markup, source reports, assets, components, documents, and block type artifacts.
 - `WordPressSitePlan\WordPressSitePlan` - projects an artifact result to the self-contained v2 block-theme plan.
 - `WordPressSitePlan\WordPressSitePlanView` - exposes the self-contained WordPress site plan and required ancillary materialization contracts without duplicating legacy compiler projections.

--- a/php-transformer/src/FormatBridge/FormatBridge.php
+++ b/php-transformer/src/FormatBridge/FormatBridge.php
@@ -79,24 +79,25 @@ final class FormatBridge
             return $this->normalize($content, $from, $options);
         }
 
-        $blocks = $this->toBlocks($content, $from, $options);
-        if ( 'blocks' === $to ) {
-            $adapter = $this->registry->get($to);
-
-            if ( null === $adapter ) {
-                throw new InvalidArgumentException(sprintf('No format adapter is registered for format "%s".', $to));
-            }
-
-            return $adapter->fromBlocks($blocks, $options);
+        $sourceAdapter = $this->registry->get($from);
+        $targetAdapter = $this->registry->get($to);
+        if ( null === $sourceAdapter ) {
+            throw new InvalidArgumentException(sprintf('No format adapter is registered for format "%s".', $from));
         }
-
-        $adapter = $this->registry->get($to);
-
-        if ( null === $adapter ) {
+        if ( null === $targetAdapter ) {
             throw new InvalidArgumentException(sprintf('No format adapter is registered for format "%s".', $to));
         }
 
-        return $adapter->fromBlocks($blocks, $options);
+        $normalizedContent = $this->normalize($content, $from, $options);
+        if ( 'html' === $to && $sourceAdapter instanceof HtmlInterchangeAdapterInterface ) {
+            return $sourceAdapter->toHtml($normalizedContent, $options);
+        }
+        if ( 'html' === $from && $targetAdapter instanceof HtmlInterchangeAdapterInterface ) {
+            return $targetAdapter->fromHtml($normalizedContent, $options);
+        }
+
+        $blocks = array_values($sourceAdapter->toBlocks($normalizedContent, $options));
+        return $targetAdapter->fromBlocks($blocks, $options);
     }
 
     /**
@@ -135,7 +136,15 @@ final class FormatBridge
             $blocks = array_values(array() !== $adapterResult
                 ? (is_array($adapterResult['blocks'] ?? null) ? $adapterResult['blocks'] : array())
                 : $sourceAdapter->toBlocks($normalizedContent, $options));
-            $output = $from === $to ? $normalizedContent : $targetAdapter->fromBlocks($blocks, $options);
+            if ( $from === $to ) {
+                $output = $normalizedContent;
+            } elseif ( 'html' === $to && $sourceAdapter instanceof HtmlInterchangeAdapterInterface ) {
+                $output = $sourceAdapter->toHtml($normalizedContent, $options);
+            } elseif ( 'html' === $from && $targetAdapter instanceof HtmlInterchangeAdapterInterface ) {
+                $output = $targetAdapter->fromHtml($normalizedContent, $options);
+            } else {
+                $output = $targetAdapter->fromBlocks($blocks, $options);
+            }
             $assets = is_array($adapterResult['assets'] ?? null) ? $adapterResult['assets'] : array();
             $fallbacks = is_array($adapterResult['fallbacks'] ?? null) ? $adapterResult['fallbacks'] : array();
             $diagnostics = array_merge(is_array($adapterResult['diagnostics'] ?? null) ? $adapterResult['diagnostics'] : array(), array(

--- a/php-transformer/src/FormatBridge/HtmlInterchangeAdapterInterface.php
+++ b/php-transformer/src/FormatBridge/HtmlInterchangeAdapterInterface.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\FormatBridge;
+
+/**
+ * A format adapter that can convert directly across the canonical HTML boundary.
+ */
+interface HtmlInterchangeAdapterInterface
+{
+    /** @param array<string, mixed> $options */
+    public function toHtml(string $content, array $options = array()): string;
+
+    /** @param array<string, mixed> $options */
+    public function fromHtml(string $html, array $options = array()): string;
+}

--- a/php-transformer/src/FormatBridge/MarkdownAdapter.php
+++ b/php-transformer/src/FormatBridge/MarkdownAdapter.php
@@ -10,7 +10,7 @@ use Throwable;
 /**
  * @internal Bundled adapters are implementation details of FormatBridge.
  */
-final class MarkdownAdapter implements FormatAdapterInterface
+final class MarkdownAdapter implements FormatAdapterInterface, HtmlInterchangeAdapterInterface
 {
     public function __construct(
         private readonly HtmlAdapter $htmlAdapter = new HtmlAdapter(),
@@ -44,7 +44,7 @@ final class MarkdownAdapter implements FormatAdapterInterface
             return array();
         }
 
-        $html = $this->markdownToHtml($content);
+        $html = $this->toHtml($content, $options);
         if ( '' === trim($html) ) {
             return array();
         }
@@ -68,7 +68,7 @@ final class MarkdownAdapter implements FormatAdapterInterface
         }
 
         $html = $this->normalizePreBlocks($html);
-        $markdown = $this->htmlToMarkdown($html, $options);
+        $markdown = $this->fromHtml($html, $options);
         $placeholders = $this->emptyDynamicBlockPlaceholders($blocks);
         if ( array() !== $placeholders ) {
             $markdown = trim($markdown . "\n\n" . implode("\n\n", $placeholders));
@@ -82,10 +82,11 @@ final class MarkdownAdapter implements FormatAdapterInterface
         return (bool) preg_match('/(^|\n)\s*(#{1,6}\s+|[-*+]\s+\S|\d+\.\s+\S|>\s+\S|```)/', $content);
     }
 
-    private function markdownToHtml(string $markdown): string
+    /** @param array<string, mixed> $options */
+    public function toHtml(string $content, array $options = array()): string
     {
         try {
-            return (string) (new GithubFlavoredMarkdownConverter())->convert($markdown);
+            return (string) (new GithubFlavoredMarkdownConverter())->convert($content);
         } catch ( Throwable ) {
             return '';
         }
@@ -94,7 +95,7 @@ final class MarkdownAdapter implements FormatAdapterInterface
     /**
      * @param array<string, mixed> $options
      */
-    private function htmlToMarkdown(string $html, array $options): string
+    public function fromHtml(string $html, array $options = array()): string
     {
         $converterOptions = array_replace(
             array(

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -5252,7 +5252,10 @@ assertSame('core/heading', $markdownToBlocksResult['blocks'][0]['blockName'], 'M
 $blocksToHtmlResult = $bridge->convertResult('<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->', 'blocks', 'html')->toArray();
 assertSame('<p>Hello</p>', $blocksToHtmlResult['documents'][0]['content'], 'Serialized blocks should render to HTML through the default blocks/html adapters.');
 $markdownToHtmlResult = $bridge->convertResult("# Title\n\nBody", 'markdown', 'html')->toArray();
-assertStringContains('<h1 class="wp-block-heading">Title</h1>', $markdownToHtmlResult['documents'][0]['content'], 'Markdown should convert to HTML through the block pivot with the canonical heading class core save() emits.');
+assertStringContains('<h1>Title</h1>', $markdownToHtmlResult['documents'][0]['content'], 'Markdown should convert directly to canonical HTML without block save-shape classes.');
+assertSame(false, str_contains($markdownToHtmlResult['documents'][0]['content'], 'wp-block-heading'), 'Direct Markdown-to-HTML conversion should not round-trip through blocks.');
+$htmlToMarkdownResult = $bridge->convertResult('<article><h2>Direct HTML</h2><p>Body with <strong>weight</strong>.</p></article>', 'html', 'markdown')->toArray();
+assertStringContains("## Direct HTML\n\nBody with **weight**.", $htmlToMarkdownResult['documents'][0]['content'], 'HTML should convert directly to Markdown across the canonical HTML boundary.');
 $blocksToMarkdownResult = $bridge->convertResult('<!-- wp:heading {"content":"Hello","level":1} --><h1>Hello</h1><!-- /wp:heading -->', 'blocks', 'markdown')->toArray();
 assertStringContains('# Hello', $blocksToMarkdownResult['documents'][0]['content'], 'Serialized blocks should convert to markdown through rendered HTML.');
 $htmlToBlocksResult = $bridge->convertResult('<h2>Hello</h2>', 'html', 'blocks')->toArray();

--- a/php-transformer/tests/fixtures/parity/markdown-conversion.json
+++ b/php-transformer/tests/fixtures/parity/markdown-conversion.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "markdown-conversion",
-  "description": "Converts Markdown through the FormatBridge block pivot into HTML and parsed block output.",
+  "description": "Converts Markdown directly to canonical HTML while retaining parsed block output in the result envelope.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "src/FormatBridge/MarkdownAdapter.php",
@@ -14,7 +14,7 @@
     "content": "# Title\n\nBody with **strong** text.\n\n- One\n- Two\n"
   },
   "expect": [
-    { "path": "converted", "assert": "contains", "value": "<h1 class=\"wp-block-heading\">Title</h1>" },
+    { "path": "converted", "assert": "contains", "value": "<h1>Title</h1>" },
     { "path": "converted", "assert": "contains", "value": "<strong>strong</strong>" },
     { "path": "blocks", "assert": "count", "count": 3 },
     { "path": "blocks.0.blockName", "assert": "equals", "value": "core/heading" },
@@ -22,7 +22,7 @@
     { "path": "result.schema", "assert": "equals", "value": "blocks-engine/php-transformer/result/v1" },
     { "path": "result.status", "assert": "equals", "value": "success" },
     { "path": "result.documents.0.format", "assert": "equals", "value": "html" },
-    { "path": "result.documents.0.content", "assert": "contains", "value": "<h1 class=\"wp-block-heading\">Title</h1>" },
+    { "path": "result.documents.0.content", "assert": "contains", "value": "<h1>Title</h1>" },
     { "path": "result.blocks.0.blockName", "assert": "equals", "value": "core/heading" },
     { "path": "result.diagnostics.0.code", "assert": "equals", "value": "format_bridge_conversion_completed" },
     { "path": "result.provenance.0.source_format", "assert": "equals", "value": "markdown" },

--- a/php-transformer/tests/fixtures/parity/mixed-source-markdown.json
+++ b/php-transformer/tests/fixtures/parity/mixed-source-markdown.json
@@ -18,7 +18,7 @@
     "content": "# Markdown Story\n\nThis page came from a nested Markdown source document.\n\n[Read the notes](notes.markdown)\n"
   },
   "expect": [
-    { "path": "converted", "assert": "contains", "value": "<h1 class=\"wp-block-heading\">Markdown Story</h1>" },
+    { "path": "converted", "assert": "contains", "value": "<h1>Markdown Story</h1>" },
     { "path": "converted", "assert": "contains", "value": "href=\"notes.markdown\"" },
     { "path": "blocks", "assert": "count", "count": 3 },
     { "path": "blocks.0.blockName", "assert": "equals", "value": "core/heading" },


### PR DESCRIPTION
## Summary

- define HTML as the canonical interchange contract for format adapters
- route Markdown-to-HTML and HTML-to-Markdown directly without a lossy WordPress block round trip
- preserve the existing block conversion, result-envelope, and optional Markdown adapter contracts
- retain League as the reference implementation for this prerequisite phase of #1189

## Why

A shared Markdown codec can only replace third-party parsers safely once Markdown conversion has a direct, explicit HTML boundary. This also matches Intelligence/Data Machine content-format use and the HTML-first WordPress.com/Static Site Importer architecture.

## Verification

- `composer test`
- 292 parity fixtures
- clean-package installation proof
- `composer validate --strict --no-interaction`
- `git diff --check`

## Follow-up

- #1189 tracks Blocks Engine adoption and downstream packaging updates.
- [WordPress/php-toolkit#313](https://github.com/WordPress/php-toolkit/issues/313) tracks the generic self-contained Markdown `<->` HTML codec.
- Once the toolkit primitive is released and differentially validated, `MarkdownAdapter` can consume it and remove Blocks Engine's direct League dependency graph without duplicating parser ownership.

---
AI assistance disclosure: OpenAI gpt-5.6-sol via OpenCode inspected the cross-project architecture, refined the trackers, implemented and verified the change, and coordinated an attempted Homeboy Cook. Homeboy with OpenCode `openai/gpt-5.6-terra` validated provider readiness but failed before execution on component worktree resolution; Chris Huber authorized the direct local implementation and remains responsible for review.