### PR TITLE
Pass element presentation as typed resolver

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Elements/ButtonElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/ButtonElementContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
 use Closure;
 use DOMElement;
 
@@ -14,7 +15,7 @@ final class ButtonElementContext
         private readonly SourceElementClassifier $sourceElementClassifier,
         private readonly Closure $isReplacedSearchClusterControl,
         private readonly Closure $convertChildren,
-        private readonly Closure $presentationAttributes,
+        private readonly ElementPresentationResolver $presentationResolver,
         private readonly Closure $createBlock,
         private readonly Closure $convertButton
     ) {
@@ -39,7 +40,7 @@ final class ButtonElementContext
     /** @return array<string, mixed> */
     public function presentationAttributes(DOMElement $element): array
     {
-        return ($this->presentationAttributes)($element);
+        return $this->presentationResolver->presentationAttributes($element);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Elements/ButtonLinkDispatchContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/ButtonLinkDispatchContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
 use Closure;
 use DOMElement;
 
@@ -20,10 +21,8 @@ final class ButtonLinkDispatchContext
      * @param Closure(DOMElement, array<int, array<string, mixed>>): ?array<string, mixed>                    $linkedSvgLogoBlockFromAnchor
      * @param Closure(DOMElement): ?array<string, mixed>                                                     $imageBlockFromAnchor
      * @param Closure(DOMElement, array<int, array<string, mixed>>): ?array<string, mixed>                    $convertLinkWrapperGroup
-     * @param Closure(DOMElement, array<int, string>, array<int, string>): array<string, mixed>               $presentationAttributes
      * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(string): string                                                                        $safeLinkUrl
-     * @param Closure(DOMElement): array<string, mixed>                                                      $structuralPresentationDeclarations
      */
     public function __construct(
         private readonly SourceElementClassifier $sourceElementClassifier,
@@ -34,10 +33,9 @@ final class ButtonLinkDispatchContext
         private readonly Closure $linkedSvgLogoBlockFromAnchor,
         private readonly Closure $imageBlockFromAnchor,
         private readonly Closure $convertLinkWrapperGroup,
-        private readonly Closure $presentationAttributes,
+        private readonly ElementPresentationResolver $presentationResolver,
         private readonly Closure $createBlock,
-        private readonly Closure $safeLinkUrl,
-        private readonly Closure $structuralPresentationDeclarations
+        private readonly Closure $safeLinkUrl
     ) {
     }
 
@@ -102,7 +100,7 @@ final class ButtonLinkDispatchContext
      */
     public function presentationAttributes(DOMElement $element, array $excludedProperties = array(), array $excludedGeometryProperties = array()): array
     {
-        return ($this->presentationAttributes)($element, $excludedProperties, $excludedGeometryProperties);
+        return $this->presentationResolver->presentationAttributes($element, $excludedProperties, $excludedGeometryProperties);
     }
 
     /**
@@ -130,6 +128,6 @@ final class ButtonLinkDispatchContext
      */
     public function structuralPresentationDeclarations(DOMElement $element): array
     {
-        return ($this->structuralPresentationDeclarations)($element);
+        return $this->presentationResolver->structuralPresentationDeclarations($element);
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Elements/DescriptionListElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/DescriptionListElementContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
 use Closure;
 use DOMElement;
 
@@ -16,7 +17,6 @@ final class DescriptionListElementContext
      * @param Closure(DOMElement): array<int, array<string, mixed>> $definitionListItems
      * @param Closure(DOMElement): bool $isCssOwnedGridElement
      * @param Closure(DOMElement): array<string, mixed> $cssOwnedGridAttributes
-     * @param Closure(DOMElement): array<string, mixed> $presentationAttributes
      * @param Closure(DOMElement, array<int, array<string, mixed>>&, bool): array<int, array<string, mixed>> $convertChildren
      * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(DOMElement): string $richTextContent
@@ -29,7 +29,7 @@ final class DescriptionListElementContext
         private readonly Closure $definitionListItems,
         private readonly Closure $isCssOwnedGridElement,
         private readonly Closure $cssOwnedGridAttributes,
-        private readonly Closure $presentationAttributes,
+        private readonly ElementPresentationResolver $presentationResolver,
         private readonly Closure $convertChildren,
         private readonly Closure $createBlock,
         private readonly Closure $richTextContent,
@@ -69,7 +69,7 @@ final class DescriptionListElementContext
     /** @return array<string, mixed> */
     public function presentationAttributes(DOMElement $element): array
     {
-        return ($this->presentationAttributes)($element);
+        return $this->presentationResolver->presentationAttributes($element);
     }
 
     /** @param array<int, array<string, mixed>> $fallbacks @return array<int, array<string, mixed>> */

--- a/php-transformer/src/HtmlToBlocks/Elements/FigureElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FigureElementContext.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
 use Closure;
 use DOMElement;
 
@@ -18,7 +19,6 @@ final class FigureElementContext
      * @param Closure(DOMElement, string): ?DOMElement $mediaElement
      * @param Closure(DOMElement, array<int, array<string, mixed>>&): ?array<string, mixed> $convertGeneric
      * @param Closure(string): bool $hasVisibleText
-     * @param Closure(DOMElement): array<string, mixed> $presentationAttributes
      * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      */
     public function __construct(
@@ -30,7 +30,7 @@ final class FigureElementContext
         private readonly Closure $mediaElement,
         private readonly Closure $convertGeneric,
         private readonly Closure $hasVisibleText,
-        private readonly Closure $presentationAttributes,
+        private readonly ElementPresentationResolver $presentationResolver,
         private readonly Closure $createBlock
     ) {
     }
@@ -87,7 +87,7 @@ final class FigureElementContext
     /** @return array<string, mixed> */
     public function presentationAttributes(DOMElement $element): array
     {
-        return ($this->presentationAttributes)($element);
+        return $this->presentationResolver->presentationAttributes($element);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Elements/FlowContainerElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FlowContainerElementContext.php
@@ -5,6 +5,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
 use Closure;
 use DOMElement;
 
@@ -49,7 +50,7 @@ final class FlowContainerElementContext
         private readonly Closure $backgroundImageBlock,
         private readonly Closure $coalescedSingleGroupWrapper,
         private readonly Closure $shouldPreserveWrapper,
-        private readonly Closure $presentationAttributes,
+        private readonly ElementPresentationResolver $presentationResolver,
         private readonly Closure $emptyVisualSpacerBlock
     ) {
     }
@@ -120,7 +121,7 @@ final class FlowContainerElementContext
     public function coalescedSingleGroupWrapper(DOMElement $element, array $child): ?array { return ($this->coalescedSingleGroupWrapper)($element, $child); }
     public function shouldPreserveWrapper(DOMElement $element): bool { return ($this->shouldPreserveWrapper)($element); }
     /** @return array<string, mixed> */
-    public function presentationAttributes(DOMElement $element): array { return ($this->presentationAttributes)($element); }
+    public function presentationAttributes(DOMElement $element): array { return $this->presentationResolver->presentationAttributes($element); }
     /** @return array<string, mixed> */
     public function emptyVisualSpacerBlock(DOMElement $element): array { return ($this->emptyVisualSpacerBlock)($element); }
 }

--- a/php-transformer/src/HtmlToBlocks/Elements/ListElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/ListElementContext.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
 use Closure;
 use DOMElement;
 
@@ -19,7 +20,6 @@ final class ListElementContext
      * @param Closure(DOMElement, array<int, array<string, mixed>>&): array<int, array<string, mixed>> $listItems
      * @param Closure(DOMElement): bool $isCssOwnedGridElement
      * @param Closure(DOMElement): array<string, mixed> $cssOwnedGridAttributes
-     * @param Closure(DOMElement): array<string, mixed> $presentationAttributes
      * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      */
     public function __construct(
@@ -32,7 +32,7 @@ final class ListElementContext
         private readonly Closure $listItems,
         private readonly Closure $isCssOwnedGridElement,
         private readonly Closure $cssOwnedGridAttributes,
-        private readonly Closure $presentationAttributes,
+        private readonly ElementPresentationResolver $presentationResolver,
         private readonly Closure $createBlock
     ) {
     }
@@ -91,7 +91,7 @@ final class ListElementContext
     /** @return array<string, mixed> */
     public function presentationAttributes(DOMElement $element): array
     {
-        return ($this->presentationAttributes)($element);
+        return $this->presentationResolver->presentationAttributes($element);
     }
 
     /** @param array<string, mixed> $attributes @param array<int, array<string, mixed>> $innerBlocks @return array<string, mixed> */

--- a/php-transformer/src/HtmlToBlocks/Elements/RichTextElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/RichTextElementContext.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use Closure;
 use DOMElement;
@@ -19,7 +20,6 @@ use DOMElement;
 final class RichTextElementContext
 {
     /**
-     * @param Closure(DOMElement, array<int, string>, array<int, string>): array<string, mixed>              $presentationAttributes
      * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(DOMElement, array<int, string>): string                                                $richTextContent
      * @param Closure(string): string                                                                        $headingRichTextContent
@@ -35,7 +35,7 @@ final class RichTextElementContext
      * @param Closure(DOMElement, array<int, array<string, mixed>>, bool): array<int, array<string, mixed>>   $convertChildren
      */
     public function __construct(
-        private readonly Closure $presentationAttributes,
+        private readonly ElementPresentationResolver $presentationResolver,
         private readonly Closure $createBlock,
         private readonly Closure $richTextContent,
         private readonly Closure $headingRichTextContent,
@@ -60,7 +60,7 @@ final class RichTextElementContext
      */
     public function presentationAttributes(DOMElement $element, array $excludedProperties = array(), array $excludedGeometryProperties = array()): array
     {
-        return ($this->presentationAttributes)($element, $excludedProperties, $excludedGeometryProperties);
+        return $this->presentationResolver->presentationAttributes($element, $excludedProperties, $excludedGeometryProperties);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Elements/SearchBlockConversionContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/SearchBlockConversionContext.php
@@ -7,6 +7,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerS
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\GeneratedSupportStylesheetState;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
 use Closure;
 use DOMElement;
 
@@ -14,8 +15,6 @@ use DOMElement;
 final class SearchBlockConversionContext
 {
     /**
-     * @param Closure(DOMElement): array<string, mixed>                                              $presentationAttributes
-     * @param Closure(DOMElement): array<string, string>                                             $presentationDeclarations
      * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(string): string                                                                $restoreSvgCasing
      * @param Closure(DOMElement): bool                                                              $isRuntimeDomTarget
@@ -23,8 +22,7 @@ final class SearchBlockConversionContext
      */
     public function __construct(
         private readonly HtmlTransformerSession $session,
-        private readonly Closure $presentationAttributes,
-        private readonly Closure $presentationDeclarations,
+        private readonly ElementPresentationResolver $presentationResolver,
         private readonly Closure $createBlock,
         private readonly Closure $restoreSvgCasing,
         private readonly Closure $isRuntimeDomTarget,
@@ -56,13 +54,13 @@ final class SearchBlockConversionContext
     /** @return array<string, mixed> */
     public function presentationAttributes(DOMElement $element): array
     {
-        return ($this->presentationAttributes)($element);
+        return $this->presentationResolver->presentationAttributes($element);
     }
 
     /** @return array<string, string> */
     public function presentationDeclarations(DOMElement $element): array
     {
-        return ($this->presentationDeclarations)($element);
+        return $this->presentationResolver->presentationDeclarations($element);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Elements/SvgElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/SvgElementContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
 use Closure;
 use DOMElement;
 
@@ -16,7 +17,6 @@ final class SvgElementContext
      * @param Closure(DOMElement): string $sanitizeMarkup
      * @param Closure(string): bool $isSafeContent
      * @param Closure(DOMElement): bool $hasDrawableContent
-     * @param Closure(DOMElement): array<string, mixed> $presentationAttributes
      * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(DOMElement, array<int, array<string, mixed>>&): void $captureFallback
      */
@@ -27,7 +27,7 @@ final class SvgElementContext
         private readonly Closure $sanitizeMarkup,
         private readonly Closure $isSafeContent,
         private readonly Closure $hasDrawableContent,
-        private readonly Closure $presentationAttributes,
+        private readonly ElementPresentationResolver $presentationResolver,
         private readonly Closure $createBlock,
         private readonly Closure $captureFallback
     ) {
@@ -66,7 +66,7 @@ final class SvgElementContext
     /** @return array<string, mixed> */
     public function presentationAttributes(DOMElement $element): array
     {
-        return ($this->presentationAttributes)($element);
+        return $this->presentationResolver->presentationAttributes($element);
     }
 
     /** @param array<string, mixed> $attributes @param array<int, array<string, mixed>> $innerBlocks @return array<string, mixed> */

--- a/php-transformer/src/HtmlToBlocks/Elements/TableElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/TableElementContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\TableClassificationPolicy;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
 use Closure;
 use DOMElement;
 
@@ -20,7 +21,6 @@ final class TableElementContext
      * @param Closure(DOMElement, array<int, array<string, mixed>>): ?array<string, mixed>                    $nestedLayoutTableColumnsBlock
      * @param Closure(DOMElement, array<int, array<string, mixed>>): ?array<string, mixed>                    $mediaLayoutTableColumnsBlock
      * @param Closure(DOMElement): array<string, mixed>                                                       $htmlPreservationBlock
-     * @param Closure(DOMElement, array<int, string>, array<int, string>): array<string, mixed>               $presentationAttributes
      * @param Closure(DOMElement): array<string, mixed>                                                       $tableAttributes
      * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      */
@@ -29,7 +29,7 @@ final class TableElementContext
         private readonly Closure $nestedLayoutTableColumnsBlock,
         private readonly Closure $mediaLayoutTableColumnsBlock,
         private readonly Closure $htmlPreservationBlock,
-        private readonly Closure $presentationAttributes,
+        private readonly ElementPresentationResolver $presentationResolver,
         private readonly Closure $tableAttributes,
         private readonly Closure $createBlock
     ) {
@@ -73,7 +73,7 @@ final class TableElementContext
      */
     public function presentationAttributes(DOMElement $element, array $excludedProperties = array(), array $excludedGeometryProperties = array()): array
     {
-        return ($this->presentationAttributes)($element, $excludedProperties, $excludedGeometryProperties);
+        return $this->presentationResolver->presentationAttributes($element, $excludedProperties, $excludedGeometryProperties);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Elements/TextLeafElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/TextLeafElementContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use Closure;
 use DOMElement;
@@ -19,7 +20,6 @@ use DOMElement;
 final class TextLeafElementContext
 {
     /**
-     * @param Closure(DOMElement, array<int, string>, array<int, string>): array<string, mixed> $presentationAttributes
      * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(DOMElement, array<int, string>): string                                  $richTextContent
      * @param Closure(DOMElement, DOMElement): array<string, mixed>                            $codePresentationAttributes
@@ -28,7 +28,7 @@ final class TextLeafElementContext
      */
     public function __construct(
         private readonly SourceElementClassifier $sourceElementClassifier,
-        private readonly Closure $presentationAttributes,
+        private readonly ElementPresentationResolver $presentationResolver,
         private readonly Closure $createBlock,
         private readonly Closure $richTextContent,
         private readonly Runtime $runtime,
@@ -45,7 +45,7 @@ final class TextLeafElementContext
      */
     public function presentationAttributes(DOMElement $element, array $excludedProperties = array(), array $excludedGeometryProperties = array()): array
     {
-        return ($this->presentationAttributes)($element, $excludedProperties, $excludedGeometryProperties);
+        return $this->presentationResolver->presentationAttributes($element, $excludedProperties, $excludedGeometryProperties);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -486,12 +486,12 @@ final class HtmlCompilation
         );
         $this->contentRoundTripReporter = new ContentRoundTripReporter();
         $this->reusableComponentRecognizer = new ReusableComponentRecognizer();
+        $this->styleResolver = new StyleResolver($this->createStyleResolutionContext(), $this->analysisCache);
         $this->patternContext = $this->createPatternContext(true);
         $this->patternContextWithoutRuntimeDomTarget = $this->createPatternContext(false);
         $this->patternProbeContext = $this->createProbePatternContext();
         $this->textLeafConverter = new TextLeafElementConverter($this->createTextLeafElementContext());
         $this->richTextConverter = new RichTextElementConverter($this->createRichTextElementContext());
-        $this->styleResolver = new StyleResolver($this->createStyleResolutionContext(), $this->analysisCache);
         $this->generatedBlockStyleProjector = new GeneratedBlockStyleProjector($this->runtime, $this->styleResolver);
         $this->sourceBlockAttributeProjector = new SourceBlockAttributeProjector($this->styleResolver, $this->generatedBlockStyleProjector);
         $this->stylesheetAnalysisComposer = new StylesheetAnalysisComposer($this->styleResolver, $this->analysisCache);
@@ -534,7 +534,7 @@ final class HtmlCompilation
             fn (DOMElement $element): string => $this->sanitizeInlineSvgMarkup($element),
             fn (string $html): bool => $this->isSafeSvgContent($html),
             fn (DOMElement $element): bool => $this->svgHasDrawableContent($element),
-            fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
+            $this->styleResolver,
             fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
             function (DOMElement $element, array &$fallbacks): void {
                 $this->captureInlineSvgFallback($element, $fallbacks);
@@ -671,7 +671,7 @@ final class HtmlCompilation
             function (DOMElement $element, array &$fallbacks, bool $captureUnsupported): array {
                 return $this->convertChildren($element, $fallbacks, $captureUnsupported);
             },
-            fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
+            $this->styleResolver,
             fn (string $name, array $attributes, array $innerBlocks, DOMElement $element): array => $this->createBlock($name, $attributes, $innerBlocks, $element),
             fn (DOMElement $element): ?array => $this->buttonLinkDispatcher->convertButton($element)
         ));
@@ -717,7 +717,7 @@ final class HtmlCompilation
                 return $this->convertFigureGeneric($figure, $fallbacks);
             },
             fn (string $html): bool => '' !== trim($this->runtime->stripAllTags($html)),
-            fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
+            $this->styleResolver,
             fn (string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement)
         ));
         $quoteConverter = new QuoteElementConverter(new QuoteElementContext(
@@ -743,7 +743,7 @@ final class HtmlCompilation
             },
             fn (DOMElement $element): bool => $this->isCssOwnedGridElement($element),
             fn (DOMElement $element): array => $this->cssOwnedGridAttributes($element),
-            fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
+            $this->styleResolver,
             fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement)
         ));
         $descriptionListConverter = new DescriptionListElementConverter(new DescriptionListElementContext(
@@ -753,7 +753,7 @@ final class HtmlCompilation
             fn (DOMElement $element): array => $this->definitionListItems($element),
             fn (DOMElement $element): bool => $this->isCssOwnedGridElement($element),
             fn (DOMElement $element): array => $this->cssOwnedGridAttributes($element),
-            fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
+            $this->styleResolver,
             function (DOMElement $element, array &$fallbacks, bool $captureUnsupported): array {
                 return $this->convertChildren($element, $fallbacks, $captureUnsupported);
             },
@@ -822,7 +822,7 @@ final class HtmlCompilation
             backgroundImageBlock: fn (DOMElement $element): ?array => $this->backgroundImageBlockFromElement($element),
             coalescedSingleGroupWrapper: fn (DOMElement $element, array $child): ?array => $this->coalescedSingleGroupWrapper($element, $child),
             shouldPreserveWrapper: fn (DOMElement $element): bool => $this->shouldPreserveWrapper($element),
-            presentationAttributes: fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
+            presentationResolver: $this->styleResolver,
             emptyVisualSpacerBlock: fn (DOMElement $element): array => $this->emptyVisualSpacerBlock($element)
         ));
         $this->mediaDispatchConverter = new MediaDispatchElementConverter(new MediaDispatchElementContext(
@@ -929,8 +929,7 @@ final class HtmlCompilation
     {
         return new SearchBlockConversionContext(
             $this->session,
-            fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
-            fn (DOMElement $element): array => $this->styleResolver->presentationDeclarations($element),
+            $this->styleResolver,
             fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
             fn (string $html): string => $this->svgMaterializer->restoreSvgCasing($html),
             fn (DOMElement $element): bool => $this->runtimeIslands->isRuntimeDomTarget($element),
@@ -972,10 +971,9 @@ final class HtmlCompilation
             function (DOMElement $element, array &$fallbacks): ?array {
                 return $this->convertLinkWrapperGroup($element, $fallbacks);
             },
-            fn (DOMElement $element, array $excludedProperties, array $excludedGeometryProperties): array => $this->styleResolver->presentationAttributes($element, $excludedProperties, $excludedGeometryProperties),
+            $this->styleResolver,
             fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
-            fn (string $href): string => $this->safeLinkUrl($href),
-            fn (DOMElement $element): array => $this->styleResolver->structuralPresentationDeclarations($element)
+            fn (string $href): string => $this->safeLinkUrl($href)
         );
     }
 
@@ -1006,7 +1004,7 @@ final class HtmlCompilation
                 return $this->mediaLayoutTableColumnsBlock($element, $fallbacks);
             },
             fn (DOMElement $element): array => $this->htmlPreservationBlock($element),
-            fn (DOMElement $element, array $excludedProperties, array $excludedGeometryProperties): array => $this->styleResolver->presentationAttributes($element, $excludedProperties, $excludedGeometryProperties),
+            $this->styleResolver,
             fn (DOMElement $element): array => $this->tableAttributes($element),
             fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement)
         );
@@ -1033,7 +1031,7 @@ final class HtmlCompilation
     private function createRichTextElementContext(): RichTextElementContext
     {
         return new RichTextElementContext(
-            fn (DOMElement $element, array $excludedProperties, array $excludedGeometryProperties): array => $this->styleResolver->presentationAttributes($element, $excludedProperties, $excludedGeometryProperties),
+            $this->styleResolver,
             fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
             fn (DOMElement $element, array $excludedTags): string => $this->richTextContentWithMaterializedInlineStyles($element, $excludedTags),
             fn (string $content): string => $this->headingRichTextContent($content),
@@ -1062,7 +1060,7 @@ final class HtmlCompilation
     {
         return new TextLeafElementContext(
             $this->sourceElementClassifier,
-            fn (DOMElement $element, array $excludedProperties, array $excludedGeometryProperties): array => $this->styleResolver->presentationAttributes($element, $excludedProperties, $excludedGeometryProperties),
+            $this->styleResolver,
             fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
             fn (DOMElement $element, array $excludedTags): string => $this->richTextContentWithMaterializedInlineStyles($element, $excludedTags),
             $this->runtime,

--- a/php-transformer/src/HtmlToBlocks/Style/ElementPresentationResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Style/ElementPresentationResolver.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
+
+use DOMElement;
+
+/** Resolves the source presentation consumed by element converters. */
+interface ElementPresentationResolver
+{
+    /** @return array<string, mixed> */
+    public function presentationAttributes(DOMElement $element, array $excludedGeometryProperties = array(), array $forcedGeometryProperties = array()): array;
+
+    /** @return array<string, string> */
+    public function presentationDeclarations(DOMElement $element): array;
+
+    /** @return array<string, string> */
+    public function structuralPresentationDeclarations(DOMElement $element): array;
+}

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
@@ -21,7 +21,7 @@ use DOMElement;
  * it needs 15 transformer operations and 3 collaborators, which is fewer
  * external dependencies than traits a third its size.
  */
-final class StyleResolver
+final class StyleResolver implements ElementPresentationResolver
 {
     public function __construct(
         private readonly StyleResolutionContext $context,

--- a/php-transformer/tests/Support/ElementPresentationResolverFixture.php
+++ b/php-transformer/tests/Support/ElementPresentationResolverFixture.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\Tests\Support;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
+use Closure;
+use DOMElement;
+
+final class ElementPresentationResolverFixture implements ElementPresentationResolver
+{
+    public function __construct(
+        private readonly Closure $presentationAttributes,
+        private readonly ?Closure $presentationDeclarations = null,
+        private readonly ?Closure $structuralPresentationDeclarations = null
+    ) {}
+
+    public function presentationAttributes(DOMElement $element, array $excludedGeometryProperties = array(), array $forcedGeometryProperties = array()): array
+    { return ($this->presentationAttributes)($element, $excludedGeometryProperties, $forcedGeometryProperties); }
+
+    public function presentationDeclarations(DOMElement $element): array
+    { return null === $this->presentationDeclarations ? array() : ($this->presentationDeclarations)($element); }
+
+    public function structuralPresentationDeclarations(DOMElement $element): array
+    { return null === $this->structuralPresentationDeclarations ? array() : ($this->structuralPresentationDeclarations)($element); }
+}

--- a/php-transformer/tests/unit/button-element-converter.php
+++ b/php-transformer/tests/unit/button-element-converter.php
@@ -6,6 +6,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonElementConverter;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
 
 $assertions = 0;
 $failures = array();
@@ -39,7 +40,7 @@ $converter = new ButtonElementConverter(new ButtonElementContext(
         $fallbacks[] = array( 'image' => true );
         return 'image' === $mode ? array( array( 'blockName' => 'core/image' ) ) : array();
     },
-    static fn (DOMElement $element): array => array( 'className' => 'carrier' ),
+    new ElementPresentationResolverFixture(static fn (DOMElement $element): array => array( 'className' => 'carrier' )),
     static fn (string $name, array $attributes, array $innerBlocks, DOMElement $element): array => array(
         'blockName' => $name,
         'attrs' => $attributes,

--- a/php-transformer/tests/unit/button-link-dispatcher.php
+++ b/php-transformer/tests/unit/button-link-dispatcher.php
@@ -15,6 +15,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispatchContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispatcher;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
 
 $assertions = 0;
 $failures   = array();
@@ -70,10 +71,9 @@ $makeDispatcher = static function (array $overrides = array()): ButtonLinkDispat
         $c['linkedLogo'],
         $c['linkedImage'],
         $c['linkWrapper'],
-        $c['presentation'],
+        new ElementPresentationResolverFixture($c['presentation'], structuralPresentationDeclarations: $c['structural']),
         $c['createBlock'],
-        $c['safeLinkUrl'],
-        $c['structural']
+        $c['safeLinkUrl']
     ));
 };
 

--- a/php-transformer/tests/unit/figure-element-converter.php
+++ b/php-transformer/tests/unit/figure-element-converter.php
@@ -5,6 +5,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FigureElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FigureElementConverter;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
 
 $assertions = 0;
 $failures = array();
@@ -68,7 +69,7 @@ $context = new FigureElementContext(
         return array( 'blockName' => 'core/group' );
     },
     static fn (string $html): bool => '' !== trim(strip_tags($html)),
-    static fn (DOMElement $element): array => array( 'className' => 'caption' ),
+    new ElementPresentationResolverFixture(static fn (DOMElement $element): array => array( 'className' => 'caption' )),
     static fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => array(
         'blockName' => $name,
         'attrs' => $attributes,

--- a/php-transformer/tests/unit/flow-container-element-converter.php
+++ b/php-transformer/tests/unit/flow-container-element-converter.php
@@ -8,6 +8,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FlowContainerEl
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FlowContainerElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\SpacerPattern;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
 
 $assertions = 0;
 $failures = array();
@@ -84,7 +85,7 @@ $operations = array(
     'backgroundImageBlock' => $null,
     'coalescedSingleGroupWrapper' => $null,
     'shouldPreserveWrapper' => $false,
-    'presentationAttributes' => static fn (): array => array( 'className' => 'flow' ),
+    'presentationResolver' => new ElementPresentationResolverFixture(static fn (): array => array( 'className' => 'flow' )),
     'emptyVisualSpacerBlock' => static fn (): array => array( 'blockName' => 'core/spacer' ),
 );
 $converter = new FlowContainerElementConverter(new FlowContainerElementContext(...$operations));

--- a/php-transformer/tests/unit/list-element-converters.php
+++ b/php-transformer/tests/unit/list-element-converters.php
@@ -8,6 +8,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\DescriptionList
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\DescriptionListElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ListElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ListElementConverter;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
 
 $assertions = 0;
 $failures = array();
@@ -45,7 +46,7 @@ $listContext = new ListElementContext(
     static fn (DOMElement $element, array &$fallbacks): array => 'empty' === $state->mode ? array() : array( array( 'blockName' => 'core/list-item' ) ),
     static fn (DOMElement $element): bool => 'grid' === $state->mode,
     static fn (DOMElement $element): array => array( 'className' => 'grid-list' ),
-    static fn (DOMElement $element): array => array( 'className' => 'presented-list' ),
+    new ElementPresentationResolverFixture(static fn (DOMElement $element): array => array( 'className' => 'presented-list' )),
     $createBlock
 );
 $listConverter = new ListElementConverter($listContext);
@@ -80,7 +81,7 @@ $descriptionContext = new DescriptionListElementContext(
     static fn (DOMElement $element): array => 'items' === $state->mode ? array( array( 'blockName' => 'core/list-item' ) ) : array(),
     static fn (DOMElement $element): bool => 'grid-items' === $state->mode,
     static fn (DOMElement $element): array => array( 'className' => 'grid-description' ),
-    static fn (DOMElement $element): array => array( 'className' => 'presented-' . strtolower($element->tagName) ),
+    new ElementPresentationResolverFixture(static fn (DOMElement $element): array => array( 'className' => 'presented-' . strtolower($element->tagName) )),
     static fn (DOMElement $element, array &$fallbacks, bool $capture): array => 'empty' === $state->mode ? array() : array( array( 'blockName' => 'core/paragraph' ) ),
     $createBlock,
     static fn (DOMElement $element): string => $element->textContent ?? '',

--- a/php-transformer/tests/unit/rich-text-element-converter.php
+++ b/php-transformer/tests/unit/rich-text-element-converter.php
@@ -15,6 +15,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RichTextElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RichTextElementConverter;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
 $assertions = 0;
@@ -53,7 +54,7 @@ $makeConverter = static function (array $overrides = array()): RichTextElementCo
     $c = array_merge($defaults, $overrides);
 
     return new RichTextElementConverter(new RichTextElementContext(
-        $c['presentationAttributes'],
+        new ElementPresentationResolverFixture($c['presentationAttributes']),
         $c['createBlock'],
         $c['richTextContent'],
         $c['headingRichTextContent'],

--- a/php-transformer/tests/unit/svg-element-converter.php
+++ b/php-transformer/tests/unit/svg-element-converter.php
@@ -7,6 +7,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceEle
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\SvgElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\SvgElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\SvgElementMaterializer;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
 
 $assertions = 0;
 $failures = array();
@@ -36,7 +37,7 @@ $context = new SvgElementContext(
     static fn (DOMElement $element): string => '<svg viewbox="0 0 1 1"></svg>',
     static fn (string $html): bool => 'runtime-safe' === $state->mode,
     static fn (DOMElement $element): bool => str_starts_with($state->mode, 'drawable-'),
-    static fn (DOMElement $element): array => array( 'className' => 'visual-svg' ),
+    new ElementPresentationResolverFixture(static fn (DOMElement $element): array => array( 'className' => 'visual-svg' )),
     static fn (string $name, array $attrs, array $innerBlocks, ?DOMElement $source): array => array(
         'blockName' => $name,
         'attrs' => $attrs,

--- a/php-transformer/tests/unit/table-element-converter.php
+++ b/php-transformer/tests/unit/table-element-converter.php
@@ -14,6 +14,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TableElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TableElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\TableClassificationPolicy;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
 
 $assertions = 0;
 $failures   = array();
@@ -55,7 +56,7 @@ $makeConverter = static function (array $overrides = array()): TableElementConve
         $c['nested'],
         $c['media'],
         $c['preserve'],
-        $c['presentation'],
+        new ElementPresentationResolverFixture($c['presentation']),
         $c['tableAttrs'],
         $c['createBlock']
     ));

--- a/php-transformer/tests/unit/text-leaf-element-converter.php
+++ b/php-transformer/tests/unit/text-leaf-element-converter.php
@@ -15,6 +15,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TextLeafElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TextLeafElementConverter;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
 $assertions = 0;
@@ -57,7 +58,7 @@ $makeConverter = static function (array $overrides = array()): TextLeafElementCo
 
     return new TextLeafElementConverter(new TextLeafElementContext(
         new SourceElementClassifier(),
-        $c['presentationAttributes'],
+        new ElementPresentationResolverFixture($c['presentationAttributes']),
         $c['createBlock'],
         $c['richTextContent'],
         new Runtime(),


### PR DESCRIPTION
## Summary
- define a narrow `ElementPresentationResolver` contract implemented by `StyleResolver`
- inject the resolver into 11 element contexts instead of 13 presentation-forwarding closures
- preserve each context facade while using one reusable resolver fixture in focused tests

## Verification
- `composer test`
- 292 PHP transformer parity fixtures
- 385 serialized-block fixture hashes identical to `origin/trunk` (`4344fd63`), with 0 exceptions
- `git diff --check origin/trunk...HEAD`
- Homeboy architecture audit: 0 introduced findings

## AI assistance
OpenAI GPT-5.6 Sol was used through OpenCode to inspect the dependency surface, implement the typed collaborator migration, update tests, and run verification. The resulting diff and evidence were reviewed by the operator.