### PR TITLE
Preserve editable responsive document structure

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -256,6 +256,7 @@ final class ArtifactCompiler
             'summary' => array('file_count' => count($normalized['files']), 'bytes' => $normalized['bytes'], 'rejected_count' => $normalized['rejected_count']),
             'compiler_options' => $this->receiptCompilerOptions(),
             'output_schema' => TransformerResult::SCHEMA,
+            'layout_geometry_proof' => $this->pageLayoutGeometryProof($partition['layout_geometry_proof'], $pageArtifact['files']),
         );
         $plan['digest'] = $this->planDigest($this->pagePlanDigestInput($plan));
         return $plan;
@@ -330,6 +331,11 @@ final class ArtifactCompiler
             ? array_merge($sharedPlan['artifact'], array('files' => $this->sharedReductionFiles($sharedPlan, $payloadReader)))
             : $this->materializePlanArtifact($sharedPlan['artifact'], $payloadReader);
         $pageArtifact = $this->materializePlanArtifact($pagePlan['artifact'], $payloadReader);
+        $pageLayoutGeometryProof = is_array($pagePlan['layout_geometry_proof'] ?? null) ? $pagePlan['layout_geometry_proof'] : array();
+        foreach ($pageArtifact['files'] as &$pageFile) {
+            if ('html' === ($pageFile['kind'] ?? null)) $pageFile['layout_geometry_proof'] = $pageLayoutGeometryProof;
+        }
+        unset($pageFile);
         $files = self::sortedByPath(array_merge($sharedArtifact['files'], $pageArtifact['files']));
 
         $entryPath = (string) ($sharedPlan['analysis']['entry_path'] ?? '');
@@ -995,7 +1001,7 @@ final class ArtifactCompiler
      * Partition an envelope before normalization so preparing one stage never
      * parses, expands, or transforms payloads owned by another stage.
      *
-     * @return array{shared:array<int,array<string,mixed>>,pages:array<string,array<int,array<string,mixed>>>,entrypoints:array<int,string>,limits:array<string,int>,runtime_declarations:array<int,array<string,mixed>>,schema:string,input_keys:array<int,string>,identity:array<string,string>,source_paths:array<int,string>}
+     * @return array{shared:array<int,array<string,mixed>>,pages:array<string,array<int,array<string,mixed>>>,entrypoints:array<int,string>,limits:array<string,int>,runtime_declarations:array<int,array<string,mixed>>,layout_geometry_proof:array<string,mixed>,schema:string,input_keys:array<int,string>,identity:array<string,string>,source_paths:array<int,string>}
      */
     private function stagePartition(array $artifact, string $scope, string $pageId = ''): array
     {
@@ -1041,6 +1047,7 @@ final class ArtifactCompiler
             'entrypoints' => $normalized['entrypoints'],
             'limits' => $normalized['limits'],
             'runtime_declarations' => $normalized['runtime_declarations'],
+            'layout_geometry_proof' => $normalized['layout_geometry_proof'],
             'schema' => is_string($artifact['schema'] ?? null) ? $artifact['schema'] : '',
             'input_keys' => array_values(array_filter(array_keys($artifact), 'is_string')),
             'identity' => $identity,
@@ -1316,7 +1323,7 @@ final class ArtifactCompiler
     }
 
     /**
-     * @param array{entrypoints:array<int,string>,limits:array<string,int>,runtime_declarations:array<int,array<string,mixed>>,schema:string,input_keys:array<int,string>} $partition
+     * @param array{entrypoints:array<int,string>,limits:array<string,int>,runtime_declarations:array<int,array<string,mixed>>,layout_geometry_proof:array<string,mixed>,schema:string,input_keys:array<int,string>} $partition
      * @param array<int,array<string,mixed>> $files
      * @return array<string,mixed>
      */
@@ -1336,6 +1343,20 @@ final class ArtifactCompiler
         }
         foreach (is_array($partition['identity'] ?? null) ? $partition['identity'] : array() as $key => $value) $artifact[$key] = $value;
         return $artifact;
+    }
+
+    /** @param array<string,mixed> $proof @param array<int,array<string,mixed>> $files @return array<string,mixed> */
+    private function pageLayoutGeometryProof(array $proof, array $files): array
+    {
+        $paths = array_fill_keys(array_map(
+            static fn(array $file): string => (string) ($file['path'] ?? ''),
+            array_filter($files, static fn(array $file): bool => 'html' === ($file['kind'] ?? null))
+        ), true);
+        $reductions = array_values(array_filter(
+            is_array($proof['reductions'] ?? null) ? $proof['reductions'] : array(),
+            static fn(array $reduction): bool => isset($paths[(string) ($reduction['source_path'] ?? '')])
+        ));
+        return array() === $reductions ? array() : array('schema' => LayoutGeometryProof::SCHEMA, 'reductions' => $reductions);
     }
 
     /** @param array<string,mixed> $artifact */
@@ -1421,6 +1442,7 @@ final class ArtifactCompiler
             $plan['shared_digest'] = $sharedDigest;
             $plan['page_id'] = $pageId;
             $plan['output_schema'] = TransformerResult::SCHEMA;
+            $plan['layout_geometry_proof'] = $this->pageLayoutGeometryProof($partition['layout_geometry_proof'], $planArtifact['files']);
         }
         foreach ($plan['artifact']['files'] as &$file) {
             if (!isset($references[$file['path']])) continue;
@@ -1590,6 +1612,7 @@ final class ArtifactCompiler
     private function pagePlanDigestInput(array $pagePlan): array
     {
         $input = array('shared_digest' => $pagePlan['shared_digest'], 'page_id' => $pagePlan['page_id'], 'artifact' => $pagePlan['artifact']);
+        if (array_key_exists('layout_geometry_proof', $pagePlan)) $input['layout_geometry_proof'] = $pagePlan['layout_geometry_proof'];
         if (isset($pagePlan['compiled_documents'])) {
             $input['receipt_schema'] = $pagePlan['receipt_schema'] ?? null;
             $input['compiled_documents'] = $pagePlan['compiled_documents'];

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -624,8 +624,14 @@ final class ArtifactCompiler
         $inlineShellCompilation = is_array($reduction['inline_shell_compilation'] ?? null)
             ? $reduction['inline_shell_compilation']
             : $this->compileSharedInlineShells($normalized['files'], $entryPath, $companionPluginPayloadBuilder->blockNamespace($artifact));
-        $authorStylesheetProjections = $entryBlocks['author_stylesheet_projections'];
-        $runtimeScriptProjections = $entryBlocks['runtime_script_projections'];
+        $authorStylesheetProjections = array_merge(
+            $entryBlocks['author_stylesheet_projections'],
+            $inlineShellCompilation['author_stylesheet_projections'] ?? array()
+        );
+        $runtimeScriptProjections = array_merge(
+            $entryBlocks['runtime_script_projections'],
+            $inlineShellCompilation['runtime_script_projections'] ?? array()
+        );
         $allDiagnostics = $this->entryTransformDiagnostics($entryBlocks['diagnostics'], $entryPath);
         $allFallbacks = $entryBlocks['fallbacks'];
         $allGeneratedBlocks = $entryBlocks['generated_blocks'];
@@ -977,7 +983,7 @@ final class ArtifactCompiler
             'block_types' => $this->dedupeRows($blockTypes),
             'entry_blocks' => $entryBlocks,
             'compiled_documents' => array_filter($compiledDocuments, fn(string $path): bool => $path !== ($sharedPlan['analysis']['entry_path'] ?? ''), ARRAY_FILTER_USE_KEY),
-            'inline_shell_compilation' => $sharedReduction['inline_shell_compilation'] ?? array('artifacts' => array(), 'assets' => array()),
+            'inline_shell_compilation' => $sharedReduction['inline_shell_compilation'] ?? array('artifacts' => array(), 'assets' => array(), 'author_stylesheet_projections' => array(), 'runtime_script_projections' => array()),
             'captured_dialogs' => $sharedPlan['analysis']['captured_dialogs'] ?? array('diagnostics' => array(), 'projected_count' => 0),
         );
     }
@@ -3439,7 +3445,7 @@ final class ArtifactCompiler
      * support classes and CSS are canonical rather than page-seeded.
      *
      * @param array<int,array<string,mixed>> $files
-     * @return array{artifacts:array<int,array<string,mixed>>,assets:array<int,array<string,mixed>>}
+     * @return array{artifacts:array<int,array<string,mixed>>,assets:array<int,array<string,mixed>>,author_stylesheet_projections:array<int,array<string,mixed>>,runtime_script_projections:array<int,array<string,mixed>>}
      */
     private function compileSharedInlineShells(array $files, string $entryPath, string $generatedBlockNamespace): array
     {
@@ -3468,10 +3474,12 @@ final class ArtifactCompiler
             $walk($body);
             $documents[(string) $file['path']] = array('content' => (string) $file['content'], 'rows' => $rows);
         }
-        if (count($documents) < 2) return array('artifacts' => array(), 'assets' => array());
+        if (count($documents) < 2) return array('artifacts' => array(), 'assets' => array(), 'author_stylesheet_projections' => array(), 'runtime_script_projections' => array());
 
         $artifacts = array();
         $assets = array();
+        $authorStylesheetProjections = array();
+        $runtimeScriptProjections = array();
         foreach (array('header', 'footer') as $area) {
             $variantCount = null; $canonicalMarkups = array();
             $sourcePath = isset($documents[$entryPath]) ? $entryPath : (string) array_key_first($documents);
@@ -3506,9 +3514,16 @@ final class ArtifactCompiler
                     $asset['compilation'] = array('scope' => 'shared');
                     $assets[] = $asset;
                 }
+                $authorStylesheetProjections = array_merge($authorStylesheetProjections, $compiled['author_stylesheet_projections']);
+                $runtimeScriptProjections = array_merge($runtimeScriptProjections, $compiled['runtime_script_projections']);
             }
         }
-        return array('artifacts' => $artifacts, 'assets' => $assets);
+        return array(
+            'artifacts' => $artifacts,
+            'assets' => $assets,
+            'author_stylesheet_projections' => $authorStylesheetProjections,
+            'runtime_script_projections' => $runtimeScriptProjections,
+        );
     }
 
     /** @param array<string,mixed> $partition @param array<string,mixed> $artifact */

--- a/php-transformer/src/HtmlToBlocks/Elements/ListElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/ListElementContext.php
@@ -89,9 +89,9 @@ final class ListElementContext
     }
 
     /** @return array<string, mixed> */
-    public function presentationAttributes(DOMElement $element): array
+    public function presentationAttributes(DOMElement $element, array $excludedGeometryProperties = array(), array $forcedGeometryProperties = array()): array
     {
-        return $this->presentationResolver->presentationAttributes($element);
+        return $this->presentationResolver->presentationAttributes($element, $excludedGeometryProperties, $forcedGeometryProperties);
     }
 
     /** @param array<string, mixed> $attributes @param array<int, array<string, mixed>> $innerBlocks @return array<string, mixed> */

--- a/php-transformer/src/HtmlToBlocks/Elements/ListElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/ListElementConverter.php
@@ -50,7 +50,7 @@ final class ListElementConverter implements ElementConverter
 
         $attributes = $this->context->isCssOwnedGridElement($element)
             ? $this->context->cssOwnedGridAttributes($element)
-            : $this->context->presentationAttributes($element);
+            : $this->context->presentationAttributes($element, array(), array( 'text-align' ));
 
         return ConversionOutcome::handled($this->context->createBlock(
             'core/list',

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -9912,7 +9912,7 @@ final class HtmlCompilation implements SourceBlockCreator
         $prefix = $selector . ' > ';
         foreach ( $this->layoutGeometry()->proofReductions() as $proof ) {
             $wrapperSelector = is_array($proof) ? (string) ($proof['wrapper_selector'] ?? '') : '';
-            if ( $selector === $wrapperSelector || str_starts_with($wrapperSelector, $prefix) ) {
+            if ( $selector === $wrapperSelector || str_starts_with($wrapperSelector, $prefix) || str_starts_with($selector, $wrapperSelector . ' > ') ) {
                 return true;
             }
         }

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -9908,9 +9908,11 @@ final class HtmlCompilation implements SourceBlockCreator
 
     private function hasLayoutGeometryProofInSubtree(DOMElement $element): bool
     {
-        $prefix = $this->elementSelector($element) . ' > ';
+        $selector = $this->elementSelector($element);
+        $prefix = $selector . ' > ';
         foreach ( $this->layoutGeometry()->proofReductions() as $proof ) {
-            if ( is_array($proof) && str_starts_with((string) ($proof['wrapper_selector'] ?? ''), $prefix) ) {
+            $wrapperSelector = is_array($proof) ? (string) ($proof['wrapper_selector'] ?? '') : '';
+            if ( $selector === $wrapperSelector || str_starts_with($wrapperSelector, $prefix) ) {
                 return true;
             }
         }

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -3329,7 +3329,8 @@ final class HtmlCompilation implements SourceBlockCreator
     private function layoutShellBlockForElements(array $elements, array $innerBlocks, DOMElement $sourceElement): array
     {
         $wrappers = array_map(function (DOMElement $element): array {
-            $tagName = strtolower($element->tagName);
+            $sourceTagName = strtolower($element->tagName);
+            $tagName = str_contains($sourceTagName, '-') ? 'div' : $sourceTagName;
             $attributes = $this->htmlAttributes($element);
             $opening = '<' . $tagName;
             foreach ( $attributes as $name => $value ) {
@@ -4080,9 +4081,13 @@ final class HtmlCompilation implements SourceBlockCreator
     }
 
     /** @return array<string, mixed> */
-    private function cssOwnedGroupAttributes(DOMElement $element): array
+    private function cssOwnedGroupAttributes(DOMElement $element, bool $carryOwnTextAlignment = false): array
     {
-        $attrs = $this->styleResolver->presentationAttributes($element);
+        $attrs = $this->styleResolver->presentationAttributes(
+            $element,
+            array(),
+            $carryOwnTextAlignment ? array( 'text-align' ) : array()
+        );
         $layout = $attrs['layout'] ?? null;
         if ( is_array($layout) && 'grid' === (string) ($layout['type'] ?? '') && '' !== (string) ($layout['minimumColumnWidth'] ?? '') ) {
             // The source track list is exactly expressible as native grid
@@ -8738,7 +8743,10 @@ final class HtmlCompilation implements SourceBlockCreator
 
         return $this->createBlock(
             'core/group',
-            array_merge($this->cssOwnedGroupAttributes($list), array( 'tagName' => strtolower($list->tagName) )),
+            // This list is already materializing as a Group, so carrying its own
+            // alignment cannot introduce the extra topology avoided by the
+            // generic presentation resolver's text-align gate.
+            array_merge($this->cssOwnedGroupAttributes($list, true), array( 'tagName' => strtolower($list->tagName) )),
             $items,
             $list
         );

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -3305,11 +3305,63 @@ final class HtmlCompilation implements SourceBlockCreator
             return $this->createBlock('core/group', array_merge($this->styleResolver->presentationAttributes($element), array( 'tagName' => 'ul' )), $converted, $element);
         }
 
+        if ( $this->hasAuthorSemanticMarker($element)
+            || $this->hasAuthorSemanticMarker($children[0])
+            || array() !== $this->styleResolver->presentationAttributes($children[0])
+        ) {
+            return $this->layoutShellBlockForElements(array( $element, $children[0] ), $converted, $element);
+        }
+
         if ( 1 === count($converted) && array() === $this->styleResolver->presentationAttributes($element) ) {
             return $converted[0];
         }
 
         return $this->createBlock('core/group', $this->styleResolver->presentationAttributes($element), $converted, $element);
+    }
+
+    /**
+     * Preserve a static source wrapper chain around editable inner blocks.
+     *
+     * @param list<DOMElement> $elements
+     * @param list<array<string, mixed>> $innerBlocks
+     * @return array<string, mixed>
+     */
+    private function layoutShellBlockForElements(array $elements, array $innerBlocks, DOMElement $sourceElement): array
+    {
+        $wrappers = array_map(function (DOMElement $element): array {
+            $tagName = strtolower($element->tagName);
+            $attributes = $this->htmlAttributes($element);
+            $opening = '<' . $tagName;
+            foreach ( $attributes as $name => $value ) {
+                if ( ! preg_match('/^[a-z_:][a-z0-9_.:-]*$/i', $name) ) {
+                    continue;
+                }
+                $opening .= ' ' . $name . '="' . htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"';
+            }
+            $opening .= '>';
+
+            return array(
+                'tagName' => $tagName,
+                'attributes' => $attributes,
+                'opening' => $opening,
+                'closing' => '</' . $tagName . '>',
+            );
+        }, $elements);
+        $blockName = $this->generatedBlocks()->blockName('layout-shell');
+        $this->generatedBlocks()->register(LayoutShellBlockGenerator::class, (new LayoutShellBlockGenerator())->definition($blockName));
+        $block = $this->createBlock(
+            $blockName,
+            array('wrappers' => array_map(static fn (array $wrapper): array => array('tagName' => $wrapper['tagName'], 'attributes' => $wrapper['attributes']), $wrappers)),
+            $innerBlocks,
+            $sourceElement
+        );
+        $opening = implode('', array_column($wrappers, 'opening'));
+        $closing = implode('', array_reverse(array_column($wrappers, 'closing')));
+        $block['innerHTML'] = $opening . $closing;
+        $block['innerContent'] = array_merge(array($opening), array_fill(0, count($innerBlocks), null), array($closing));
+        $block['_layout_shell_wrappers'] = $wrappers;
+
+        return $block;
     }
 
     private function isSafeTransparentCustomElement(DOMElement $element): bool

--- a/php-transformer/src/HtmlToBlocks/Style/ClosedStateNormalizer.php
+++ b/php-transformer/src/HtmlToBlocks/Style/ClosedStateNormalizer.php
@@ -114,6 +114,10 @@ final class ClosedStateNormalizer
 
     public function isDecorativeHiddenElement(DOMElement $element, callable $attr): bool
     {
+        if ( $this->isAccessibilityBoundaryMarker($element, $attr) ) {
+            return true;
+        }
+
         if ( in_array(strtolower(trim((string) $attr($element, 'role'))), array( 'presentation', 'none' ), true) ) {
             return true;
         }
@@ -132,6 +136,26 @@ final class ClosedStateNormalizer
         }
 
         return true;
+    }
+
+    private function isAccessibilityBoundaryMarker(DOMElement $element, callable $attr): bool
+    {
+        $boundary = $element;
+        if ( 'region' !== strtolower(trim((string) $attr($boundary, 'role'))) ) {
+            $boundary = $element->parentNode instanceof DOMElement ? $element->parentNode : null;
+        }
+        if (
+            ! $boundary instanceof DOMElement
+            || 'region' !== strtolower(trim((string) $attr($boundary, 'role')))
+            || '-1' !== trim((string) $attr($boundary, 'tabindex'))
+        ) {
+            return false;
+        }
+
+        $normalize = static fn (string $value): string => strtolower(trim((string) preg_replace('/\s+/', ' ', $value)));
+        $label = $normalize((string) $attr($boundary, 'aria-label'));
+
+        return '' !== $label && $label === $normalize($boundary->textContent ?? '');
     }
 
     /**

--- a/php-transformer/tests/contract/layout-geometry-proof.php
+++ b/php-transformer/tests/contract/layout-geometry-proof.php
@@ -29,6 +29,14 @@ $assert(preg_match('/be-layout-proof-[a-f0-9]{32}/', $markup, $carrier) && str_c
 $applied = $coalesced['source_reports']['layout_geometry_proof'] ?? array();
 $assert(1 === count($applied) && 'main:nth-of-type(1) > div:nth-of-type(1)' === ($applied[0]['wrapper_selector'] ?? null), 'Applied proof provenance retains the stable source-node identity.');
 
+$stagedArtifact = array('entrypoint' => 'index.html', 'files' => array('index.html' => $html), 'layout_geometry_proof' => $proof);
+$stagedCompiler = new ArtifactCompiler();
+$stagedShared = $stagedCompiler->prepareShared($stagedArtifact);
+$stagedPages = $stagedCompiler->preparePages($stagedArtifact, $stagedShared);
+$stagedReceipts = $stagedCompiler->compilePreparedPages($stagedShared, array_values($stagedPages));
+$stagedResult = $stagedCompiler->compose($stagedShared, array_values($stagedReceipts))->toArray();
+$assert('core/image' === ($stagedResult['blocks'][0]['blockName'] ?? null) && 1 === count($stagedResult['source_reports']['layout_geometry_proof'] ?? array()), 'Digest-bound staged page plans preserve validated layout geometry proof during worker compilation.');
+
 $exact = $proof;
 $exact['nodes'][0]['boxes'][0]['simulated']['width'] = 24;
 $exact['nodes'][0]['boxes'][1]['simulated']['width'] = 24;

--- a/php-transformer/tests/contract/layout-geometry-proof.php
+++ b/php-transformer/tests/contract/layout-geometry-proof.php
@@ -76,10 +76,10 @@ $assert(1 === count($deep['source_reports']['layout_geometry_proof'] ?? array())
 
 $boundaryHtml = '<main>' . str_repeat('<div>', 21) . '<p>Editable copy</p>' . str_repeat('</div>', 21) . '</main>';
 $boundaryHash = hash('sha256', $boundaryHtml);
-$boundaryWrapper = 'main:nth-of-type(1)' . str_repeat(' > div:nth-of-type(1)', 21);
+$boundaryWrapper = 'main:nth-of-type(1)' . str_repeat(' > div:nth-of-type(1)', 20);
 $boundaryProof = array('schema' => LayoutGeometryProof::SCHEMA, 'nodes' => array(
     array('id' => 'boundary-wrapper', 'source_path' => 'boundary.html', 'source_hash' => $boundaryHash, 'selector' => $boundaryWrapper, 'boxes' => $boxes()),
-    array('id' => 'boundary-target', 'source_path' => 'boundary.html', 'source_hash' => $boundaryHash, 'selector' => $boundaryWrapper . ' > p:nth-of-type(1)', 'boxes' => $boxes()),
+    array('id' => 'boundary-target', 'source_path' => 'boundary.html', 'source_hash' => $boundaryHash, 'selector' => $boundaryWrapper . ' > div:nth-of-type(1)', 'boxes' => $boxes()),
 ), 'reductions' => array(array('wrapper' => 'boundary-wrapper', 'target' => 'boundary-target', 'invariants' => array('selectors' => true, 'runtime' => true, 'semantics' => true, 'viewports' => true), 'corrective_css' => array('declarations' => array()))));
 $boundary = (new ArtifactCompiler())->compile(array('entrypoint' => 'boundary.html', 'files' => array('boundary.html' => $boundaryHtml), 'layout_geometry_proof' => $boundaryProof))->toArray();
 $assert(!str_contains((string) ($boundary['serialized_blocks'] ?? ''), 'responsive-layout') && str_contains((string) ($boundary['serialized_blocks'] ?? ''), '<!-- wp:paragraph'), 'Proof attached to a deep boundary itself takes precedence over opaque responsive-layout preservation.');

--- a/php-transformer/tests/contract/layout-geometry-proof.php
+++ b/php-transformer/tests/contract/layout-geometry-proof.php
@@ -74,6 +74,16 @@ $deepProof = array('schema' => LayoutGeometryProof::SCHEMA, 'nodes' => array(
 $deep = (new ArtifactCompiler())->compile(array('entrypoint' => 'deep.html', 'files' => array('deep.html' => $deepHtml), 'layout_geometry_proof' => $deepProof))->toArray();
 $assert(1 === count($deep['source_reports']['layout_geometry_proof'] ?? array()) && !str_contains((string) ($deep['serialized_blocks'] ?? ''), '"kind":"layout"'), 'Explicit measured reductions take precedence over a coarse captured-media layout boundary.');
 
+$boundaryHtml = '<main>' . str_repeat('<div>', 21) . '<p>Editable copy</p>' . str_repeat('</div>', 21) . '</main>';
+$boundaryHash = hash('sha256', $boundaryHtml);
+$boundaryWrapper = 'main:nth-of-type(1)' . str_repeat(' > div:nth-of-type(1)', 21);
+$boundaryProof = array('schema' => LayoutGeometryProof::SCHEMA, 'nodes' => array(
+    array('id' => 'boundary-wrapper', 'source_path' => 'boundary.html', 'source_hash' => $boundaryHash, 'selector' => $boundaryWrapper, 'boxes' => $boxes()),
+    array('id' => 'boundary-target', 'source_path' => 'boundary.html', 'source_hash' => $boundaryHash, 'selector' => $boundaryWrapper . ' > p:nth-of-type(1)', 'boxes' => $boxes()),
+), 'reductions' => array(array('wrapper' => 'boundary-wrapper', 'target' => 'boundary-target', 'invariants' => array('selectors' => true, 'runtime' => true, 'semantics' => true, 'viewports' => true), 'corrective_css' => array('declarations' => array()))));
+$boundary = (new ArtifactCompiler())->compile(array('entrypoint' => 'boundary.html', 'files' => array('boundary.html' => $boundaryHtml), 'layout_geometry_proof' => $boundaryProof))->toArray();
+$assert(!str_contains((string) ($boundary['serialized_blocks'] ?? ''), 'responsive-layout') && str_contains((string) ($boundary['serialized_blocks'] ?? ''), '<!-- wp:paragraph'), 'Proof attached to a deep boundary itself takes precedence over opaque responsive-layout preservation.');
+
 $providerChain = '<main>' . str_repeat('<provider-frame>', 24) . '<img src="hero.jpg" alt="Copy">' . str_repeat('</provider-frame>', 24) . '</main>';
 $providerHash = hash('sha256', $providerChain);
 $providerSelectors = array();

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -147,6 +147,17 @@ $assert(
         && array() === ($customImageResult['fallbacks'] ?? array()),
     'image-only custom elements should lower to core/image while retaining lazy image and CSS identity'
 );
+$selectorBoundaryCustomElementResult = ( new HtmlTransformer() )->transform(
+    '<style>.menu-host .menu-nav .menu-items{width:100%}</style><menu-host class="menu-host" data-mode="desktop"><nav class="menu-nav"><ul class="menu-items"><li>Home</li><li>About</li></ul></nav></menu-host>'
+)->toArray();
+$selectorBoundaryCustomElementMarkup = (string) ($selectorBoundaryCustomElementResult['serialized_blocks'] ?? '');
+$assert(
+    str_contains($selectorBoundaryCustomElementMarkup, '<!-- wp:custom/layout-shell')
+        && str_contains($selectorBoundaryCustomElementMarkup, '<menu-host class="menu-host" data-mode="desktop"><nav class="menu-nav">')
+        && str_contains($selectorBoundaryCustomElementMarkup, '<!-- wp:list')
+        && ! str_contains($selectorBoundaryCustomElementMarkup, '<!-- wp:html'),
+    'static custom-element wrappers retain selector-bearing host and structural boundaries around editable blocks'
+);
 $dimensionedCustomImageResult = ( new HtmlTransformer() )->transform('<media-image><img src="hero.jpg" style="width:320px;height:281px;object-fit:cover" width="1951" height="1951" alt="Hero"></media-image>')->toArray();
 $assert(
     str_contains((string) ($dimensionedCustomImageResult['serialized_blocks'] ?? ''), 'style="object-fit:cover;width:320px;height:281px"')

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -148,15 +148,17 @@ $assert(
     'image-only custom elements should lower to core/image while retaining lazy image and CSS identity'
 );
 $selectorBoundaryCustomElementResult = ( new HtmlTransformer() )->transform(
-    '<style>.menu-host .menu-nav .menu-items{width:100%}</style><menu-host class="menu-host" data-mode="desktop"><nav class="menu-nav"><ul class="menu-items"><li>Home</li><li>About</li></ul></nav></menu-host>'
+    '<style>.menu-host .menu-nav .menu-items{width:100%}.menu-items li{display:inline-block}</style><menu-host class="menu-host" data-mode="desktop"><nav class="menu-nav"><ul class="menu-items" style="text-align:right"><li>Home</li><li>About</li></ul></nav></menu-host>'
 )->toArray();
 $selectorBoundaryCustomElementMarkup = (string) ($selectorBoundaryCustomElementResult['serialized_blocks'] ?? '');
+$selectorBoundaryCustomElementCss = implode("\n", array_map(static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '', $selectorBoundaryCustomElementResult['assets'] ?? array()));
 $assert(
     str_contains($selectorBoundaryCustomElementMarkup, '<!-- wp:custom/layout-shell')
-        && str_contains($selectorBoundaryCustomElementMarkup, '<menu-host class="menu-host" data-mode="desktop"><nav class="menu-nav">')
+        && str_contains($selectorBoundaryCustomElementMarkup, '<div class="menu-host" data-mode="desktop"><nav class="menu-nav">')
         && str_contains($selectorBoundaryCustomElementMarkup, '<!-- wp:list')
+        && str_contains($selectorBoundaryCustomElementCss, 'text-align:right')
         && ! str_contains($selectorBoundaryCustomElementMarkup, '<!-- wp:html'),
-    'static custom-element wrappers retain selector-bearing host and structural boundaries around editable blocks'
+    'static custom-element wrappers retain block display, selector boundaries, and alignment around editable blocks'
 );
 $dimensionedCustomImageResult = ( new HtmlTransformer() )->transform('<media-image><img src="hero.jpg" style="width:320px;height:281px;object-fit:cover" width="1951" height="1951" alt="Hero"></media-image>')->toArray();
 $assert(

--- a/php-transformer/tests/contract/shared-shell-plan.php
+++ b/php-transformer/tests/contract/shared-shell-plan.php
@@ -105,6 +105,19 @@ $sourceResponsiveResult = (new ArtifactCompiler())->compile(array('entrypoint' =
 $sourceResponsiveArtifacts = $sourceResponsiveResult['source_reports']['compiled_site']['inline_shell_artifacts'] ?? array();
 $assert(array('header-1', 'header-2', 'footer-1', 'footer-2') === array_column($sourceResponsiveArtifacts, 'slug'), 'Source-identical nested shell variants are compiled once before route-specific page projection.');
 $assert(array() === array_filter($sourceResponsiveArtifacts, static fn(array $artifact): bool => array('index.html', 'about.html') !== ($artifact['source_paths'] ?? array())), 'Canonical source-level shell artifacts retain every contributing route.');
+$styledShellHtml = static fn(string $title): string => '<!doctype html><html><head><link rel="stylesheet" href="site.css"></head><body><div><header><p>Shared header</p></header><main><h1>' . $title . '</h1></main><footer><p>Shared footer</p></footer></div></body></html>';
+$styledShellResult = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array(
+    'index.html' => $styledShellHtml('Home'),
+    'about.html' => $styledShellHtml('About'),
+    'site.css' => 'p{margin:0}',
+)))->toArray();
+$styledShellParts = $styledShellResult['source_reports']['compiled_site']['inline_shell_artifacts'] ?? array();
+$styledShellClasses = array();
+foreach ($styledShellParts as $part) {
+    if (preg_match_all('/blocks-engine-source-p-[a-f0-9]+-\d+/', (string) ($part['block_markup'] ?? ''), $matches)) $styledShellClasses = array_merge($styledShellClasses, $matches[0]);
+}
+$styledShellCss = implode("\n", array_map(static fn(array $asset): string => 'css' === ($asset['kind'] ?? null) ? (string) ($asset['content'] ?? '') : '', $styledShellResult['source_reports']['wordpress_site_plan']['assets'] ?? array()));
+$assert(array() !== $styledShellClasses && array() === array_filter(array_unique($styledShellClasses), static fn(string $class): bool => !str_contains($styledShellCss, '.' . $class)), 'Shared-shell selector projections are materialized for the native classes emitted inside extracted template parts.');
 $sourceDivergentResult = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => $sourceResponsiveHtml('Home'), 'about.html' => str_replace('Mobile header', 'Different mobile header', $sourceResponsiveHtml('About')))))->toArray();
 $sourceDivergentArtifacts = $sourceDivergentResult['source_reports']['compiled_site']['inline_shell_artifacts'] ?? array();
 $assert(!array_filter($sourceDivergentArtifacts, static fn(array $artifact): bool => 'header' === ($artifact['area'] ?? null)) && 2 === count(array_filter($sourceDivergentArtifacts, static fn(array $artifact): bool => 'footer' === ($artifact['area'] ?? null))), 'A divergent source variant rejects the complete area bundle while an independently shared area remains canonical.');

--- a/php-transformer/tests/contract/staged-artifact-compilation.php
+++ b/php-transformer/tests/contract/staged-artifact-compilation.php
@@ -288,7 +288,7 @@ $v2Receipts = array();
 foreach ($pageIds as $pageId) {
     $v2Page = $compiler->preparePage($artifact, $v2Shared, $pageId);
     $v2Page['compiler_options']['compiled_page_schema'] = ArtifactCompiler::COMPILED_RECEIPT_SCHEMA;
-    $v2Page['digest'] = RuntimeDeclarations::hash(array('shared_digest' => $v2Page['shared_digest'], 'page_id' => $v2Page['page_id'], 'artifact' => $v2Page['artifact'], 'compiler_options' => $v2Page['compiler_options'], 'output_schema' => $v2Page['output_schema']));
+    $v2Page['digest'] = RuntimeDeclarations::hash(array('shared_digest' => $v2Page['shared_digest'], 'page_id' => $v2Page['page_id'], 'artifact' => $v2Page['artifact'], 'layout_geometry_proof' => $v2Page['layout_geometry_proof'], 'compiler_options' => $v2Page['compiler_options'], 'output_schema' => $v2Page['output_schema']));
     $v2Receipts[] = $compiler->compilePreparedPage($v2Shared, $v2Page);
 }
 $v2Result = $compiler->compose($v2Shared, array_reverse($v2Receipts))->toArray();
@@ -302,7 +302,7 @@ $legacyReceipts = array();
 foreach ($pageIds as $pageId) {
     $legacyPage = $compiler->preparePage($artifact, $legacyShared, $pageId);
     $legacyPage['compiler_options']['compiled_page_schema'] = ArtifactCompiler::PAGE_RECEIPT_SCHEMA;
-    $legacyPage['digest'] = RuntimeDeclarations::hash(array('shared_digest' => $legacyPage['shared_digest'], 'page_id' => $legacyPage['page_id'], 'artifact' => $legacyPage['artifact'], 'compiler_options' => $legacyPage['compiler_options'], 'output_schema' => $legacyPage['output_schema']));
+    $legacyPage['digest'] = RuntimeDeclarations::hash(array('shared_digest' => $legacyPage['shared_digest'], 'page_id' => $legacyPage['page_id'], 'artifact' => $legacyPage['artifact'], 'layout_geometry_proof' => $legacyPage['layout_geometry_proof'], 'compiler_options' => $legacyPage['compiler_options'], 'output_schema' => $legacyPage['output_schema']));
     $legacyReceipts[] = $compiler->compilePreparedPage($legacyShared, $legacyPage);
 }
 $legacyResult = $compiler->compose($legacyShared, array_reverse($legacyReceipts))->toArray();

--- a/php-transformer/tests/unit/inert-closed-state-interactions.php
+++ b/php-transformer/tests/unit/inert-closed-state-interactions.php
@@ -320,6 +320,21 @@ $assert(
     $emptyMarkup
 );
 
+$boundaryMarker = <<<'HTML'
+<style>.boundary-label { display: none; }</style>
+<div id="scroll-top" role="region" tabindex="-1" aria-label="top of page">
+  <span class="boundary-label">top of page</span>
+</div>
+HTML;
+
+$boundaryMarkerResult = ( new HtmlTransformer() )->transform($boundaryMarker)->toArray();
+$boundaryMarkerAfterAuthor = $cssContent($boundaryMarkerResult, 'after-author', 'both');
+$assert(
+    ! str_contains($boundaryMarkerAfterAuthor, '.boundary-label{display:revert!important}'),
+    'a hidden accessibility boundary label stays out of layout',
+    $boundaryMarkerAfterAuthor
+);
+
 if ( $failures > 0 ) {
     fwrite(STDERR, "inert closed-state interactions: {$failures} failed, {$passes} passed\n");
     exit(1);


### PR DESCRIPTION
## Summary

- preserve captured geometry proof through staged compilation and apply it at proven layout boundaries
- retain hidden accessibility boundaries, selector-bearing custom wrappers, and authored list alignment while lowering descendants to editable native blocks
- project authored stylesheet and runtime-script rewrites from extracted shared shells into final assets
- avoid document-sized opaque responsive-layout payloads while retaining visual structure

Closes #1522.

## Verification

- `composer test`
- 292 PHP transformer parity fixtures pass
- staged artifact compilation, distribution shape, and package-install contracts pass
- shared-shell contract proves linked paragraph resets target the native classes emitted in extracted template parts
- fresh six-route WordPress 7.1 import through Static Site Importer produced 913 native blocks with zero fallback, core HTML, freeform, invalid, or responsive-layout blocks
- homepage rendered at 1280x2060 with exact 70px header and 53.0625px footer geometry, no overflow, and no browser errors
- Gutenberg loaded all 235 homepage blocks without dirtying content; nested core/paragraph and custom/layout-shell blocks were individually selectable and valid

Mobile outer-page parity remains tracked separately as authored viewport metadata materialization in Static Site Importer #1495.

## AI assistance

GPT-5.6 Sol through OpenCode traced the compiler and materialized WordPress behavior, implemented the repairs under human direction, added regression coverage, and ran the package and browser verification workflows.