### PR TITLE
Pass source block creator as typed context

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Elements/AuthoredFormControlBlockConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/AuthoredFormControlBlockConverter.php
@@ -6,6 +6,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredInputBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredSelectBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use Closure;
@@ -17,7 +18,6 @@ final class AuthoredFormControlBlockConverter
     /**
      * @param Closure(DOMElement): array<string, mixed>                                                     $structuralPresentationDeclarations
      * @param Closure(DOMElement): array<string, mixed>                                                     $presentationAttributes
-     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(class-string, array<string, mixed>): void                                             $registerGeneratedBlock
      * @param Closure(string): void                                                                         $registerEcho
      * @param Closure(string): string                                                                       $safeAnchor
@@ -26,7 +26,7 @@ final class AuthoredFormControlBlockConverter
         private readonly FormControlMetadataBuilder $metadataBuilder,
         private readonly Closure $structuralPresentationDeclarations,
         private readonly Closure $presentationAttributes,
-        private readonly Closure $createBlock,
+        private readonly SourceBlockCreator $createBlock,
         private readonly Closure $registerGeneratedBlock,
         private readonly Closure $registerEcho,
         private readonly Runtime $runtime,
@@ -57,12 +57,12 @@ final class AuthoredFormControlBlockConverter
                     $optionLabel .= ' (selected)';
                 }
                 ($this->registerEcho)($optionLabel);
-                $optionBlocks[] = ($this->createBlock)('core/list-item', array( 'content' => $this->runtime->escapeHtml($optionLabel) ), array(), null);
+                $optionBlocks[] = $this->createBlock->createBlock('core/list-item', array( 'content' => $this->runtime->escapeHtml($optionLabel) ));
             }
 
-            return ($this->createBlock)('core/group', ($this->presentationAttributes)($select), array(
-                ($this->createBlock)('core/paragraph', array( 'content' => $this->runtime->escapeHtml($label) ), array(), $select),
-                ($this->createBlock)('core/list', array(), $optionBlocks, $select),
+            return $this->createBlock->createBlock('core/group', ($this->presentationAttributes)($select), array(
+                $this->createBlock->createBlock('core/paragraph', array( 'content' => $this->runtime->escapeHtml($label) ), array(), $select),
+                $this->createBlock->createBlock('core/list', array(), $optionBlocks, $select),
             ), $select);
         }
 
@@ -89,7 +89,7 @@ final class AuthoredFormControlBlockConverter
 
         // Preserve the established structural address while source identity and
         // authored selectors remain on the native control inside this shell.
-        return ($this->createBlock)('core/group', array_filter(array(
+        return $this->createBlock->createBlock('core/group', array_filter(array(
             'anchor' => ($this->safeAnchor)(SourceDom::attr($select, 'id')),
             'className' => 'blocks-engine-authored-select-wrapper',
         )), array( $controlBlock ), null);

--- a/php-transformer/src/HtmlToBlocks/Elements/ButtonElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/ButtonElementContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
 use Closure;
 use DOMElement;
@@ -16,7 +17,7 @@ final class ButtonElementContext
         private readonly Closure $isReplacedSearchClusterControl,
         private readonly Closure $convertChildren,
         private readonly ElementPresentationResolver $presentationResolver,
-        private readonly Closure $createBlock,
+        private readonly SourceBlockCreator $createBlock,
         private readonly Closure $convertButton
     ) {
     }
@@ -50,7 +51,7 @@ final class ButtonElementContext
      */
     public function createBlock(string $name, array $attributes, array $innerBlocks, DOMElement $element): array
     {
-        return ($this->createBlock)($name, $attributes, $innerBlocks, $element);
+        return $this->createBlock->createBlock($name, $attributes, $innerBlocks, $element);
     }
 
     /** @return array<string, mixed>|null */

--- a/php-transformer/src/HtmlToBlocks/Elements/ButtonLinkDispatchContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/ButtonLinkDispatchContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
 use Closure;
 use DOMElement;
@@ -21,7 +22,6 @@ final class ButtonLinkDispatchContext
      * @param Closure(DOMElement, array<int, array<string, mixed>>): ?array<string, mixed>                    $linkedSvgLogoBlockFromAnchor
      * @param Closure(DOMElement): ?array<string, mixed>                                                     $imageBlockFromAnchor
      * @param Closure(DOMElement, array<int, array<string, mixed>>): ?array<string, mixed>                    $convertLinkWrapperGroup
-     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(string): string                                                                        $safeLinkUrl
      */
     public function __construct(
@@ -34,7 +34,7 @@ final class ButtonLinkDispatchContext
         private readonly Closure $imageBlockFromAnchor,
         private readonly Closure $convertLinkWrapperGroup,
         private readonly ElementPresentationResolver $presentationResolver,
-        private readonly Closure $createBlock,
+        private readonly SourceBlockCreator $createBlock,
         private readonly Closure $safeLinkUrl
     ) {
     }
@@ -110,7 +110,7 @@ final class ButtonLinkDispatchContext
      */
     public function createBlock(string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array
     {
-        return ($this->createBlock)($name, $attributes, $innerBlocks, $sourceElement);
+        return $this->createBlock->createBlock($name, $attributes, $innerBlocks, $sourceElement);
     }
 
     public function safeLinkUrl(string $href): string

--- a/php-transformer/src/HtmlToBlocks/Elements/DescriptionListElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/DescriptionListElementContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
 use Closure;
 use DOMElement;
@@ -18,7 +19,6 @@ final class DescriptionListElementContext
      * @param Closure(DOMElement): bool $isCssOwnedGridElement
      * @param Closure(DOMElement): array<string, mixed> $cssOwnedGridAttributes
      * @param Closure(DOMElement, array<int, array<string, mixed>>&, bool): array<int, array<string, mixed>> $convertChildren
-     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(DOMElement): string $richTextContent
      * @param Closure(string): bool $hasVisibleText
      */
@@ -31,7 +31,7 @@ final class DescriptionListElementContext
         private readonly Closure $cssOwnedGridAttributes,
         private readonly ElementPresentationResolver $presentationResolver,
         private readonly Closure $convertChildren,
-        private readonly Closure $createBlock,
+        private readonly SourceBlockCreator $createBlock,
         private readonly Closure $richTextContent,
         private readonly Closure $hasVisibleText
     ) {
@@ -81,7 +81,7 @@ final class DescriptionListElementContext
     /** @param array<string, mixed> $attributes @param array<int, array<string, mixed>> $innerBlocks @return array<string, mixed> */
     public function createBlock(string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array
     {
-        return ($this->createBlock)($name, $attributes, $innerBlocks, $sourceElement);
+        return $this->createBlock->createBlock($name, $attributes, $innerBlocks, $sourceElement);
     }
 
     public function richTextContent(DOMElement $element): string

--- a/php-transformer/src/HtmlToBlocks/Elements/FigureElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FigureElementContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Closure;
 use DOMElement;
 
@@ -19,7 +20,6 @@ final class FigureElementContext
      * @param Closure(DOMElement, string): ?DOMElement $mediaElement
      * @param Closure(DOMElement, array<int, array<string, mixed>>&): ?array<string, mixed> $convertGeneric
      * @param Closure(string): bool $hasVisibleText
-     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      */
     public function __construct(
         private readonly Closure $mediaGalleryBlock,
@@ -31,7 +31,7 @@ final class FigureElementContext
         private readonly Closure $convertGeneric,
         private readonly Closure $hasVisibleText,
         private readonly ElementPresentationResolver $presentationResolver,
-        private readonly Closure $createBlock
+        private readonly SourceBlockCreator $createBlock
     ) {
     }
 
@@ -97,6 +97,6 @@ final class FigureElementContext
      */
     public function createBlock(string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array
     {
-        return ($this->createBlock)($name, $attributes, $innerBlocks, $sourceElement);
+        return $this->createBlock->createBlock($name, $attributes, $innerBlocks, $sourceElement);
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Elements/FlowContainerElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FlowContainerElementContext.php
@@ -5,6 +5,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
 use Closure;
 use DOMElement;
@@ -30,7 +31,7 @@ final class FlowContainerElementContext
         private readonly Closure $proofBackedWrapperCoalescing,
         private readonly Closure $shouldPreserveEmptyVisualElement,
         private readonly Closure $emptyVisualElementAttributes,
-        private readonly Closure $createBlock,
+        private readonly SourceBlockCreator $createBlock,
         private readonly PatternContext $patternContext,
         private readonly Closure $shouldDeferNavigationPatternToChildren,
         private readonly Closure $rememberAccordionDisclosureRoot,
@@ -84,7 +85,7 @@ final class FlowContainerElementContext
     /** @return array<string, mixed> */
     public function emptyVisualElementAttributes(DOMElement $element): array { return ($this->emptyVisualElementAttributes)($element); }
     /** @param array<string, mixed> $attributes @param array<int, array<string, mixed>> $innerBlocks @return array<string, mixed> */
-    public function createBlock(string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array { return ($this->createBlock)($name, $attributes, $innerBlocks, $sourceElement); }
+    public function createBlock(string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array { return $this->createBlock->createBlock($name, $attributes, $innerBlocks, $sourceElement); }
     public function patternContext(): PatternContext { return $this->patternContext; }
     public function shouldDeferNavigationPatternToChildren(DOMElement $element): bool { return ($this->shouldDeferNavigationPatternToChildren)($element); }
     /** @param array<string, mixed> $block @return array<string, mixed> */

--- a/php-transformer/src/HtmlToBlocks/Elements/FormCompositionPlanner.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FormCompositionPlanner.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerSession;
 use Closure;
 use DOMElement;
@@ -14,14 +15,13 @@ final class FormCompositionPlanner
     /**
      * @param Closure(DOMElement, array<int, array<string, mixed>>&, bool): array<int, array<string, mixed>> $convertChildren
      * @param Closure(DOMElement): array<string, mixed>                                                     $presentationAttributes
-     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(DOMElement, DOMElement): bool                                                         $elementContains
      */
     public function __construct(
         private readonly HtmlTransformerSession $session,
         private readonly Closure $convertChildren,
         private readonly Closure $presentationAttributes,
-        private readonly Closure $createBlock,
+        private readonly SourceBlockCreator $createBlock,
         private readonly Closure $elementContains
     ) {
     }
@@ -51,7 +51,7 @@ final class FormCompositionPlanner
         }
 
         return array(
-            'block' => ($this->createBlock)('core/group', ($this->presentationAttributes)($form), $children, $form),
+            'block' => $this->createBlock->createBlock('core/group', ($this->presentationAttributes)($form), $children, $form),
             'slot'  => $slotBlock,
         );
     }

--- a/php-transformer/src/HtmlToBlocks/Elements/InlineContentElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/InlineContentElementContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Closure;
 use DOMElement;
 
@@ -20,7 +21,6 @@ final class InlineContentElementContext
      * @param Closure(DOMElement): bool $hasAuthorSemanticMarker
      * @param Closure(string): bool $richTextContentHasStructuralHtml
      * @param Closure(DOMElement, array<int, array<string, mixed>>&, bool): array<int, array<string, mixed>> $convertChildren
-     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(DOMElement): string $richTextMarker
      * @param Closure(DOMElement): array<string, string> $richTextInlineVisualDeclarations
      * @param Closure(DOMElement): ?string $dynamicTextContent
@@ -40,7 +40,7 @@ final class InlineContentElementContext
         private readonly Closure $hasAuthorSemanticMarker,
         private readonly Closure $richTextContentHasStructuralHtml,
         private readonly Closure $convertChildren,
-        private readonly Closure $createBlock,
+        private readonly SourceBlockCreator $createBlock,
         private readonly Closure $richTextMarker,
         private readonly Closure $richTextInlineVisualDeclarations,
         private readonly Closure $dynamicTextContent,
@@ -66,7 +66,7 @@ final class InlineContentElementContext
     /** @param array<int, array<string, mixed>> $fallbacks @return array<int, array<string, mixed>> */
     public function convertChildren(DOMElement $element, array &$fallbacks): array { return ($this->convertChildren)($element, $fallbacks, true); }
     /** @param array<string, mixed> $attributes @param array<int, array<string, mixed>> $innerBlocks @return array<string, mixed> */
-    public function createBlock(string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array { return ($this->createBlock)($name, $attributes, $innerBlocks, $sourceElement); }
+    public function createBlock(string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array { return $this->createBlock->createBlock($name, $attributes, $innerBlocks, $sourceElement); }
     public function richTextMarker(DOMElement $element): string { return ($this->richTextMarker)($element); }
     public function hasBlockContentChildren(DOMElement $element): bool { return $this->sourceElementClassifier->hasBlockContentChildren($element); }
     /** @return array<string, string> */

--- a/php-transformer/src/HtmlToBlocks/Elements/ListElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/ListElementContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Closure;
 use DOMElement;
 
@@ -20,7 +21,6 @@ final class ListElementContext
      * @param Closure(DOMElement, array<int, array<string, mixed>>&): array<int, array<string, mixed>> $listItems
      * @param Closure(DOMElement): bool $isCssOwnedGridElement
      * @param Closure(DOMElement): array<string, mixed> $cssOwnedGridAttributes
-     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      */
     public function __construct(
         private readonly Closure $recognizePatterns,
@@ -33,7 +33,7 @@ final class ListElementContext
         private readonly Closure $isCssOwnedGridElement,
         private readonly Closure $cssOwnedGridAttributes,
         private readonly ElementPresentationResolver $presentationResolver,
-        private readonly Closure $createBlock
+        private readonly SourceBlockCreator $createBlock
     ) {
     }
 
@@ -97,6 +97,6 @@ final class ListElementContext
     /** @param array<string, mixed> $attributes @param array<int, array<string, mixed>> $innerBlocks @return array<string, mixed> */
     public function createBlock(string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array
     {
-        return ($this->createBlock)($name, $attributes, $innerBlocks, $sourceElement);
+        return $this->createBlock->createBlock($name, $attributes, $innerBlocks, $sourceElement);
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Elements/ReadableFormBlockBuilder.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/ReadableFormBlockBuilder.php
@@ -5,6 +5,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredInputBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use Closure;
 use DOMElement;
@@ -16,7 +17,6 @@ final class ReadableFormBlockBuilder
      * @param Closure(DOMElement): array<string, mixed>                                                     $eventMetadata
      * @param Closure(DOMElement): bool                                                                     $isRuntimeDomTarget
      * @param Closure(DOMElement): array<string, mixed>                                                     $presentationAttributes
-     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      */
     public function __construct(
         private readonly FormControlMetadataBuilder $metadataBuilder,
@@ -26,7 +26,7 @@ final class ReadableFormBlockBuilder
         private readonly Closure $eventMetadata,
         private readonly Closure $isRuntimeDomTarget,
         private readonly Closure $presentationAttributes,
-        private readonly Closure $createBlock
+        private readonly SourceBlockCreator $createBlock
     ) {
     }
 
@@ -47,7 +47,7 @@ final class ReadableFormBlockBuilder
             }
 
             if ( FormControlClassifier::isSubmitLikeControl($control) ) {
-                $buttonBlocks[] = ($this->createBlock)('core/button', array_merge(($this->presentationAttributes)($control), array(
+                $buttonBlocks[] = $this->createBlock->createBlock('core/button', array_merge(($this->presentationAttributes)($control), array(
                     'text' => $this->runtime->escapeHtml($this->metadataBuilder->submitText($control, 'Submit')),
                 )), array(), $control);
                 continue;
@@ -73,17 +73,17 @@ final class ReadableFormBlockBuilder
             $fieldBlocks[] = $readableControlBlock;
             $contentBlocks[] = ( 1 === count($fieldBlocks) && AuthoredInputBlockGenerator::NAME !== ($readableControlBlock['blockName'] ?? '') )
                 ? $fieldBlocks[0]
-                : ($this->createBlock)('core/group', array(), $fieldBlocks, $control);
+                : $this->createBlock->createBlock('core/group', array(), $fieldBlocks, $control);
         }
 
         if ( array() !== $buttonBlocks ) {
-            $contentBlocks[] = ($this->createBlock)('core/buttons', array(), $buttonBlocks, $form);
+            $contentBlocks[] = $this->createBlock->createBlock('core/buttons', array(), $buttonBlocks, $form);
         }
 
         if ( array() === $contentBlocks ) {
             return null;
         }
 
-        return ($this->createBlock)('core/group', ($this->presentationAttributes)($form), $contentBlocks, $form);
+        return $this->createBlock->createBlock('core/group', ($this->presentationAttributes)($form), $contentBlocks, $form);
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Elements/ReadableFormControlBlockConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/ReadableFormControlBlockConverter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use Closure;
@@ -17,7 +18,6 @@ final class ReadableFormControlBlockConverter
      * @param Closure(DOMElement): bool                                                                     $isRuntimeDomTarget
      * @param Closure(DOMElement): array<string, mixed>                                                     $htmlPreservationBlock
      * @param Closure(DOMElement): array<string, mixed>                                                     $presentationAttributes
-     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(string): void                                                                         $registerEcho
      */
     public function __construct(
@@ -29,7 +29,7 @@ final class ReadableFormControlBlockConverter
         private readonly Closure $isRuntimeDomTarget,
         private readonly Closure $htmlPreservationBlock,
         private readonly Closure $presentationAttributes,
-        private readonly Closure $createBlock,
+        private readonly SourceBlockCreator $createBlock,
         private readonly Closure $registerEcho
     ) {
     }
@@ -85,7 +85,7 @@ final class ReadableFormControlBlockConverter
             return null;
         }
 
-        return ($this->createBlock)('core/paragraph', array_merge(($this->presentationAttributes)($element), array( 'content' => $summary )), array(), $element);
+        return $this->createBlock->createBlock('core/paragraph', array_merge(($this->presentationAttributes)($element), array( 'content' => $summary )), array(), $element);
     }
 
     /** @return array<string, mixed>|null */
@@ -106,7 +106,7 @@ final class ReadableFormControlBlockConverter
 
                 $summary = $this->controlText($control);
                 if ( '' !== $summary ) {
-                    $blocks[] = ($this->createBlock)('core/paragraph', array( 'content' => $summary ), array(), $control);
+                    $blocks[] = $this->createBlock->createBlock('core/paragraph', array( 'content' => $summary ), array(), $control);
                 }
             }
 
@@ -115,7 +115,7 @@ final class ReadableFormControlBlockConverter
             }
 
             return array() !== $blocks
-                ? ($this->createBlock)('core/group', ($this->presentationAttributes)($element), $blocks, $element)
+                ? $this->createBlock->createBlock('core/group', ($this->presentationAttributes)($element), $blocks, $element)
                 : null;
         }
 
@@ -125,7 +125,7 @@ final class ReadableFormControlBlockConverter
         }
 
         return '' !== $label
-            ? ($this->createBlock)('core/paragraph', array( 'content' => $this->runtime->escapeHtml($label) ), array(), $element)
+            ? $this->createBlock->createBlock('core/paragraph', array( 'content' => $this->runtime->escapeHtml($label) ), array(), $element)
             : null;
     }
 

--- a/php-transformer/src/HtmlToBlocks/Elements/RichTextElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/RichTextElementContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use Closure;
 use DOMElement;
@@ -20,7 +21,6 @@ use DOMElement;
 final class RichTextElementContext
 {
     /**
-     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(DOMElement, array<int, string>): string                                                $richTextContent
      * @param Closure(string): string                                                                        $headingRichTextContent
      * @param Closure(DOMElement, string): ?string                                                            $richTextWithMaterializedSvgImages
@@ -36,7 +36,7 @@ final class RichTextElementContext
      */
     public function __construct(
         private readonly ElementPresentationResolver $presentationResolver,
-        private readonly Closure $createBlock,
+        private readonly SourceBlockCreator $createBlock,
         private readonly Closure $richTextContent,
         private readonly Closure $headingRichTextContent,
         private readonly Closure $richTextWithMaterializedSvgImages,
@@ -70,7 +70,7 @@ final class RichTextElementContext
      */
     public function createBlock(string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array
     {
-        return ($this->createBlock)($name, $attributes, $innerBlocks, $sourceElement);
+        return $this->createBlock->createBlock($name, $attributes, $innerBlocks, $sourceElement);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Elements/RuntimeResourceElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/RuntimeResourceElementConverter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerSession;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Closure;
 use DOMElement;
 
@@ -12,12 +13,11 @@ final class RuntimeResourceElementConverter implements ElementConverter
 {
     /**
      * @param Closure(DOMElement): array<string, mixed> $htmlPreservationBlock
-     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement): array<string, mixed> $createBlock
      */
     public function __construct(
         private readonly HtmlTransformerSession $session,
         private readonly Closure $htmlPreservationBlock,
-        private readonly Closure $createBlock
+        private readonly SourceBlockCreator $createBlock
     ) {
     }
 
@@ -126,7 +126,7 @@ final class RuntimeResourceElementConverter implements ElementConverter
         }
         $body = str_replace('</script', '<\/script', (string) ($metadata['body'] ?? ''));
 
-        return ($this->createBlock)(
+        return $this->createBlock->createBlock(
             'core/html',
             array( 'content' => '<script' . $attributeHtml . '>' . $body . '</script>' ),
             array(),

--- a/php-transformer/src/HtmlToBlocks/Elements/SearchBlockConversionContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/SearchBlockConversionContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerSession;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\GeneratedSupportStylesheetState;
@@ -15,7 +16,6 @@ use DOMElement;
 final class SearchBlockConversionContext
 {
     /**
-     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(string): string                                                                $restoreSvgCasing
      * @param Closure(DOMElement): bool                                                              $isRuntimeDomTarget
      * @param Closure(DOMElement): array<string, mixed>                                              $htmlPreservationBlock
@@ -23,7 +23,7 @@ final class SearchBlockConversionContext
     public function __construct(
         private readonly HtmlTransformerSession $session,
         private readonly ElementPresentationResolver $presentationResolver,
-        private readonly Closure $createBlock,
+        private readonly SourceBlockCreator $createBlock,
         private readonly Closure $restoreSvgCasing,
         private readonly Closure $isRuntimeDomTarget,
         private readonly Closure $htmlPreservationBlock
@@ -70,7 +70,7 @@ final class SearchBlockConversionContext
      */
     public function createBlock(string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array
     {
-        return ($this->createBlock)($name, $attributes, $innerBlocks, $sourceElement);
+        return $this->createBlock->createBlock($name, $attributes, $innerBlocks, $sourceElement);
     }
 
     public function restoreSvgCasing(string $html): string

--- a/php-transformer/src/HtmlToBlocks/Elements/SvgElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/SvgElementContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
 use Closure;
 use DOMElement;
@@ -17,7 +18,6 @@ final class SvgElementContext
      * @param Closure(DOMElement): string $sanitizeMarkup
      * @param Closure(string): bool $isSafeContent
      * @param Closure(DOMElement): bool $hasDrawableContent
-     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(DOMElement, array<int, array<string, mixed>>&): void $captureFallback
      */
     public function __construct(
@@ -28,7 +28,7 @@ final class SvgElementContext
         private readonly Closure $isSafeContent,
         private readonly Closure $hasDrawableContent,
         private readonly ElementPresentationResolver $presentationResolver,
-        private readonly Closure $createBlock,
+        private readonly SourceBlockCreator $createBlock,
         private readonly Closure $captureFallback
     ) {
     }
@@ -72,7 +72,7 @@ final class SvgElementContext
     /** @param array<string, mixed> $attributes @param array<int, array<string, mixed>> $innerBlocks @return array<string, mixed> */
     public function createBlock(string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array
     {
-        return ($this->createBlock)($name, $attributes, $innerBlocks, $sourceElement);
+        return $this->createBlock->createBlock($name, $attributes, $innerBlocks, $sourceElement);
     }
 
     /** @param array<int, array<string, mixed>> $fallbacks */

--- a/php-transformer/src/HtmlToBlocks/Elements/TableElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/TableElementContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\TableClassificationPolicy;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
 use Closure;
 use DOMElement;
@@ -22,7 +23,6 @@ final class TableElementContext
      * @param Closure(DOMElement, array<int, array<string, mixed>>): ?array<string, mixed>                    $mediaLayoutTableColumnsBlock
      * @param Closure(DOMElement): array<string, mixed>                                                       $htmlPreservationBlock
      * @param Closure(DOMElement): array<string, mixed>                                                       $tableAttributes
-     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      */
     public function __construct(
         private readonly TableClassificationPolicy $classificationPolicy,
@@ -31,7 +31,7 @@ final class TableElementContext
         private readonly Closure $htmlPreservationBlock,
         private readonly ElementPresentationResolver $presentationResolver,
         private readonly Closure $tableAttributes,
-        private readonly Closure $createBlock
+        private readonly SourceBlockCreator $createBlock
     ) {
     }
 
@@ -91,6 +91,6 @@ final class TableElementContext
      */
     public function createBlock(string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array
     {
-        return ($this->createBlock)($name, $attributes, $innerBlocks, $sourceElement);
+        return $this->createBlock->createBlock($name, $attributes, $innerBlocks, $sourceElement);
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Elements/TextLeafElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/TextLeafElementContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use Closure;
@@ -20,7 +21,6 @@ use DOMElement;
 final class TextLeafElementContext
 {
     /**
-     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(DOMElement, array<int, string>): string                                  $richTextContent
      * @param Closure(DOMElement, DOMElement): array<string, mixed>                            $codePresentationAttributes
      * @param Closure(DOMElement): string                                                      $codeContent
@@ -29,7 +29,7 @@ final class TextLeafElementContext
     public function __construct(
         private readonly SourceElementClassifier $sourceElementClassifier,
         private readonly ElementPresentationResolver $presentationResolver,
-        private readonly Closure $createBlock,
+        private readonly SourceBlockCreator $createBlock,
         private readonly Closure $richTextContent,
         private readonly Runtime $runtime,
         private readonly Closure $codePresentationAttributes,
@@ -55,7 +55,7 @@ final class TextLeafElementContext
      */
     public function createBlock(string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array
     {
-        return ($this->createBlock)($name, $attributes, $innerBlocks, $sourceElement);
+        return $this->createBlock->createBlock($name, $attributes, $innerBlocks, $sourceElement);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -108,6 +108,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognit
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerRegistry;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecursiveConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PlaceholderMediaPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ProbeBlockCreator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\QuotePattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\QuotePatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\SpacerPattern;
@@ -151,7 +152,7 @@ use DOMElement;
 use DOMNode;
 
 /** Run-scoped compiler for one HTML document. */
-final class HtmlCompilation
+final class HtmlCompilation implements SourceBlockCreator
 {
     private const GENERATED_COMPONENT_MIN_SOURCE_DEPTH = 14;
 
@@ -535,7 +536,7 @@ final class HtmlCompilation
             fn (string $html): bool => $this->isSafeSvgContent($html),
             fn (DOMElement $element): bool => $this->svgHasDrawableContent($element),
             $this->styleResolver,
-            fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
+            $this,
             function (DOMElement $element, array &$fallbacks): void {
                 $this->captureInlineSvgFallback($element, $fallbacks);
             }
@@ -551,7 +552,7 @@ final class HtmlCompilation
             fn (DOMElement $element): bool => $this->hasAuthorSemanticMarker($element),
             fn (string $content): bool => $this->richTextContentHasStructuralHtml($content),
             fn (DOMElement $element, array &$fallbacks, bool $captureUnsupported): array => $this->convertChildren($element, $fallbacks, $captureUnsupported),
-            fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
+            $this,
             fn (DOMElement $element): string => $this->richTextMarkerForElement($element),
             fn (DOMElement $element): array => $this->richTextInlineVisualDeclarations($element),
             fn (DOMElement $element): ?string => $this->dynamicTextContent($element),
@@ -568,7 +569,7 @@ final class HtmlCompilation
             $this->formControlMetadataBuilder,
             fn (DOMElement $element): array => $this->styleResolver->structuralPresentationDeclarations($element),
             fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
-            fn (string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
+            $this,
             function (string $identity, array $definition): void {
                 $this->generatedBlocks()->register($identity, $definition);
             },
@@ -584,7 +585,7 @@ final class HtmlCompilation
         $this->runtimeResourceConverter = new RuntimeResourceElementConverter(
             $this->session,
             fn (DOMElement $element): array => $this->htmlPreservationBlock($element),
-            fn (string $name, array $attributes, array $innerBlocks, DOMElement $element): array => $this->createBlock($name, $attributes, $innerBlocks, $element)
+            $this
         );
         $this->formRuntimeIslandRecorder = new FormRuntimeIslandRecorder(
             $this->formControlMetadataBuilder,
@@ -603,7 +604,7 @@ final class HtmlCompilation
             fn (DOMElement $element): bool => $this->runtimeIslands->isRuntimeDomTarget($element),
             fn (DOMElement $element): array => $this->htmlPreservationBlock($element),
             fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
-            fn (string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
+            $this,
             function (string $text): void {
                 $this->transformationEvidence()->recordFormControlEcho($text);
             }
@@ -616,7 +617,7 @@ final class HtmlCompilation
             fn (DOMElement $element): array => $this->eventMetadata($element),
             fn (DOMElement $element): bool => $this->runtimeIslands->isRuntimeDomTarget($element),
             fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
-            fn (string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement)
+            $this
         );
         $this->formCompositionPlanner = new FormCompositionPlanner(
             $this->session,
@@ -624,7 +625,7 @@ final class HtmlCompilation
                 return $this->convertChildren($element, $fallbacks, $captureUnsupported);
             },
             fn (DOMElement $element): array => $this->styleResolver->presentationAttributes($element),
-            fn (string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
+            $this,
             fn (DOMElement $container, DOMElement $element): bool => $this->elementContains($container, $element)
         );
         $this->formRuntimeRequirementAnalyzer = new FormRuntimeRequirementAnalyzer(
@@ -672,7 +673,7 @@ final class HtmlCompilation
                 return $this->convertChildren($element, $fallbacks, $captureUnsupported);
             },
             $this->styleResolver,
-            fn (string $name, array $attributes, array $innerBlocks, DOMElement $element): array => $this->createBlock($name, $attributes, $innerBlocks, $element),
+            $this,
             fn (DOMElement $element): ?array => $this->buttonLinkDispatcher->convertButton($element)
         ));
         $detailsConverter = new DetailsElementConverter(new DetailsElementContext(
@@ -718,7 +719,7 @@ final class HtmlCompilation
             },
             fn (string $html): bool => '' !== trim($this->runtime->stripAllTags($html)),
             $this->styleResolver,
-            fn (string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement)
+            $this
         ));
         $quoteConverter = new QuoteElementConverter(new QuoteElementContext(
             function (DOMElement $element, array &$fallbacks): ?array {
@@ -744,7 +745,7 @@ final class HtmlCompilation
             fn (DOMElement $element): bool => $this->isCssOwnedGridElement($element),
             fn (DOMElement $element): array => $this->cssOwnedGridAttributes($element),
             $this->styleResolver,
-            fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement)
+            $this
         ));
         $descriptionListConverter = new DescriptionListElementConverter(new DescriptionListElementContext(
             $this->sourceElementClassifier,
@@ -757,7 +758,7 @@ final class HtmlCompilation
             function (DOMElement $element, array &$fallbacks, bool $captureUnsupported): array {
                 return $this->convertChildren($element, $fallbacks, $captureUnsupported);
             },
-            fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
+            $this,
             fn (DOMElement $element): string => $this->richTextContentWithMaterializedInlineStyles($element),
             fn (string $html): bool => '' !== trim($this->runtime->stripAllTags($html))
         ));
@@ -799,7 +800,7 @@ final class HtmlCompilation
             proofBackedWrapperCoalescing: fn (DOMElement $element, array &$fallbacks): ?array => $this->proofBackedWrapperCoalescing($element, $fallbacks),
             shouldPreserveEmptyVisualElement: fn (DOMElement $element): bool => $this->shouldPreserveEmptyVisualElement($element),
             emptyVisualElementAttributes: fn (DOMElement $element): array => $this->emptyVisualElementAttributes($element),
-            createBlock: fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
+            createBlock: $this,
             patternContext: $this->patternContext,
             shouldDeferNavigationPatternToChildren: fn (DOMElement $element): bool => $this->shouldDeferNavigationPatternToChildren($element),
             rememberAccordionDisclosureRoot: fn (array $block, DOMElement $element): array => $this->rememberAccordionDisclosureRoot($block, $element),
@@ -916,8 +917,7 @@ final class HtmlCompilation
         return new SvgMaterializationContext(
             $this->session,
             $this->sourceElementClassifier,
-            fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null, ?DOMElement $logicalSourceElement = null): array
-                => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement, $logicalSourceElement),
+            $this,
             fn (DOMElement $element): ?string => $this->reusableComponentFingerprintFor($element),
             fn (DOMElement $element): string => $this->safeFallbackHtml($element),
             fn (DOMElement $element): string => $this->sanitizeInlineSvgMarkup($element)
@@ -930,7 +930,7 @@ final class HtmlCompilation
         return new SearchBlockConversionContext(
             $this->session,
             $this->styleResolver,
-            fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
+            $this,
             fn (string $html): string => $this->svgMaterializer->restoreSvgCasing($html),
             fn (DOMElement $element): bool => $this->runtimeIslands->isRuntimeDomTarget($element),
             fn (DOMElement $element): array => $this->htmlPreservationBlock($element)
@@ -972,7 +972,7 @@ final class HtmlCompilation
                 return $this->convertLinkWrapperGroup($element, $fallbacks);
             },
             $this->styleResolver,
-            fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
+            $this,
             fn (string $href): string => $this->safeLinkUrl($href)
         );
     }
@@ -1006,7 +1006,7 @@ final class HtmlCompilation
             fn (DOMElement $element): array => $this->htmlPreservationBlock($element),
             $this->styleResolver,
             fn (DOMElement $element): array => $this->tableAttributes($element),
-            fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement)
+            $this
         );
     }
 
@@ -1032,7 +1032,7 @@ final class HtmlCompilation
     {
         return new RichTextElementContext(
             $this->styleResolver,
-            fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
+            $this,
             fn (DOMElement $element, array $excludedTags): string => $this->richTextContentWithMaterializedInlineStyles($element, $excludedTags),
             fn (string $content): string => $this->headingRichTextContent($content),
             fn (DOMElement $element, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($element, $content),
@@ -1061,7 +1061,7 @@ final class HtmlCompilation
         return new TextLeafElementContext(
             $this->sourceElementClassifier,
             $this->styleResolver,
-            fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => $this->createBlock($name, $attributes, $innerBlocks, $sourceElement),
+            $this,
             fn (DOMElement $element, array $excludedTags): string => $this->richTextContentWithMaterializedInlineStyles($element, $excludedTags),
             $this->runtime,
             fn (DOMElement $pre, DOMElement $code): array => $this->codePresentationAttributes($pre, $code),
@@ -2541,7 +2541,7 @@ final class HtmlCompilation
     {
         return new PatternContext(
             fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->styleResolver->presentationAttributes($sourceElement, $excludedGeometryProperties),
-            fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null, ?DOMElement $logicalSourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement, $logicalSourceElement),
+            $this,
             new PatternRecursiveConverter(
                 function (DOMElement $sourceElement, bool $captureUnsupported): PatternConversionResult {
                     $fallbacks = array();
@@ -2641,11 +2641,7 @@ final class HtmlCompilation
     {
         return new PatternContext(
             presentationAttributes: fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->styleResolver->presentationAttributes($sourceElement, $excludedGeometryProperties),
-            createBlock: static fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => array(
-                'blockName'   => $name,
-                'attrs'       => $attrs,
-                'innerBlocks' => $innerBlocks,
-            ),
+            createBlock: new ProbeBlockCreator(),
             navigationContext: new NavigationPatternContext(
                 null,
                 fn (DOMElement $item, DOMElement $anchor): string => $this->navigationUnderlineColor($item, $anchor),
@@ -3541,7 +3537,7 @@ final class HtmlCompilation
      * @param array<int, array<string, mixed>> $innerBlocks
      * @return array<string, mixed>
      */
-    private function createBlock(string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null, ?DOMElement $logicalSourceElement = null): array
+    public function createBlock(string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null, ?DOMElement $logicalSourceElement = null): array
     {
         if ( $sourceElement instanceof DOMElement
             && in_array($name, array( 'core/paragraph', 'core/heading', 'core/list-item' ), true)

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Closure;
 use DOMElement;
 
@@ -10,7 +11,6 @@ final class PatternContext
 {
     /**
      * @param Closure(DOMElement, array<int, string>): array<string, mixed> $presentationAttributes
-     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null, DOMElement|null): array<string, mixed> $createBlock
      * @param PatternRecursiveConverter|null $recursiveConverter
      * @param NavigationPatternContext|null $navigationContext
      * @param MediaPatternContext|null $mediaContext
@@ -24,7 +24,7 @@ final class PatternContext
      */
     public function __construct(
         private readonly Closure $presentationAttributes,
-        private readonly Closure $createBlock,
+        private readonly SourceBlockCreator $createBlock,
         private readonly ?PatternRecursiveConverter $recursiveConverter = null,
         private readonly ?NavigationPatternContext $navigationContext = null,
         private readonly ?MediaPatternContext $mediaContext = null,
@@ -54,7 +54,7 @@ final class PatternContext
      */
     public function createBlock(string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null, ?DOMElement $logicalSourceElement = null): array
     {
-        return ($this->createBlock)($name, $attributes, $innerBlocks, $sourceElement, $logicalSourceElement);
+        return $this->createBlock->createBlock($name, $attributes, $innerBlocks, $sourceElement, $logicalSourceElement);
     }
 
     public function recursiveConverter(): ?PatternRecursiveConverter { return $this->recursiveConverter; }

--- a/php-transformer/src/HtmlToBlocks/Patterns/ProbeBlockCreator.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ProbeBlockCreator.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
+use DOMElement;
+
+final class ProbeBlockCreator implements SourceBlockCreator
+{
+    /**
+     * @param array<string, mixed> $attrs
+     * @param array<int, array<string, mixed>> $innerBlocks
+     * @return array<string, mixed>
+     */
+    public function createBlock(string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null, ?DOMElement $logicalSourceElement = null): array
+    {
+        return array(
+            'blockName'   => $name,
+            'attrs'       => $attrs,
+            'innerBlocks' => $innerBlocks,
+        );
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/SourceBlockCreator.php
+++ b/php-transformer/src/HtmlToBlocks/SourceBlockCreator.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+
+use DOMElement;
+
+interface SourceBlockCreator
+{
+    /**
+     * @param array<string, mixed> $attrs
+     * @param array<int, array<string, mixed>> $innerBlocks
+     * @return array<string, mixed>
+     */
+    public function createBlock(string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null, ?DOMElement $logicalSourceElement = null): array;
+}

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationContext.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\AssetMaterializationState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerSession;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\TransformationEvidenceState;
@@ -21,7 +22,6 @@ use DOMElement;
 final class SvgMaterializationContext
 {
     /**
-     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement, ?DOMElement): array<string, mixed> $createBlock
      * @param Closure(DOMElement): ?string                                                         $reusableComponentFingerprintFor
      * @param Closure(DOMElement): string                                                          $safeFallbackHtml
      * @param Closure(DOMElement): string                                                          $sanitizeInlineSvgMarkup
@@ -29,7 +29,7 @@ final class SvgMaterializationContext
     public function __construct(
         private readonly HtmlTransformerSession $session,
         private readonly SourceElementClassifier $sourceElementClassifier,
-        private readonly Closure $createBlock,
+        private readonly SourceBlockCreator $createBlock,
         private readonly Closure $reusableComponentFingerprintFor,
         private readonly Closure $safeFallbackHtml,
         private readonly Closure $sanitizeInlineSvgMarkup
@@ -48,7 +48,7 @@ final class SvgMaterializationContext
         ?DOMElement $sourceElement = null,
         ?DOMElement $logicalSourceElement = null
     ): array {
-        return ($this->createBlock)($name, $attrs, $innerBlocks, $sourceElement, $logicalSourceElement);
+        return $this->createBlock->createBlock($name, $attrs, $innerBlocks, $sourceElement, $logicalSourceElement);
     }
 
     public function isInlineContentElement(string $tagName): bool

--- a/php-transformer/tests/Support/SourceBlockCreatorFixture.php
+++ b/php-transformer/tests/Support/SourceBlockCreatorFixture.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\Tests\Support;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
+use Closure;
+use DOMElement;
+
+final class SourceBlockCreatorFixture implements SourceBlockCreator
+{
+    /** @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, ?DOMElement, ?DOMElement): array<string, mixed> $createBlock */
+    public function __construct(private readonly Closure $createBlock) {}
+
+    /** @return array<string, mixed> */
+    public function createBlock(string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null, ?DOMElement $logicalSourceElement = null): array
+    {
+        return ($this->createBlock)($name, $attrs, $innerBlocks, $sourceElement, $logicalSourceElement);
+    }
+}

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -452,7 +452,7 @@ $registry = new PatternRecognizerRegistry(array(
 ));
 $registryContext = new PatternContext(
     static fn (DOMElement $element): array => array(),
-    static fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => array('blockName' => $name, 'attrs' => $attrs, 'innerBlocks' => $innerBlocks)
+    new \Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture(static fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => array('blockName' => $name, 'attrs' => $attrs, 'innerBlocks' => $innerBlocks))
 );
 $assert($registryElement instanceof DOMElement, 'pattern registry fixture element parses');
 $assert('core/group' === ($registry->firstMatch($registryElement, $registryContext)?->block()['blockName'] ?? null), 'pattern registry returns the first recognizer match');

--- a/php-transformer/tests/unit/authored-form-control-block-converter.php
+++ b/php-transformer/tests/unit/authored-form-control-block-converter.php
@@ -8,6 +8,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormControlMeta
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredInputBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredSelectBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
 
 $assertions = 0;
 $failures = array();
@@ -35,11 +36,11 @@ $converter = new AuthoredFormControlBlockConverter(
     $metadataBuilder,
     static fn (DOMElement $element): array => $element->hasAttribute('data-styled') ? array( 'display' => 'block' ) : array(),
     static fn (DOMElement $element): array => array( 'className' => 'presented' ),
-    static fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => array(
+    new SourceBlockCreatorFixture(static fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => array(
         'blockName' => $name,
         'attrs' => $attrs,
         'innerBlocks' => $innerBlocks,
-    ),
+    )),
     static function (string $identity, array $definition) use (&$registered): void {
         $registered[$identity] = $definition;
     },

--- a/php-transformer/tests/unit/button-element-converter.php
+++ b/php-transformer/tests/unit/button-element-converter.php
@@ -7,6 +7,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceEle
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
 
 $assertions = 0;
 $failures = array();
@@ -41,11 +42,11 @@ $converter = new ButtonElementConverter(new ButtonElementContext(
         return 'image' === $mode ? array( array( 'blockName' => 'core/image' ) ) : array();
     },
     new ElementPresentationResolverFixture(static fn (DOMElement $element): array => array( 'className' => 'carrier' )),
-    static fn (string $name, array $attributes, array $innerBlocks, DOMElement $element): array => array(
+    new SourceBlockCreatorFixture(static fn (string $name, array $attributes, array $innerBlocks, DOMElement $element): array => array(
         'blockName' => $name,
         'attrs' => $attributes,
         'innerBlocks' => $innerBlocks,
-    ),
+    )),
     static function (DOMElement $element) use (&$genericCalls, &$genericBlock): ?array {
         ++$genericCalls;
         return $genericBlock;

--- a/php-transformer/tests/unit/button-link-dispatcher.php
+++ b/php-transformer/tests/unit/button-link-dispatcher.php
@@ -16,6 +16,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceEle
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispatchContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispatcher;
 use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
 
 $assertions = 0;
 $failures   = array();
@@ -53,7 +54,7 @@ $makeDispatcher = static function (array $overrides = array()): ButtonLinkDispat
             return null;
         },
         'presentation'     => static fn (DOMElement $e, array $p, array $g): array => array(),
-        'createBlock'      => static fn (string $n, array $a, array $i, ?DOMElement $s): array => array('blockName' => $n, 'attrs' => $a),
+        'createBlock'      => new SourceBlockCreatorFixture(static fn (string $n, array $a, array $i, ?DOMElement $s): array => array('blockName' => $n, 'attrs' => $a)),
         'attr'             => static fn (DOMElement $e, string $n): string => $e->getAttribute($n),
         'outerHtml'        => static fn (DOMElement $e): string => $e->ownerDocument->saveHTML($e),
         'safeLinkUrl'      => static fn (string $h): string => str_starts_with($h, 'javascript:') ? '' : $h,

--- a/php-transformer/tests/unit/figure-element-converter.php
+++ b/php-transformer/tests/unit/figure-element-converter.php
@@ -6,6 +6,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FigureElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FigureElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
 
 $assertions = 0;
 $failures = array();
@@ -70,12 +71,12 @@ $context = new FigureElementContext(
     },
     static fn (string $html): bool => '' !== trim(strip_tags($html)),
     new ElementPresentationResolverFixture(static fn (DOMElement $element): array => array( 'className' => 'caption' )),
-    static fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => array(
+    new SourceBlockCreatorFixture(static fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => array(
         'blockName' => $name,
         'attrs' => $attributes,
         'innerBlocks' => $innerBlocks,
         'sourceTag' => $sourceElement?->tagName,
-    )
+    ))
 );
 $converter = new FigureElementConverter($context);
 

--- a/php-transformer/tests/unit/flow-container-element-converter.php
+++ b/php-transformer/tests/unit/flow-container-element-converter.php
@@ -9,6 +9,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FlowContainerEl
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\SpacerPattern;
 use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
 
 $assertions = 0;
 $failures = array();
@@ -52,13 +53,13 @@ $operations = array(
     'proofBackedWrapperCoalescing' => $null,
     'shouldPreserveEmptyVisualElement' => static fn (): bool => 'visual-empty' === $state->mode,
     'emptyVisualElementAttributes' => static fn (): array => array(),
-    'createBlock' => static fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => array(
+    'createBlock' => new SourceBlockCreatorFixture(static fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => array(
         'blockName' => $name,
         'attrs' => $attributes,
         'innerBlocks' => $innerBlocks,
         'sourceTag' => $sourceElement?->tagName,
-    ),
-    'patternContext' => new PatternContext($null, $null),
+    )),
+    'patternContext' => new PatternContext($null, new SourceBlockCreatorFixture(static fn (): array => array())),
     'shouldDeferNavigationPatternToChildren' => $false,
     'rememberAccordionDisclosureRoot' => static fn (array $block): array => $block,
     'metadataGridBlock' => $null,

--- a/php-transformer/tests/unit/form-composition-planner.php
+++ b/php-transformer/tests/unit/form-composition-planner.php
@@ -6,6 +6,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormCompositionPlanner;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerSession;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
 
 $assertions = 0;
 $failures = array();
@@ -43,12 +44,12 @@ $planner = new FormCompositionPlanner(
             : $children;
     },
     static fn (DOMElement $element): array => array( 'className' => 'presented-' . strtolower($element->tagName) ),
-    static fn (string $name, array $attrs, array $innerBlocks, ?DOMElement $sourceElement): array => array(
+    new SourceBlockCreatorFixture(static fn (string $name, array $attrs, array $innerBlocks, ?DOMElement $sourceElement): array => array(
         'blockName' => $name,
         'attrs' => $attrs,
         'innerBlocks' => $innerBlocks,
         'sourceTag' => $sourceElement?->tagName,
-    ),
+    )),
     static function (DOMElement $container, DOMElement $element): bool {
         for ( $node = $element; $node instanceof DOMElement; $node = $node->parentNode ) {
             if ( $node === $container ) {

--- a/php-transformer/tests/unit/inline-content-element-converter.php
+++ b/php-transformer/tests/unit/inline-content-element-converter.php
@@ -8,6 +8,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\InlineContentEl
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\InlineContentElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolver;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
 
 $assertions = 0;
 $failures = array();
@@ -40,12 +41,12 @@ $context = new InlineContentElementContext(
     static fn (DOMElement $element): bool => false,
     static fn (string $content): bool => false,
     static fn (DOMElement $element, array &$fallbacks, bool $captureUnsupported): array => array(),
-    static fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => array(
+    new SourceBlockCreatorFixture(static fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => array(
         'blockName' => $name,
         'attrs' => $attributes,
         'innerBlocks' => $innerBlocks,
         'sourceTag' => $sourceElement?->tagName,
-    ),
+    )),
     static fn (DOMElement $element): string => '',
     static fn (DOMElement $element): array => array(),
     static fn (DOMElement $element): ?string => null,

--- a/php-transformer/tests/unit/list-element-converters.php
+++ b/php-transformer/tests/unit/list-element-converters.php
@@ -9,6 +9,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\DescriptionList
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ListElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ListElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
 
 $assertions = 0;
 $failures = array();
@@ -28,12 +29,12 @@ $elementFrom = static function (string $html): DOMElement {
     }
     throw new RuntimeException('No element parsed');
 };
-$createBlock = static fn (string $name, array $attrs, array $innerBlocks, ?DOMElement $source): array => array(
+$createBlock = new SourceBlockCreatorFixture(static fn (string $name, array $attrs, array $innerBlocks, ?DOMElement $source): array => array(
     'blockName' => $name,
     'attrs' => $attrs,
     'innerBlocks' => $innerBlocks,
     'sourceTag' => $source?->tagName,
-);
+));
 
 $state = (object) array( 'mode' => 'native' );
 $listContext = new ListElementContext(

--- a/php-transformer/tests/unit/pattern-recognizer-registry.php
+++ b/php-transformer/tests/unit/pattern-recognizer-registry.php
@@ -11,6 +11,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\MathPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\MarkupPatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PlaceholderMediaPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\SpacerPattern;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
 $failures = 0;
@@ -31,11 +32,11 @@ if ( ! $element instanceof DOMElement ) {
 
 $context = new PatternContext(
     static fn (DOMElement $source): array => array(),
-    static fn (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null): array => array( 'blockName' => $name )
+    new SourceBlockCreatorFixture(static fn (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null): array => array( 'blockName' => $name ))
 );
 $semanticContext = new PatternContext(
     static fn (DOMElement $source, array $excluded = array()): array => array( 'excluded' => $excluded ),
-    static fn (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null, ?DOMElement $logicalSource = null): array => array( 'blockName' => $name, 'logicalTag' => $logicalSource?->tagName )
+    new SourceBlockCreatorFixture(static fn (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null, ?DOMElement $logicalSource = null): array => array( 'blockName' => $name, 'logicalTag' => $logicalSource?->tagName ))
 );
 $assertSame(array( 'excluded' => array( 'width' ) ), $semanticContext->presentationAttributes($element, array( 'width' )), 'Pattern context forwards presentation exclusions through its semantic API.');
 $assertSame(array( 'blockName' => 'core/group', 'logicalTag' => 'div' ), $semanticContext->createBlock('core/group', logicalSourceElement: $element), 'Pattern context forwards logical block provenance through its semantic API.');
@@ -96,7 +97,7 @@ $innerHtml = static function (DOMElement $source): string {
 
     return trim($html);
 };
-$createBlock = static fn (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null): array => array( 'blockName' => $name, 'attrs' => $attrs, 'innerBlocks' => $children );
+$createBlock = new SourceBlockCreatorFixture(static fn (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null): array => array( 'blockName' => $name, 'attrs' => $attrs, 'innerBlocks' => $children ));
 $directContext = new PatternContext(
     static fn (DOMElement $source, array $excluded = array()): array => array(),
     $createBlock,
@@ -138,10 +139,10 @@ $missingPlaceholderMarkup = new PatternContext(
         $placeholderState[] = 'presentation';
         return array();
     },
-    static function (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null) use ($placeholderState): array {
+    new SourceBlockCreatorFixture(static function (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null) use ($placeholderState): array {
         $placeholderState[] = 'create-block';
         return array();
-    }
+    })
 );
 $assertSame(null, ( new PlaceholderMediaPattern() )->recognize($elementFromHtml('<div class="placeholder media" style="aspect-ratio: 16 / 9">Label</div>'), $missingPlaceholderMarkup), 'Placeholder media declines without its atomic markup capability.');
 $assertSame(array(), $placeholderState->getArrayCopy(), 'Placeholder media validates missing dependencies before invoking stateful context callbacks.');

--- a/php-transformer/tests/unit/pattern-registry-staged-dispatch.php
+++ b/php-transformer/tests/unit/pattern-registry-staged-dispatch.php
@@ -12,6 +12,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternConversi
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerRegistry;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecursiveConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\SpacerPattern;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
 
 $assertions = 0;
 $assert = static function (bool $condition, string $message) use (&$assertions): void {
@@ -27,7 +28,7 @@ if ( ! $spacerElement instanceof DOMElement ) {
 }
 $spacerContext = new PatternContext(
     static fn (DOMElement $source, array $excluded = array()): array => array( 'style' => array( 'dimensions' => array( 'minHeight' => '1rem' ) ) ),
-    static fn (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null): array => array( 'blockName' => $name, 'attrs' => $attrs, 'innerBlocks' => $children )
+    new SourceBlockCreatorFixture(static fn (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null): array => array( 'blockName' => $name, 'attrs' => $attrs, 'innerBlocks' => $children ))
 );
 $spacerResult = (new PatternRecognizerRegistry(array( new SpacerPattern() )))->firstMatch($spacerElement, $spacerContext, array( SpacerPattern::class ));
 $assert('core/spacer' === ($spacerResult?->block()['blockName'] ?? null), 'Spacer is dispatched directly by class through the pattern registry.');
@@ -133,7 +134,7 @@ $innerHtml = static function (DOMElement $element): string {
     }
     return $html;
 };
-$createBlock = static fn (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null): array => array( 'blockName' => $name, 'attrs' => $attrs, 'innerBlocks' => $children );
+$createBlock = new SourceBlockCreatorFixture(static fn (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null): array => array( 'blockName' => $name, 'attrs' => $attrs, 'innerBlocks' => $children ));
 $recursiveCalls = 0;
 $navigationConverter = new PatternRecursiveConverter(
     static fn (DOMElement $source, bool $captureUnsupported): PatternConversionResult => new PatternConversionResult(array()),

--- a/php-transformer/tests/unit/readable-form-block-builder.php
+++ b/php-transformer/tests/unit/readable-form-block-builder.php
@@ -10,6 +10,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ReadableFormBlo
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ReadableFormControlBlockConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredInputBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
 
 $assertions = 0;
 $failures = array();
@@ -30,11 +31,11 @@ $formFrom = static function (string $html): DOMElement {
     throw new RuntimeException('No form parsed');
 };
 
-$createBlock = static fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => array(
+$createBlock = new SourceBlockCreatorFixture(static fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => array(
     'blockName' => $name,
     'attrs' => $attrs,
     'innerBlocks' => $innerBlocks,
-);
+));
 $presentationAttributes = static fn (DOMElement $element): array => array( 'className' => 'presented-' . strtolower($element->tagName) );
 $eventMetadata = static fn (DOMElement $element): array => $element->hasAttribute('data-event') ? array( 'submit' => true ) : array();
 $isRuntimeDomTarget = static fn (DOMElement $element): bool => $element->hasAttribute('data-runtime');

--- a/php-transformer/tests/unit/readable-form-control-block-converter.php
+++ b/php-transformer/tests/unit/readable-form-control-block-converter.php
@@ -9,6 +9,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\FormRuntimeIsla
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ReadableFormControlBlockConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\AuthoredInputBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
 
 $assertions = 0;
 $failures = array();
@@ -29,11 +30,11 @@ $elementFrom = static function (string $html, string $tagName): DOMElement {
     throw new RuntimeException('No ' . $tagName . ' parsed');
 };
 
-$createBlock = static fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => array(
+$createBlock = new SourceBlockCreatorFixture(static fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => array(
     'blockName' => $name,
     'attrs' => $attrs,
     'innerBlocks' => $innerBlocks,
-);
+));
 $presentationAttributes = static fn (DOMElement $element): array => array( 'className' => 'presented' );
 $echoes = array();
 $recorded = array();

--- a/php-transformer/tests/unit/rich-text-element-converter.php
+++ b/php-transformer/tests/unit/rich-text-element-converter.php
@@ -16,6 +16,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RichTextElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RichTextElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
 $assertions = 0;
@@ -30,11 +31,11 @@ $assert     = static function (bool $condition, string $label, string $detail = 
 $makeConverter = static function (array $overrides = array()): RichTextElementConverter {
     $defaults = array(
         'presentationAttributes'            => static fn (DOMElement $e, array $p, array $g): array => array(),
-        'createBlock'                       => static fn (string $n, array $a, array $i, ?DOMElement $s): array => array(
+        'createBlock'                       => new SourceBlockCreatorFixture(static fn (string $n, array $a, array $i, ?DOMElement $s): array => array(
             'blockName'   => $n,
             'attrs'       => $a,
             'innerBlocks' => $i,
-        ),
+        )),
         'richTextContent'                   => static fn (DOMElement $e, array $x): string => (string) $e->textContent,
         'headingRichTextContent'            => static fn (string $c): string => $c,
         'richTextWithMaterializedSvgImages' => static fn (DOMElement $e, string $c): ?string => null,

--- a/php-transformer/tests/unit/runtime-resource-element-converter.php
+++ b/php-transformer/tests/unit/runtime-resource-element-converter.php
@@ -7,6 +7,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RuntimeResource
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerSession;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\RuntimeSelectorState;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
 
 $assertions = 0;
 $failures = array();
@@ -47,11 +48,11 @@ $converter = new RuntimeResourceElementConverter(
         ++$preserved;
         return array( 'blockName' => 'core/html', 'attrs' => array( 'content' => 'preserved:' . $element->tagName ) );
     },
-    static fn (string $name, array $attributes, array $innerBlocks, DOMElement $element): array => array(
+    new SourceBlockCreatorFixture(static fn (string $name, array $attributes, array $innerBlocks, DOMElement $element): array => array(
         'blockName' => $name,
         'attrs' => $attributes,
         'innerBlocks' => $innerBlocks,
-    )
+    ))
 );
 $fallbacks = array();
 

--- a/php-transformer/tests/unit/svg-element-converter.php
+++ b/php-transformer/tests/unit/svg-element-converter.php
@@ -8,6 +8,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\SvgElementConte
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\SvgElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\SvgElementMaterializer;
 use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
 
 $assertions = 0;
 $failures = array();
@@ -38,12 +39,12 @@ $context = new SvgElementContext(
     static fn (string $html): bool => 'runtime-safe' === $state->mode,
     static fn (DOMElement $element): bool => str_starts_with($state->mode, 'drawable-'),
     new ElementPresentationResolverFixture(static fn (DOMElement $element): array => array( 'className' => 'visual-svg' )),
-    static fn (string $name, array $attrs, array $innerBlocks, ?DOMElement $source): array => array(
+    new SourceBlockCreatorFixture(static fn (string $name, array $attrs, array $innerBlocks, ?DOMElement $source): array => array(
         'blockName' => $name,
         'attrs' => $attrs,
         'innerBlocks' => $innerBlocks,
         'sourceTag' => $source?->tagName,
-    ),
+    )),
     static function (DOMElement $element, array &$fallbacks) use (&$fallbackCaptures): void {
         ++$fallbackCaptures;
         $fallbacks[] = array( 'diagnostic_code' => 'html_inline_svg_fallback' );

--- a/php-transformer/tests/unit/table-element-converter.php
+++ b/php-transformer/tests/unit/table-element-converter.php
@@ -15,6 +15,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TableElementCon
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TableElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\TableClassificationPolicy;
 use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
 
 $assertions = 0;
 $failures   = array();
@@ -47,7 +48,7 @@ $makeConverter = static function (array $overrides = array()): TableElementConve
         'preserve'    => static fn (DOMElement $e): array => array('blockName' => 'core/html'),
         'presentation' => static fn (DOMElement $e, array $p, array $g): array => array('className' => 'pres'),
         'tableAttrs'  => static fn (DOMElement $e): array => array('hasFixedLayout' => true),
-        'createBlock' => static fn (string $n, array $a, array $i, ?DOMElement $s): array => array('blockName' => $n, 'attrs' => $a),
+        'createBlock' => new SourceBlockCreatorFixture(static fn (string $n, array $a, array $i, ?DOMElement $s): array => array('blockName' => $n, 'attrs' => $a)),
     );
     $c = array_merge($defaults, $overrides);
 

--- a/php-transformer/tests/unit/text-leaf-element-converter.php
+++ b/php-transformer/tests/unit/text-leaf-element-converter.php
@@ -16,6 +16,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceEle
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TextLeafElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TextLeafElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
 $assertions = 0;
@@ -33,11 +34,11 @@ $makeConverter = static function (array $overrides = array()): TextLeafElementCo
         'presentationAttributes'        => static fn (DOMElement $e, array $p, array $g): array => array(),
         'innerHtml'                     => static fn (DOMElement $e): string => (string) $e->textContent,
         'innerHtmlPreservingWhitespace' => static fn (DOMElement $e): string => (string) $e->textContent,
-        'createBlock'                   => static fn (string $n, array $a, array $i, ?DOMElement $s): array => array(
+        'createBlock'                   => new SourceBlockCreatorFixture(static fn (string $n, array $a, array $i, ?DOMElement $s): array => array(
             'blockName'   => $n,
             'attrs'       => $a,
             'innerBlocks' => $i,
-        ),
+        )),
         'richTextContent'               => static fn (DOMElement $e, array $x): string => (string) $e->textContent,
         'firstChildElement'             => static function (DOMElement $e, string $tag): ?DOMElement {
             foreach ($e->childNodes as $child) {


### PR DESCRIPTION
## Summary
- define a narrow `SourceBlockCreator` contract implemented by `HtmlCompilation`
- replace 19 stored block-creation closures and 19 composition-root forwarding adapters with the typed collaborator
- preserve side-effect-free pattern probes through an explicit `ProbeBlockCreator` implementation
- use one reusable test fixture for focused constructor-level behavior controls

## Verification
- `composer test`
- 292 PHP transformer parity fixtures
- 385 serialized-block fixture hashes identical to `origin/trunk` (`d3f68004`), with 0 exceptions
- namespace resolution: 249 class-likes, 0 unresolved references
- `git diff --check`
- Homeboy architecture audit: one informational pre-existing `god_file` heuristic surfaced because `tests/contract/run.php` now exercises the typed constructor; no behavioral or ownership defect was identified

## AI assistance
OpenAI GPT-5.6 Sol was used through OpenCode to inventory the callback seam, implement and review the typed collaborator migration, and run verification. The resulting diff and evidence were reviewed by the operator.