### PR TITLE
Extract rich text materialization

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -96,6 +96,7 @@
       "php tests/unit/cover-pattern.php",
       "php tests/unit/media-text-block-factory.php",
       "php tests/unit/rich-text-source-serialization.php",
+      "php tests/unit/rich-text-svg-transaction.php",
       "php tests/unit/media-text-pattern.php",
       "php tests/unit/cover-style-resolver.php",
       "php tests/unit/css-stylesheet-transformer.php",

--- a/php-transformer/src/HtmlToBlocks/Elements/DescriptionListElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/DescriptionListElementContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\RichText\RichTextMaterialization;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
 use Closure;
@@ -19,7 +20,6 @@ final class DescriptionListElementContext
      * @param Closure(DOMElement): bool $isCssOwnedGridElement
      * @param Closure(DOMElement): array<string, mixed> $cssOwnedGridAttributes
      * @param Closure(DOMElement, array<int, array<string, mixed>>&, bool): array<int, array<string, mixed>> $convertChildren
-     * @param Closure(DOMElement): string $richTextContent
      * @param Closure(string): bool $hasVisibleText
      */
     public function __construct(
@@ -32,7 +32,7 @@ final class DescriptionListElementContext
         private readonly ElementPresentationResolver $presentationResolver,
         private readonly Closure $convertChildren,
         private readonly SourceBlockCreator $createBlock,
-        private readonly Closure $richTextContent,
+        private readonly RichTextMaterialization $richTextMaterializer,
         private readonly Closure $hasVisibleText
     ) {
     }
@@ -86,7 +86,7 @@ final class DescriptionListElementContext
 
     public function richTextContent(DOMElement $element): string
     {
-        return ($this->richTextContent)($element);
+        return $this->richTextMaterializer->content($element);
     }
 
     public function hasVisibleText(string $html): bool

--- a/php-transformer/src/HtmlToBlocks/Elements/InlineContentElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/InlineContentElementContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\RichText\RichTextMaterialization;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Closure;
 use DOMElement;
@@ -19,10 +20,8 @@ final class InlineContentElementContext
      * @param Closure(DOMElement): bool $ownsPositioningGeometry
      * @param Closure(DOMElement, array<int, array<string, mixed>>&): ?array<string, mixed> $positionedInlineCarrierBlock
      * @param Closure(DOMElement): bool $hasAuthorSemanticMarker
-     * @param Closure(string): bool $richTextContentHasStructuralHtml
      * @param Closure(DOMElement, array<int, array<string, mixed>>&, bool): array<int, array<string, mixed>> $convertChildren
      * @param Closure(DOMElement): string $richTextMarker
-     * @param Closure(DOMElement): array<string, string> $richTextInlineVisualDeclarations
      * @param Closure(DOMElement): ?string $dynamicTextContent
      * @param Closure(DOMElement, string): ?DOMElement $ancestorElement
      * @param Closure(DOMElement): bool $isStructuralListItem
@@ -38,11 +37,10 @@ final class InlineContentElementContext
         private readonly Closure $ownsPositioningGeometry,
         private readonly Closure $positionedInlineCarrierBlock,
         private readonly Closure $hasAuthorSemanticMarker,
-        private readonly Closure $richTextContentHasStructuralHtml,
+        private readonly RichTextMaterialization $richTextMaterializer,
         private readonly Closure $convertChildren,
         private readonly SourceBlockCreator $createBlock,
         private readonly Closure $richTextMarker,
-        private readonly Closure $richTextInlineVisualDeclarations,
         private readonly Closure $dynamicTextContent,
         private readonly Closure $ancestorElement,
         private readonly Closure $isStructuralListItem,
@@ -62,7 +60,7 @@ final class InlineContentElementContext
     /** @param array<int, array<string, mixed>> $fallbacks @return array<string, mixed>|null */
     public function positionedInlineCarrierBlock(DOMElement $element, array &$fallbacks): ?array { return ($this->positionedInlineCarrierBlock)($element, $fallbacks); }
     public function hasAuthorSemanticMarker(DOMElement $element): bool { return ($this->hasAuthorSemanticMarker)($element); }
-    public function richTextContentHasStructuralHtml(string $content): bool { return ($this->richTextContentHasStructuralHtml)($content); }
+    public function richTextContentHasStructuralHtml(string $content): bool { return $this->richTextMaterializer->hasStructuralHtml($content); }
     /** @param array<int, array<string, mixed>> $fallbacks @return array<int, array<string, mixed>> */
     public function convertChildren(DOMElement $element, array &$fallbacks): array { return ($this->convertChildren)($element, $fallbacks, true); }
     /** @param array<string, mixed> $attributes @param array<int, array<string, mixed>> $innerBlocks @return array<string, mixed> */
@@ -70,7 +68,7 @@ final class InlineContentElementContext
     public function richTextMarker(DOMElement $element): string { return ($this->richTextMarker)($element); }
     public function hasBlockContentChildren(DOMElement $element): bool { return $this->sourceElementClassifier->hasBlockContentChildren($element); }
     /** @return array<string, string> */
-    public function richTextInlineVisualDeclarations(DOMElement $element): array { return ($this->richTextInlineVisualDeclarations)($element); }
+    public function richTextInlineVisualDeclarations(DOMElement $element): array { return $this->richTextMaterializer->inlineVisualDeclarations($element); }
     public function dynamicTextContent(DOMElement $element): ?string { return ($this->dynamicTextContent)($element); }
     public function ancestorElement(DOMElement $element, string $tagName): ?DOMElement { return ($this->ancestorElement)($element, $tagName); }
     public function isStructuralListItem(DOMElement $element): bool { return ($this->isStructuralListItem)($element); }

--- a/php-transformer/src/HtmlToBlocks/Elements/RichTextElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/RichTextElementContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\RichText\RichTextMaterialization;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use Closure;
@@ -21,11 +22,6 @@ use DOMElement;
 final class RichTextElementContext
 {
     /**
-     * @param Closure(DOMElement, array<int, string>): string                                                $richTextContent
-     * @param Closure(string): string                                                                        $headingRichTextContent
-     * @param Closure(DOMElement, string): ?string                                                            $richTextWithMaterializedSvgImages
-     * @param Closure(string): bool                                                                          $requiresHtmlFallback
-     * @param Closure(string): bool                                                                          $containsNativeSvgImageObject
      * @param Closure(DOMElement): array<string, mixed>                                                      $htmlPreservationBlock
      * @param Closure(DOMElement): ?array<string, mixed>                                                     $authoredMarqueeBlock
      * @param Closure(DOMElement): bool                                                                      $hasEmptyVisualInlineChild
@@ -37,11 +33,7 @@ final class RichTextElementContext
     public function __construct(
         private readonly ElementPresentationResolver $presentationResolver,
         private readonly SourceBlockCreator $createBlock,
-        private readonly Closure $richTextContent,
-        private readonly Closure $headingRichTextContent,
-        private readonly Closure $richTextWithMaterializedSvgImages,
-        private readonly Closure $requiresHtmlFallback,
-        private readonly Closure $containsNativeSvgImageObject,
+        private readonly RichTextMaterialization $richTextMaterializer,
         private readonly Closure $htmlPreservationBlock,
         private readonly Closure $authoredMarqueeBlock,
         private readonly Closure $hasEmptyVisualInlineChild,
@@ -78,27 +70,27 @@ final class RichTextElementContext
      */
     public function richTextContent(DOMElement $element, array $excludedTags = array()): string
     {
-        return ($this->richTextContent)($element, $excludedTags);
+        return $this->richTextMaterializer->content($element, $excludedTags);
     }
 
     public function headingRichTextContent(string $content): string
     {
-        return ($this->headingRichTextContent)($content);
+        return $this->richTextMaterializer->headingContent($content);
     }
 
     public function richTextWithMaterializedSvgImages(DOMElement $element, string $content): ?string
     {
-        return ($this->richTextWithMaterializedSvgImages)($element, $content);
+        return $this->richTextMaterializer->contentWithMaterializedSvgImages($element, $content);
     }
 
     public function requiresHtmlFallback(string $content): bool
     {
-        return ($this->requiresHtmlFallback)($content);
+        return $this->richTextMaterializer->requiresHtmlFallbackWithoutNativeSvgImageObjects($content);
     }
 
     public function containsNativeSvgImageObject(string $content): bool
     {
-        return ($this->containsNativeSvgImageObject)($content);
+        return $this->richTextMaterializer->containsNativeSvgImageObject($content);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Elements/TextLeafElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/TextLeafElementContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SourceElementClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\RichText\RichTextMaterialization;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\SourceBlockCreator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\ElementPresentationResolver;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
@@ -21,7 +22,6 @@ use DOMElement;
 final class TextLeafElementContext
 {
     /**
-     * @param Closure(DOMElement, array<int, string>): string                                  $richTextContent
      * @param Closure(DOMElement, DOMElement): array<string, mixed>                            $codePresentationAttributes
      * @param Closure(DOMElement): string                                                      $codeContent
      * @param Closure(DOMElement, array<int, array<string, mixed>>, bool): array<int, array<string, mixed>> $convertChildren
@@ -30,7 +30,7 @@ final class TextLeafElementContext
         private readonly SourceElementClassifier $sourceElementClassifier,
         private readonly ElementPresentationResolver $presentationResolver,
         private readonly SourceBlockCreator $createBlock,
-        private readonly Closure $richTextContent,
+        private readonly RichTextMaterialization $richTextMaterializer,
         private readonly Runtime $runtime,
         private readonly Closure $codePresentationAttributes,
         private readonly Closure $codeContent,
@@ -63,7 +63,7 @@ final class TextLeafElementContext
      */
     public function richTextContent(DOMElement $element, array $excludedTags = array()): string
     {
-        return ($this->richTextContent)($element, $excludedTags);
+        return $this->richTextMaterializer->content($element, $excludedTags);
     }
 
     public function stripAllTags(string $html): string

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -32,6 +32,8 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\ResponsiveMed
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Generators\VisualIframeBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolutionContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolver;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\RichText\RichTextInlinePolicy;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\RichText\RichTextMaterializer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonElementContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ButtonLinkDispatchContext;
@@ -152,7 +154,7 @@ use DOMElement;
 use DOMNode;
 
 /** Run-scoped compiler for one HTML document. */
-final class HtmlCompilation implements SourceBlockCreator
+final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy
 {
     private const GENERATED_COMPONENT_MIN_SOURCE_DEPTH = 14;
 
@@ -314,6 +316,8 @@ final class HtmlCompilation implements SourceBlockCreator
     private readonly NavigationStyleProjector $navigationStyleProjector;
 
     private readonly SvgMaterializer $svgMaterializer;
+
+    private readonly RichTextMaterializer $richTextMaterializer;
 
     private readonly OrderedElementConverterRegistry $structuralContentConverters;
 
@@ -488,11 +492,6 @@ final class HtmlCompilation implements SourceBlockCreator
         $this->contentRoundTripReporter = new ContentRoundTripReporter();
         $this->reusableComponentRecognizer = new ReusableComponentRecognizer();
         $this->styleResolver = new StyleResolver($this->createStyleResolutionContext(), $this->analysisCache);
-        $this->patternContext = $this->createPatternContext(true);
-        $this->patternContextWithoutRuntimeDomTarget = $this->createPatternContext(false);
-        $this->patternProbeContext = $this->createProbePatternContext();
-        $this->textLeafConverter = new TextLeafElementConverter($this->createTextLeafElementContext());
-        $this->richTextConverter = new RichTextElementConverter($this->createRichTextElementContext());
         $this->generatedBlockStyleProjector = new GeneratedBlockStyleProjector($this->runtime, $this->styleResolver);
         $this->sourceBlockAttributeProjector = new SourceBlockAttributeProjector($this->styleResolver, $this->generatedBlockStyleProjector);
         $this->stylesheetAnalysisComposer = new StylesheetAnalysisComposer($this->styleResolver, $this->analysisCache);
@@ -528,6 +527,12 @@ final class HtmlCompilation implements SourceBlockCreator
             $this->styleResolver,
             $this->runtime
         );
+        $this->richTextMaterializer = new RichTextMaterializer($this->styleResolver, $this->svgMaterializer, $this->session, $this);
+        $this->patternContext = $this->createPatternContext(true);
+        $this->patternContextWithoutRuntimeDomTarget = $this->createPatternContext(false);
+        $this->patternProbeContext = $this->createProbePatternContext();
+        $this->textLeafConverter = new TextLeafElementConverter($this->createTextLeafElementContext());
+        $this->richTextConverter = new RichTextElementConverter($this->createRichTextElementContext());
         $svgConverter = new SvgElementConverter(new SvgElementContext(
             $this->sourceElementClassifier,
             fn (DOMElement $element): bool => $this->isInertHiddenSvgStorage($element),
@@ -550,11 +555,10 @@ final class HtmlCompilation implements SourceBlockCreator
             fn (DOMElement $element): bool => $this->ownsPositioningGeometry($element),
             fn (DOMElement $element, array &$fallbacks): ?array => $this->positionedInlineCarrierBlock($element, $fallbacks),
             fn (DOMElement $element): bool => $this->hasAuthorSemanticMarker($element),
-            fn (string $content): bool => $this->richTextContentHasStructuralHtml($content),
+            $this->richTextMaterializer,
             fn (DOMElement $element, array &$fallbacks, bool $captureUnsupported): array => $this->convertChildren($element, $fallbacks, $captureUnsupported),
             $this,
             fn (DOMElement $element): string => $this->richTextMarkerForElement($element),
-            fn (DOMElement $element): array => $this->richTextInlineVisualDeclarations($element),
             fn (DOMElement $element): ?string => $this->dynamicTextContent($element),
             fn (DOMElement $element, string $tagName): ?DOMElement => $this->ancestorElement($element, $tagName),
             fn (DOMElement $element): bool => $this->isStructuralListItem($element),
@@ -759,7 +763,7 @@ final class HtmlCompilation implements SourceBlockCreator
                 return $this->convertChildren($element, $fallbacks, $captureUnsupported);
             },
             $this,
-            fn (DOMElement $element): string => $this->richTextContentWithMaterializedInlineStyles($element),
+            $this->richTextMaterializer,
             fn (string $html): bool => '' !== trim($this->runtime->stripAllTags($html))
         ));
         $this->structuralContentConverters = new OrderedElementConverterRegistry(array(
@@ -1033,11 +1037,7 @@ final class HtmlCompilation implements SourceBlockCreator
         return new RichTextElementContext(
             $this->styleResolver,
             $this,
-            fn (DOMElement $element, array $excludedTags): string => $this->richTextContentWithMaterializedInlineStyles($element, $excludedTags),
-            fn (string $content): string => $this->headingRichTextContent($content),
-            fn (DOMElement $element, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($element, $content),
-            fn (string $content): bool => $this->richTextRequiresHtmlFallbackWithoutNativeSvgImageObjects($content),
-            fn (string $content): bool => $this->richTextContainsNativeSvgImageObject($content),
+            $this->richTextMaterializer,
             fn (DOMElement $element): array => $this->htmlPreservationBlock($element),
             fn (DOMElement $element): ?array => $this->authoredMarqueeBlock($element),
             fn (DOMElement $element): bool => $this->hasEmptyVisualInlineChild($element),
@@ -1062,7 +1062,7 @@ final class HtmlCompilation implements SourceBlockCreator
             $this->sourceElementClassifier,
             $this->styleResolver,
             $this,
-            fn (DOMElement $element, array $excludedTags): string => $this->richTextContentWithMaterializedInlineStyles($element, $excludedTags),
+            $this->richTextMaterializer,
             $this->runtime,
             fn (DOMElement $pre, DOMElement $code): array => $this->codePresentationAttributes($pre, $code),
             fn (DOMElement $code): string => $this->codeContent($code),
@@ -2259,14 +2259,6 @@ final class HtmlCompilation implements SourceBlockCreator
         );
     }
 
-    /** Convert invalid block wrappers inside a heading into valid RichText breaks. */
-    private function headingRichTextContent(string $content): string
-    {
-        if ( ! preg_match('/<\/?(?:div|p)\b/i', $content) ) return $content;
-        $content = preg_replace_callback('/<\s*(\/)?\s*(?:div|p)\b[^>]*>/i', static fn (array $match): string => ! empty($match[1]) ? '<br>' : '', $content) ?? $content;
-        return preg_replace('/(?:<br>\s*){2,}/i', '<br>', $content) ?? $content;
-    }
-
     /**
      * @param array<int, array<string, mixed>> $fallbacks
      * @return array<string, mixed>
@@ -2586,8 +2578,7 @@ final class HtmlCompilation implements SourceBlockCreator
             new ButtonPatternContext(
                 fn (DOMElement $anchor): ?array => $this->fileBlockFromAnchor($anchor),
                 fn (DOMElement $sourceElement): string => $this->styleResolver->resolveCssVariablesInValue($this->styleResolver->specificityResolvedPresentationStyle($sourceElement)),
-                fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement),
-                fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content),
+                $this->richTextMaterializer,
                 fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name),
                 fn (DOMElement $sourceElement): bool => $sourceElement->parentNode instanceof DOMElement && in_array($this->authoredDisplay($sourceElement->parentNode), array('grid', 'inline-grid'), true),
                 fn (DOMElement $anchor): PatternRecognitionResult => new PatternRecognitionResult(
@@ -2605,8 +2596,7 @@ final class HtmlCompilation implements SourceBlockCreator
                 fn (DOMElement $sourceCode): string => $this->codeContent($sourceCode)
             ),
             new LogoPatternContext(
-                fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement),
-                fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content)
+                $this->richTextMaterializer
             ),
             new GalleryPatternContext(
                 fn (DOMElement $image, ?DOMElement $figure = null, ?DOMElement $picture = null, ?DOMElement $link = null): ?array => $this->convertImageElement($image, $figure, $picture, $link),
@@ -2656,8 +2646,7 @@ final class HtmlCompilation implements SourceBlockCreator
                 fn (DOMElement $sourceCode): string => $this->codeContent($sourceCode)
             ),
             logoContext: new LogoPatternContext(
-                fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement),
-                fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content)
+                $this->richTextMaterializer
             ),
             galleryContext: new GalleryPatternContext(
                 fn (DOMElement $image, ?DOMElement $figure = null, ?DOMElement $picture = null, ?DOMElement $link = null): ?array => $this->convertImageElement($image, $figure, $picture, $link),
@@ -3541,7 +3530,7 @@ final class HtmlCompilation implements SourceBlockCreator
     {
         if ( $sourceElement instanceof DOMElement
             && in_array($name, array( 'core/paragraph', 'core/heading', 'core/list-item' ), true)
-            && $this->richTextContentHasStructuralHtml((string) ($attrs['content'] ?? ''))
+            && $this->richTextMaterializer->hasStructuralHtml((string) ($attrs['content'] ?? ''))
         ) {
             $structuralFallbacks = array();
             $children = $this->convertChildren($sourceElement, $structuralFallbacks, true);
@@ -3562,9 +3551,9 @@ final class HtmlCompilation implements SourceBlockCreator
             }
         }
 
-        if ( $sourceElement instanceof DOMElement && in_array($name, array( 'core/paragraph', 'core/heading' ), true) && $this->richTextRequiresHtmlFallbackWithoutNativeSvgImageObjects((string) ($attrs['content'] ?? '')) ) {
-            $attrs['content'] = $this->stripDecorativeSvgFromRichText((string) ($attrs['content'] ?? ''));
-            if ( $this->richTextRequiresHtmlFallbackWithoutNativeSvgImageObjects((string) ($attrs['content'] ?? '')) ) {
+        if ( $sourceElement instanceof DOMElement && in_array($name, array( 'core/paragraph', 'core/heading' ), true) && $this->richTextMaterializer->requiresHtmlFallbackWithoutNativeSvgImageObjects((string) ($attrs['content'] ?? '')) ) {
+            $attrs['content'] = $this->richTextMaterializer->stripDecorativeSvg((string) ($attrs['content'] ?? ''));
+            if ( $this->richTextMaterializer->requiresHtmlFallbackWithoutNativeSvgImageObjects((string) ($attrs['content'] ?? '')) ) {
                 return $this->createBlock('core/html', array( 'content' => $this->safeFallbackHtml($sourceElement) ), array(), $sourceElement);
             }
         }
@@ -3753,7 +3742,7 @@ final class HtmlCompilation implements SourceBlockCreator
                 : $this->createBlock('core/group', $this->positionedInlineCarrierAttributes($element), $children, $element);
         }
 
-        $content = $this->richTextContentWithMaterializedInlineStyles($element);
+        $content = $this->richTextMaterializer->content($element);
         if ( '' === trim($this->runtime->stripAllTags($content)) ) {
             return null;
         }
@@ -4270,6 +4259,11 @@ final class HtmlCompilation implements SourceBlockCreator
         return $this->authorSelectorProjections()->richTextMarker($this->sourceElementIdentity($element));
     }
 
+    public function richTextMarker(DOMElement $element): string
+    {
+        return $this->richTextMarkerForElement($element);
+    }
+
     /**
      * Lift class/style styling hooks out of a block's RichText source so the
      * stored block round-trips through RichText unchanged.
@@ -4530,206 +4524,13 @@ final class HtmlCompilation implements SourceBlockCreator
         return $attributes;
     }
 
-    private function richTextRequiresHtmlFallback(string $content): bool
-    {
-        return (bool) preg_match('/<(?:svg|canvas|img|picture|video|audio|iframe|object|embed|input|button|select|textarea|form)\b/i', $content);
-    }
-
-    private function richTextContentHasStructuralHtml(string $content): bool
-    {
-        return (bool) preg_match('/<(?:address|article|aside|blockquote|details|div|dl|figure|h[1-6]|hr|main|menu|nav|ol|p|pre|section|table|ul)\b/i', $content);
-    }
-
-    /**
-     * @param array<int, string> $excludedTags
-     */
-    private function richTextContentWithMaterializedInlineStyles(DOMElement $element, array $excludedTags = array()): string
-    {
-        $content = array() === $excludedTags ? $this->innerHtml($element) : $this->innerHtmlWithoutTags($element, $excludedTags);
-        if ( '' === $content || ! preg_match('/<(?:span|font|em|i|strong|b|mark|small|sub|sup)\b/i', $content) ) {
-            return $content;
-        }
-
-        $document = new DOMDocument();
-        $previous = libxml_use_internal_errors(true);
-        $loaded   = $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $content . '</body>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
-        libxml_clear_errors();
-        libxml_use_internal_errors($previous);
-
-        $body = $loaded ? $document->getElementsByTagName('body')->item(0) : null;
-        if ( ! $body instanceof DOMElement ) {
-            return $content;
-        }
-
-        $sourceInlines = array();
-        foreach ( $element->getElementsByTagName('*') as $sourceInline ) {
-            if ( $sourceInline instanceof DOMElement && in_array(strtolower($sourceInline->tagName), array( 'span', 'font', 'em', 'i', 'strong', 'b', 'mark', 'small', 'sub', 'sup' ), true) ) {
-                for ( $parent = $sourceInline->parentNode; $parent instanceof DOMElement && $parent !== $element; $parent = $parent->parentNode ) {
-                    if ( in_array(strtolower($parent->tagName), $excludedTags, true) ) {
-                        continue 2;
-                    }
-                }
-                $sourceInlines[] = $sourceInline;
-            }
-        }
-
-        $targetInlines = array();
-        foreach ( $body->getElementsByTagName('*') as $targetInline ) {
-            if ( $targetInline instanceof DOMElement && in_array(strtolower($targetInline->tagName), array( 'span', 'font', 'em', 'i', 'strong', 'b', 'mark', 'small', 'sub', 'sup' ), true) ) {
-                $targetInlines[] = $targetInline;
-            }
-        }
-
-        foreach ( $targetInlines as $index => $targetInline ) {
-            $sourceInline = $sourceInlines[$index] ?? null;
-            if ( ! $sourceInline instanceof DOMElement ) {
-                continue;
-            }
-
-            if ( '' === trim($sourceInline->textContent ?? '') && 0 === $this->childElementCount($sourceInline) && ! $this->runtimeIslands->isRuntimeDomTarget($sourceInline) && ! $this->shouldPreserveEmptyVisualElement($sourceInline) ) {
-                $targetInline->parentNode?->removeChild($targetInline);
-                continue;
-            }
-
-            $inline = $this->richTextInlineVisualDeclarations($sourceInline);
-            $marker = $this->richTextMarkerForElement($sourceInline);
-            if ( '' !== $marker ) {
-                $headerCarrier = array_intersect_key($inline, array( 'place-items' => true, 'box-shadow' => true ));
-                if ( array() !== $headerCarrier && $this->hasAncestorTag($sourceInline, array( 'header' )) ) {
-                    $selector = 'mark[style*="--blocks-engine-richtext-marker:' . $marker . '"]'
-                        . ',span[data-blocks-engine-richtext-marker="' . $marker . '"]';
-                    $this->generatedSupportStyles()->registerHeaderRichText($marker, $selector . '{' . $this->styleResolver->cssDeclarationString($headerCarrier) . '}');
-                }
-                $inline['--blocks-engine-richtext-marker'] = $marker;
-            }
-            if ( array() === $inline ) {
-                continue;
-            }
-
-            $existing = $this->styleResolver->cssDeclarations($this->attr($targetInline, 'style'));
-            $targetInline->setAttribute('style', $this->styleResolver->cssDeclarationString(array_merge($inline, $existing)));
-        }
-
-        // Source comments are authoring metadata, not RichText. Gutenberg exposes comments inside
-        // editable content as visible text, so remove them while retaining comments elsewhere in
-        // the document where they may delimit templates or runtime payloads.
-        $xpath = new \DOMXPath($document);
-        foreach ( $xpath->query('//body//comment()') ?: array() as $comment ) {
-            $comment->parentNode?->removeChild($comment);
-        }
-
-        return $this->innerHtml($body);
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    private function richTextInlineVisualDeclarations(DOMElement $element): array
-    {
-        $allowed = array_flip(array(
-            '-webkit-background-clip',
-            '-webkit-text-fill-color',
-            'background',
-            'background-clip',
-            'background-color',
-            'border',
-            'border-bottom',
-            'border-color',
-            'border-left',
-            'border-radius',
-            'border-right',
-            'border-top',
-            'box-shadow',
-            'color',
-            'display',
-            'font-family',
-            'font-size',
-            'font-style',
-            'font-weight',
-            'letter-spacing',
-            'line-height',
-            'height',
-            'max-height',
-            'max-width',
-            'margin',
-            'margin-bottom',
-            'margin-left',
-            'margin-right',
-            'margin-top',
-            'padding',
-            'padding-bottom',
-            'padding-left',
-            'padding-right',
-            'padding-top',
-            'place-items',
-            'text-decoration',
-            'text-transform',
-            'width',
-        ));
-
-        $declarations = $this->styleResolver->cssDeclarations($this->styleResolver->specificityResolvedPresentationStyle($element));
-        if ('font' === strtolower($element->tagName)) {
-            $color = trim($this->attr($element, 'color'));
-            $face = trim($this->attr($element, 'face'));
-            $size = trim($this->attr($element, 'size'));
-            if ('' !== $color && !isset($declarations['color'])) $declarations['color'] = $color;
-            if ('' !== $face && !isset($declarations['font-family'])) $declarations['font-family'] = $face;
-            $resolvedSize = $this->legacyFontSize($element);
-            if ('' !== $resolvedSize && !isset($declarations['font-size'])) $declarations['font-size'] = $resolvedSize;
-        }
-
-        if ( 'transparent' === strtolower((string) ($declarations['-webkit-text-fill-color'] ?? '')) ) {
-            $declarations['color'] = 'transparent';
-        }
-
-        $declarations = array_intersect_key($declarations, $allowed);
-        if ( ! $this->hasAncestorTag($element, array( 'header' )) ) {
-            unset($declarations['box-shadow'], $declarations['place-items']);
-        }
-        if ( in_array(strtolower($element->tagName), array( 'em', 'i' ), true) ) {
-            if ( 'italic' === strtolower((string) ($declarations['font-style'] ?? '')) ) {
-                unset($declarations['font-style']);
-            }
-            if ( 'inherit' === strtolower((string) ($declarations['font-weight'] ?? '')) ) {
-                unset($declarations['font-weight']);
-            }
-            foreach ( array( 'margin', 'margin-bottom', 'margin-left', 'margin-right', 'margin-top', 'padding', 'padding-bottom', 'padding-left', 'padding-right', 'padding-top' ) as $property ) {
-                if ( isset($declarations[$property]) && ! $this->cssValueIsNonZero($declarations[$property]) ) {
-                    unset($declarations[$property]);
-                }
-            }
-        }
-
-        return $declarations;
-    }
-
-    private function legacyFontSize(DOMElement $element): string
-    {
-        $sizes = array('1' => '10px', '2' => '13px', '3' => '16px', '4' => '18px', '5' => '24px', '6' => '32px', '7' => '48px');
-        $level = 3;
-        $found = false;
-        $fonts = array();
-        for ($node = $element; $node instanceof DOMElement; $node = $node->parentNode instanceof DOMElement ? $node->parentNode : null) if ('font' === strtolower($node->tagName)) $fonts[] = $node;
-        foreach (array_reverse($fonts) as $font) {
-            $size = trim($this->attr($font, 'size'));
-            if (preg_match('/^[1-7]$/', $size)) {
-                $level = (int) $size;
-                $found = true;
-            } elseif (preg_match('/^[+-]\d+$/', $size)) {
-                $level = min(7, max(1, $level + (int) $size));
-                $found = true;
-            }
-        }
-        return $found ? $sizes[(string) $level] : '';
-    }
-
     private function replaceRichTextStylingHookWithMark(DOMElement $element): bool
     {
         if ( $element->getElementsByTagName('mark')->length > 0 ) {
             return false;
         }
 
-        $declarations = $this->richTextInlineVisualDeclarations($element);
+        $declarations = $this->richTextMaterializer->inlineVisualDeclarations($element);
         $existingDeclarations = $this->styleResolver->cssDeclarations($this->attr($element, 'style'));
         $marker = trim((string) ($existingDeclarations['--blocks-engine-richtext-marker'] ?? ''));
         if ( '' === $marker ) {
@@ -5591,6 +5392,11 @@ final class HtmlCompilation implements SourceBlockCreator
         return $this->isEmptyVisualInlineCandidate($element);
     }
 
+    public function retainsEmptyRichTextInline(DOMElement $sourceInline): bool
+    {
+        return $this->runtimeIslands->isRuntimeDomTarget($sourceInline) || $this->shouldPreserveEmptyVisualElement($sourceInline);
+    }
+
     private function hasSubstantiveSourceDescendant(DOMElement $element): bool
     {
         if ( '' !== $this->renderedTextContent($element) ) {
@@ -5956,17 +5762,12 @@ final class HtmlCompilation implements SourceBlockCreator
             return null;
         }
 
-        $content = $this->richTextContentWithoutDecorativeSvg($element);
+        $content = $this->richTextMaterializer->contentWithoutDecorativeSvg($element);
         if ( '' === trim($this->runtime->stripAllTags($content)) ) {
             return null;
         }
 
         return $this->createBlock('core/paragraph', array_merge($this->styleResolver->presentationAttributes($element), array( 'content' => $content )), array(), $element);
-    }
-
-    private function richTextContentWithoutDecorativeSvg(DOMElement $element): string
-    {
-        return $this->stripDecorativeSvgFromRichText($this->innerHtml($element));
     }
 
     /**
@@ -6040,88 +5841,12 @@ final class HtmlCompilation implements SourceBlockCreator
         }
 
         $content = trim($textRun);
-        if ( '' === trim($this->runtime->stripAllTags($content)) || $this->richTextRequiresHtmlFallbackWithoutNativeSvgImageObjects($content) ) {
+        if ( '' === trim($this->runtime->stripAllTags($content)) || $this->richTextMaterializer->requiresHtmlFallbackWithoutNativeSvgImageObjects($content) ) {
             $this->materializedAssets()->restore($generatedAssets);
             return null;
         }
 
         return $this->createBlock('core/paragraph', array_merge($this->styleResolver->presentationAttributes($element), array( 'content' => $content )), array(), $element);
-    }
-
-    private function richTextContentWithMaterializedSvgImages(DOMElement $element, string $content): ?string
-    {
-        if ( 0 === $element->getElementsByTagName('svg')->length ) {
-            return $content;
-        }
-
-        $generatedAssets = $this->materializedAssets()->checkpoint();
-        foreach ( $element->getElementsByTagName('svg') as $svg ) {
-            if ( ! $svg instanceof DOMElement ) {
-                continue;
-            }
-            $image = $this->svgMaterializer->inlineSvgRichTextImageMarkup($svg, false);
-            if ( null === $image ) {
-                $this->materializedAssets()->restore($generatedAssets);
-                return null;
-            }
-            // RichText preparation may normalize SVG casing (viewBox -> viewbox),
-            // so the DOM serialization is not a stable replacement key.
-            $replaced = preg_replace('@<svg\b[^>]*>.*?</svg>@is', $image, $content, 1);
-            if ( ! is_string($replaced) || $replaced === $content ) {
-                $this->materializedAssets()->restore($generatedAssets);
-                return null;
-            }
-            $content = $replaced;
-        }
-
-        return $content;
-    }
-
-    private function richTextRequiresHtmlFallbackWithoutNativeSvgImageObjects(string $content): bool
-    {
-        // RichText stores core/image objects as <img> nodes. The generic fallback
-        // detector intentionally rejects arbitrary images, so remove only our
-        // materialized SVG image objects before applying that conservative gate.
-        $content = preg_replace_callback(
-            '@<img\b[^>]*\s*/?>@i',
-            fn (array $matches): string => $this->isGeneratedInlineSvgSource($this->imageSourceFromMarkup($matches[0])) ? '' : $matches[0],
-            $content
-        ) ?? $content;
-        return $this->richTextRequiresHtmlFallback($content);
-    }
-
-    private function richTextContainsNativeSvgImageObject(string $content): bool
-    {
-        if ( ! preg_match_all('@<img\b[^>]*\s*/?>@i', $content, $matches) ) {
-            return false;
-        }
-
-        foreach ( $matches[0] as $markup ) {
-            if ( $this->isGeneratedInlineSvgSource($this->imageSourceFromMarkup($markup)) ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function imageSourceFromMarkup(string $markup): string
-    {
-        return preg_match('/\bsrc\s*=\s*(["\'])(.*?)\1/i', $markup, $matches)
-            ? html_entity_decode($matches[2], ENT_QUOTES | ENT_HTML5, 'UTF-8')
-            : '';
-    }
-
-    private function isGeneratedInlineSvgSource(string $source): bool
-    {
-        return $this->materializedAssets()->hasInlineSvgSource($source);
-    }
-
-    private function stripDecorativeSvgFromRichText(string $content): string
-    {
-        $content = preg_replace('/<(?:span|i|b)\b(?=[^>]*\baria-hidden\s*=\s*(["\'])true\1)[^>]*>\s*<svg\b[\s\S]*?<\/svg>\s*<\/(?:span|i|b)>\s*/i', '', $content) ?? $content;
-
-        return preg_replace('/<svg\b(?=[^>]*\baria-hidden\s*=\s*(["\'])true\1)[\s\S]*?<\/svg>\s*/i', '', $content) ?? $content;
     }
 
     private function inlineTokenGroupBlockFromElement(DOMElement $element, array &$fallbacks): ?array
@@ -6193,8 +5918,8 @@ final class HtmlCompilation implements SourceBlockCreator
             }
         }
 
-        $content = $this->richTextContentWithMaterializedInlineStyles($element);
-        if ( '' === trim($this->runtime->stripAllTags($content)) || $this->richTextRequiresHtmlFallback($content) ) {
+        $content = $this->richTextMaterializer->content($element);
+        if ( '' === trim($this->runtime->stripAllTags($content)) || $this->richTextMaterializer->requiresHtmlFallback($content) ) {
             return null;
         }
 
@@ -6342,7 +6067,7 @@ final class HtmlCompilation implements SourceBlockCreator
             return $this->createBlock('core/group', $this->styleResolver->presentationAttributes($element), $structuredInlineItems, $element);
         }
 
-        $content = $this->richTextContentWithMaterializedInlineStyles($element);
+        $content = $this->richTextMaterializer->content($element);
         if ( '' === trim($this->runtime->stripAllTags($content)) ) {
             return null;
         }
@@ -6378,12 +6103,12 @@ final class HtmlCompilation implements SourceBlockCreator
             return null;
         }
 
-        $content = $this->richTextContentWithMaterializedInlineStyles($element);
-        $inlineSvgContent = $this->richTextContentWithMaterializedSvgImages($element, $content);
+        $content = $this->richTextMaterializer->content($element);
+        $inlineSvgContent = $this->richTextMaterializer->contentWithMaterializedSvgImages($element, $content);
         if ( null !== $inlineSvgContent ) {
             $content = $inlineSvgContent;
         }
-        if ( '' === trim($this->runtime->stripAllTags($content)) || $this->richTextRequiresHtmlFallbackWithoutNativeSvgImageObjects($content) ) {
+        if ( '' === trim($this->runtime->stripAllTags($content)) || $this->richTextMaterializer->requiresHtmlFallbackWithoutNativeSvgImageObjects($content) ) {
             return null;
         }
 
@@ -8573,7 +8298,7 @@ final class HtmlCompilation implements SourceBlockCreator
 
     private function metadataCellContent(DOMElement $element): string
     {
-        $content = $this->richTextContentWithMaterializedInlineStyles($element);
+        $content = $this->richTextMaterializer->content($element);
         if ( in_array(strtolower($element->tagName), array( 'dt', 'b', 'strong' ), true) ) {
             return '<strong>' . $content . '</strong>';
         }
@@ -8722,7 +8447,7 @@ final class HtmlCompilation implements SourceBlockCreator
             }
         }
 
-        return $this->richTextContentWithMaterializedInlineStyles($content);
+        return $this->richTextMaterializer->content($content);
     }
 
     /**
@@ -8793,7 +8518,7 @@ final class HtmlCompilation implements SourceBlockCreator
                 return false;
             }
 
-            if ( $this->sourceElementClassifier->hasBlockContentChildren($child) || $this->richTextContentHasStructuralHtml($this->innerHtml($child)) ) {
+            if ( $this->sourceElementClassifier->hasBlockContentChildren($child) || $this->richTextMaterializer->hasStructuralHtml($this->innerHtml($child)) ) {
                 return false;
             }
 
@@ -9378,7 +9103,7 @@ final class HtmlCompilation implements SourceBlockCreator
 
         $attrs = array_filter(array_merge($this->styleResolver->presentationAttributes($anchor), array(
             'href'               => $href,
-            'fileName'           => $this->richTextContentWithMaterializedInlineStyles($anchor),
+            'fileName'           => $this->richTextMaterializer->content($anchor),
             'textLinkHref'       => $href,
             'showDownloadButton' => $anchor->hasAttribute('download'),
         )), static fn (mixed $value): bool => is_bool($value) ? true : '' !== $value);

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonPatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonPatternContext.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\RichText\RichTextMaterialization;
 use Closure;
 use DOMElement;
 
@@ -11,8 +12,6 @@ final class ButtonPatternContext
     /**
      * @param Closure(DOMElement): ?array<string, mixed> $fileBlockFromAnchor
      * @param Closure(DOMElement): string $resolvedStyle
-     * @param Closure(DOMElement): string $richText
-     * @param Closure(DOMElement, string): ?string $materializeSvgImages
      * @param Closure(DOMElement, string): string $attribute
      * @param Closure(DOMElement): bool $isGridItem
      * @param Closure(DOMElement): PatternRecognitionResult $accessibleNameFallback
@@ -20,8 +19,7 @@ final class ButtonPatternContext
     public function __construct(
         private readonly Closure $fileBlockFromAnchor,
         private readonly Closure $resolvedStyle,
-        private readonly Closure $richText,
-        private readonly Closure $materializeSvgImages,
+        private readonly RichTextMaterialization $richTextMaterializer,
         private readonly Closure $attribute,
         private readonly Closure $isGridItem,
         private readonly Closure $accessibleNameFallback
@@ -30,8 +28,8 @@ final class ButtonPatternContext
 
     public function fileBlockFromAnchor(DOMElement $anchor): ?array { return ($this->fileBlockFromAnchor)($anchor); }
     public function resolvedStyle(DOMElement $element): string { return ($this->resolvedStyle)($element); }
-    public function richText(DOMElement $element): string { return ($this->richText)($element); }
-    public function materializeSvgImages(DOMElement $element, string $content): ?string { return ($this->materializeSvgImages)($element, $content); }
+    public function richText(DOMElement $element): string { return $this->richTextMaterializer->content($element); }
+    public function materializeSvgImages(DOMElement $element, string $content): ?string { return $this->richTextMaterializer->contentWithMaterializedSvgImages($element, $content); }
     public function attribute(DOMElement $element, string $name): string { return ($this->attribute)($element, $name); }
     public function isGridItem(DOMElement $element): bool { return ($this->isGridItem)($element); }
     public function accessibleNameFallback(DOMElement $anchor): PatternRecognitionResult { return ($this->accessibleNameFallback)($anchor); }

--- a/php-transformer/src/HtmlToBlocks/Patterns/LogoPatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/LogoPatternContext.php
@@ -3,21 +3,17 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\RichText\RichTextMaterialization;
 use Closure;
 use DOMElement;
 
 final class LogoPatternContext
 {
-    /**
-     * @param Closure(DOMElement): string $richText
-     * @param Closure(DOMElement, string): ?string $materializeSvgImages
-     */
     public function __construct(
-        private readonly Closure $richText,
-        private readonly Closure $materializeSvgImages
+        private readonly RichTextMaterialization $richTextMaterializer
     ) {
     }
 
-    public function richText(DOMElement $element): string { return ($this->richText)($element); }
-    public function materializeSvgImages(DOMElement $element, string $content): ?string { return ($this->materializeSvgImages)($element, $content); }
+    public function richText(DOMElement $element): string { return $this->richTextMaterializer->content($element); }
+    public function materializeSvgImages(DOMElement $element, string $content): ?string { return $this->richTextMaterializer->contentWithMaterializedSvgImages($element, $content); }
 }

--- a/php-transformer/src/HtmlToBlocks/RichText/RichTextInlinePolicy.php
+++ b/php-transformer/src/HtmlToBlocks/RichText/RichTextInlinePolicy.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\RichText;
+
+use DOMElement;
+
+interface RichTextInlinePolicy
+{
+    public function richTextMarker(DOMElement $element): string;
+
+    public function retainsEmptyRichTextInline(DOMElement $element): bool;
+}

--- a/php-transformer/src/HtmlToBlocks/RichText/RichTextMaterialization.php
+++ b/php-transformer/src/HtmlToBlocks/RichText/RichTextMaterialization.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\RichText;
+
+use DOMElement;
+
+interface RichTextMaterialization
+{
+    /** @param array<int, string> $excludedTags */
+    public function content(DOMElement $element, array $excludedTags = array()): string;
+
+    public function headingContent(string $content): string;
+
+    public function requiresHtmlFallback(string $content): bool;
+
+    public function hasStructuralHtml(string $content): bool;
+
+    /** @return array<string, string> */
+    public function inlineVisualDeclarations(DOMElement $element): array;
+
+    public function contentWithoutDecorativeSvg(DOMElement $element): string;
+
+    public function contentWithMaterializedSvgImages(DOMElement $element, string $content): ?string;
+
+    public function requiresHtmlFallbackWithoutNativeSvgImageObjects(string $content): bool;
+
+    public function containsNativeSvgImageObject(string $content): bool;
+
+    public function stripDecorativeSvg(string $content): string;
+}

--- a/php-transformer/src/HtmlToBlocks/RichText/RichTextMaterializer.php
+++ b/php-transformer/src/HtmlToBlocks/RichText/RichTextMaterializer.php
@@ -1,0 +1,310 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\RichText;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Session\HtmlTransformerSession;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssValueInspector;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolver;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SvgMaterializer;
+use DOMDocument;
+use DOMElement;
+
+/** Materializes source inline markup into content accepted by block RichText. */
+final class RichTextMaterializer implements RichTextMaterialization
+{
+    public function __construct(
+        private readonly StyleResolver $styleResolver,
+        private readonly SvgMaterializer $svgMaterializer,
+        private readonly HtmlTransformerSession $session,
+        private readonly RichTextInlinePolicy $inlinePolicy
+    ) {
+    }
+
+    /** Convert invalid block wrappers inside a heading into valid RichText breaks. */
+    public function headingContent(string $content): string
+    {
+        if ( ! preg_match('/<\/?(?:div|p)\b/i', $content) ) {
+            return $content;
+        }
+        $content = preg_replace_callback('/<\s*(\/)?\s*(?:div|p)\b[^>]*>/i', static fn (array $match): string => ! empty($match[1]) ? '<br>' : '', $content) ?? $content;
+        return preg_replace('/(?:<br>\s*){2,}/i', '<br>', $content) ?? $content;
+    }
+
+    public function requiresHtmlFallback(string $content): bool
+    {
+        return (bool) preg_match('/<(?:svg|canvas|img|picture|video|audio|iframe|object|embed|input|button|select|textarea|form)\b/i', $content);
+    }
+
+    public function hasStructuralHtml(string $content): bool
+    {
+        return (bool) preg_match('/<(?:address|article|aside|blockquote|details|div|dl|figure|h[1-6]|hr|main|menu|nav|ol|p|pre|section|table|ul)\b/i', $content);
+    }
+
+    /** @param array<int, string> $excludedTags */
+    public function content(DOMElement $element, array $excludedTags = array()): string
+    {
+        $content = array() === $excludedTags ? SourceDom::innerHtml($element) : SourceDom::innerHtmlWithoutTags($element, $excludedTags);
+        if ( '' === $content || ! preg_match('/<(?:span|font|em|i|strong|b|mark|small|sub|sup)\b/i', $content) ) {
+            return $content;
+        }
+
+        $document = new DOMDocument();
+        $previous = libxml_use_internal_errors(true);
+        $loaded   = $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $content . '</body>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        $body = $loaded ? $document->getElementsByTagName('body')->item(0) : null;
+        if ( ! $body instanceof DOMElement ) {
+            return $content;
+        }
+
+        $sourceInlines = array();
+        foreach ( $element->getElementsByTagName('*') as $sourceInline ) {
+            if ( $sourceInline instanceof DOMElement && in_array(strtolower($sourceInline->tagName), array( 'span', 'font', 'em', 'i', 'strong', 'b', 'mark', 'small', 'sub', 'sup' ), true) ) {
+                for ( $parent = $sourceInline->parentNode; $parent instanceof DOMElement && $parent !== $element; $parent = $parent->parentNode ) {
+                    if ( in_array(strtolower($parent->tagName), $excludedTags, true) ) {
+                        continue 2;
+                    }
+                }
+                $sourceInlines[] = $sourceInline;
+            }
+        }
+
+        $targetInlines = array();
+        foreach ( $body->getElementsByTagName('*') as $targetInline ) {
+            if ( $targetInline instanceof DOMElement && in_array(strtolower($targetInline->tagName), array( 'span', 'font', 'em', 'i', 'strong', 'b', 'mark', 'small', 'sub', 'sup' ), true) ) {
+                $targetInlines[] = $targetInline;
+            }
+        }
+
+        foreach ( $targetInlines as $index => $targetInline ) {
+            $sourceInline = $sourceInlines[$index] ?? null;
+            if ( ! $sourceInline instanceof DOMElement ) {
+                continue;
+            }
+
+            if ( '' === trim($sourceInline->textContent ?? '') && 0 === SourceDom::childElementCount($sourceInline) && ! $this->inlinePolicy->retainsEmptyRichTextInline($sourceInline) ) {
+                $targetInline->parentNode?->removeChild($targetInline);
+                continue;
+            }
+
+            $inline = $this->inlineVisualDeclarations($sourceInline);
+            $marker = $this->inlinePolicy->richTextMarker($sourceInline);
+            if ( '' !== $marker ) {
+                $headerCarrier = array_intersect_key($inline, array( 'place-items' => true, 'box-shadow' => true ));
+                if ( array() !== $headerCarrier && SourceDom::hasAncestorTag($sourceInline, array( 'header' )) ) {
+                    $selector = 'mark[style*="--blocks-engine-richtext-marker:' . $marker . '"]'
+                        . ',span[data-blocks-engine-richtext-marker="' . $marker . '"]';
+                    $this->session->generatedSupportStylesheetState()->registerHeaderRichText($marker, $selector . '{' . $this->styleResolver->cssDeclarationString($headerCarrier) . '}');
+                }
+                $inline['--blocks-engine-richtext-marker'] = $marker;
+            }
+            if ( array() === $inline ) {
+                continue;
+            }
+
+            $existing = $this->styleResolver->cssDeclarations(SourceDom::attr($targetInline, 'style'));
+            $targetInline->setAttribute('style', $this->styleResolver->cssDeclarationString(array_merge($inline, $existing)));
+        }
+
+        // Comments are authoring metadata that Gutenberg would expose as visible RichText.
+        $xpath = new \DOMXPath($document);
+        foreach ( $xpath->query('//body//comment()') ?: array() as $comment ) {
+            $comment->parentNode?->removeChild($comment);
+        }
+
+        return SourceDom::innerHtml($body);
+    }
+
+    /** @return array<string, string> */
+    public function inlineVisualDeclarations(DOMElement $element): array
+    {
+        $allowed = array_flip(array(
+            '-webkit-background-clip',
+            '-webkit-text-fill-color',
+            'background',
+            'background-clip',
+            'background-color',
+            'border',
+            'border-bottom',
+            'border-color',
+            'border-left',
+            'border-radius',
+            'border-right',
+            'border-top',
+            'box-shadow',
+            'color',
+            'display',
+            'font-family',
+            'font-size',
+            'font-style',
+            'font-weight',
+            'letter-spacing',
+            'line-height',
+            'height',
+            'max-height',
+            'max-width',
+            'margin',
+            'margin-bottom',
+            'margin-left',
+            'margin-right',
+            'margin-top',
+            'padding',
+            'padding-bottom',
+            'padding-left',
+            'padding-right',
+            'padding-top',
+            'place-items',
+            'text-decoration',
+            'text-transform',
+            'width',
+        ));
+
+        $declarations = $this->styleResolver->cssDeclarations($this->styleResolver->specificityResolvedPresentationStyle($element));
+        if ( 'font' === strtolower($element->tagName) ) {
+            $color = trim(SourceDom::attr($element, 'color'));
+            $face = trim(SourceDom::attr($element, 'face'));
+            $size = trim(SourceDom::attr($element, 'size'));
+            if ( '' !== $color && ! isset($declarations['color']) ) {
+                $declarations['color'] = $color;
+            }
+            if ( '' !== $face && ! isset($declarations['font-family']) ) {
+                $declarations['font-family'] = $face;
+            }
+            $resolvedSize = $this->legacyFontSize($element);
+            if ( '' !== $resolvedSize && ! isset($declarations['font-size']) ) {
+                $declarations['font-size'] = $resolvedSize;
+            }
+        }
+
+        if ( 'transparent' === strtolower((string) ($declarations['-webkit-text-fill-color'] ?? '')) ) {
+            $declarations['color'] = 'transparent';
+        }
+
+        $declarations = array_intersect_key($declarations, $allowed);
+        if ( ! SourceDom::hasAncestorTag($element, array( 'header' )) ) {
+            unset($declarations['box-shadow'], $declarations['place-items']);
+        }
+        if ( in_array(strtolower($element->tagName), array( 'em', 'i' ), true) ) {
+            if ( 'italic' === strtolower((string) ($declarations['font-style'] ?? '')) ) {
+                unset($declarations['font-style']);
+            }
+            if ( 'inherit' === strtolower((string) ($declarations['font-weight'] ?? '')) ) {
+                unset($declarations['font-weight']);
+            }
+            foreach ( array( 'margin', 'margin-bottom', 'margin-left', 'margin-right', 'margin-top', 'padding', 'padding-bottom', 'padding-left', 'padding-right', 'padding-top' ) as $property ) {
+                if ( isset($declarations[$property]) && ! CssValueInspector::isNonZero($declarations[$property]) ) {
+                    unset($declarations[$property]);
+                }
+            }
+        }
+
+        return $declarations;
+    }
+
+    public function contentWithoutDecorativeSvg(DOMElement $element): string
+    {
+        return $this->stripDecorativeSvg(SourceDom::innerHtml($element));
+    }
+
+    public function contentWithMaterializedSvgImages(DOMElement $element, string $content): ?string
+    {
+        if ( 0 === $element->getElementsByTagName('svg')->length ) {
+            return $content;
+        }
+
+        $generatedAssets = $this->session->assetMaterializationState()->checkpoint();
+        foreach ( $element->getElementsByTagName('svg') as $svg ) {
+            if ( ! $svg instanceof DOMElement ) {
+                continue;
+            }
+            $image = $this->svgMaterializer->inlineSvgRichTextImageMarkup($svg, false);
+            if ( null === $image ) {
+                $this->session->assetMaterializationState()->restore($generatedAssets);
+                return null;
+            }
+            // RichText preparation may normalize SVG casing, so DOM serialization
+            // is not a stable replacement key.
+            $replaced = preg_replace('@<svg\b[^>]*>.*?</svg>@is', $image, $content, 1);
+            if ( ! is_string($replaced) || $replaced === $content ) {
+                $this->session->assetMaterializationState()->restore($generatedAssets);
+                return null;
+            }
+            $content = $replaced;
+        }
+
+        return $content;
+    }
+
+    public function requiresHtmlFallbackWithoutNativeSvgImageObjects(string $content): bool
+    {
+        // Generic fallback rejects arbitrary images. Remove only SVG image objects
+        // materialized by this transform before applying that conservative gate.
+        $content = preg_replace_callback(
+            '@<img\b[^>]*\s*/?>@i',
+            fn (array $matches): string => $this->isGeneratedInlineSvgSource($this->imageSourceFromMarkup($matches[0])) ? '' : $matches[0],
+            $content
+        ) ?? $content;
+        return $this->requiresHtmlFallback($content);
+    }
+
+    public function containsNativeSvgImageObject(string $content): bool
+    {
+        if ( ! preg_match_all('@<img\b[^>]*\s*/?>@i', $content, $matches) ) {
+            return false;
+        }
+
+        foreach ( $matches[0] as $markup ) {
+            if ( $this->isGeneratedInlineSvgSource($this->imageSourceFromMarkup($markup)) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function stripDecorativeSvg(string $content): string
+    {
+        $content = preg_replace('/<(?:span|i|b)\b(?=[^>]*\baria-hidden\s*=\s*(["\'])true\1)[^>]*>\s*<svg\b[\s\S]*?<\/svg>\s*<\/(?:span|i|b)>\s*/i', '', $content) ?? $content;
+        return preg_replace('/<svg\b(?=[^>]*\baria-hidden\s*=\s*(["\'])true\1)[\s\S]*?<\/svg>\s*/i', '', $content) ?? $content;
+    }
+
+    private function legacyFontSize(DOMElement $element): string
+    {
+        $sizes = array('1' => '10px', '2' => '13px', '3' => '16px', '4' => '18px', '5' => '24px', '6' => '32px', '7' => '48px');
+        $level = 3;
+        $found = false;
+        $fonts = array();
+        for ( $node = $element; $node instanceof DOMElement; $node = $node->parentNode instanceof DOMElement ? $node->parentNode : null ) {
+            if ( 'font' === strtolower($node->tagName) ) {
+                $fonts[] = $node;
+            }
+        }
+        foreach ( array_reverse($fonts) as $font ) {
+            $size = trim(SourceDom::attr($font, 'size'));
+            if ( preg_match('/^[1-7]$/', $size) ) {
+                $level = (int) $size;
+                $found = true;
+            } elseif ( preg_match('/^[+-]\d+$/', $size) ) {
+                $level = min(7, max(1, $level + (int) $size));
+                $found = true;
+            }
+        }
+        return $found ? $sizes[(string) $level] : '';
+    }
+
+    private function imageSourceFromMarkup(string $markup): string
+    {
+        return preg_match('/\bsrc\s*=\s*(["\'])(.*?)\1/i', $markup, $matches)
+            ? html_entity_decode($matches[2], ENT_QUOTES | ENT_HTML5, 'UTF-8')
+            : '';
+    }
+
+    private function isGeneratedInlineSvgSource(string $source): bool
+    {
+        return $this->session->assetMaterializationState()->hasInlineSvgSource($source);
+    }
+}

--- a/php-transformer/tests/Support/RichTextMaterializationFixture.php
+++ b/php-transformer/tests/Support/RichTextMaterializationFixture.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\Tests\Support;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\RichText\RichTextMaterialization;
+use Closure;
+use DOMElement;
+
+final class RichTextMaterializationFixture implements RichTextMaterialization
+{
+    /** @param array<string, Closure> $operations */
+    public function __construct(private readonly array $operations = array()) {}
+
+    /** @param array<int, string> $excludedTags */
+    public function content(DOMElement $element, array $excludedTags = array()): string { return isset($this->operations['content']) ? ($this->operations['content'])($element, $excludedTags) : (string) $element->textContent; }
+    public function headingContent(string $content): string { return isset($this->operations['headingContent']) ? ($this->operations['headingContent'])($content) : $content; }
+    public function requiresHtmlFallback(string $content): bool { return isset($this->operations['requiresHtmlFallback']) && ($this->operations['requiresHtmlFallback'])($content); }
+    public function hasStructuralHtml(string $content): bool { return isset($this->operations['hasStructuralHtml']) && ($this->operations['hasStructuralHtml'])($content); }
+    public function inlineVisualDeclarations(DOMElement $element): array { return isset($this->operations['inlineVisualDeclarations']) ? ($this->operations['inlineVisualDeclarations'])($element) : array(); }
+    public function contentWithoutDecorativeSvg(DOMElement $element): string { return $this->content($element); }
+    public function contentWithMaterializedSvgImages(DOMElement $element, string $content): ?string { return isset($this->operations['contentWithMaterializedSvgImages']) ? ($this->operations['contentWithMaterializedSvgImages'])($element, $content) : $content; }
+    public function requiresHtmlFallbackWithoutNativeSvgImageObjects(string $content): bool { return $this->requiresHtmlFallback($content); }
+    public function containsNativeSvgImageObject(string $content): bool { return isset($this->operations['containsNativeSvgImageObject']) && ($this->operations['containsNativeSvgImageObject'])($content); }
+    public function stripDecorativeSvg(string $content): string { return $content; }
+}

--- a/php-transformer/tests/unit/inline-content-element-converter.php
+++ b/php-transformer/tests/unit/inline-content-element-converter.php
@@ -9,6 +9,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\InlineContentEl
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolver;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\RichTextMaterializationFixture;
 
 $assertions = 0;
 $failures = array();
@@ -39,7 +40,7 @@ $context = new InlineContentElementContext(
     static fn (DOMElement $element): bool => 'positioned' === $state->mode,
     static fn (DOMElement $element, array &$fallbacks): ?array => array( 'blockName' => 'core/group', 'attrs' => array( 'positioned' => true ) ),
     static fn (DOMElement $element): bool => false,
-    static fn (string $content): bool => false,
+    new RichTextMaterializationFixture(),
     static fn (DOMElement $element, array &$fallbacks, bool $captureUnsupported): array => array(),
     new SourceBlockCreatorFixture(static fn (string $name, array $attributes, array $innerBlocks, ?DOMElement $sourceElement): array => array(
         'blockName' => $name,
@@ -48,7 +49,6 @@ $context = new InlineContentElementContext(
         'sourceTag' => $sourceElement?->tagName,
     )),
     static fn (DOMElement $element): string => '',
-    static fn (DOMElement $element): array => array(),
     static fn (DOMElement $element): ?string => null,
     static fn (DOMElement $element, string $tagName): ?DOMElement => null,
     static fn (DOMElement $element): bool => false,

--- a/php-transformer/tests/unit/list-element-converters.php
+++ b/php-transformer/tests/unit/list-element-converters.php
@@ -10,6 +10,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ListElementCont
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\ListElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
 use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\RichTextMaterializationFixture;
 
 $assertions = 0;
 $failures = array();
@@ -85,7 +86,7 @@ $descriptionContext = new DescriptionListElementContext(
     new ElementPresentationResolverFixture(static fn (DOMElement $element): array => array( 'className' => 'presented-' . strtolower($element->tagName) )),
     static fn (DOMElement $element, array &$fallbacks, bool $capture): array => 'empty' === $state->mode ? array() : array( array( 'blockName' => 'core/paragraph' ) ),
     $createBlock,
-    static fn (DOMElement $element): string => $element->textContent ?? '',
+    new RichTextMaterializationFixture(array( 'content' => static fn (DOMElement $element): string => $element->textContent ?? '' )),
     static fn (string $text): bool => '' !== trim(strip_tags($text))
 );
 $descriptionConverter = new DescriptionListElementConverter($descriptionContext);

--- a/php-transformer/tests/unit/rich-text-element-converter.php
+++ b/php-transformer/tests/unit/rich-text-element-converter.php
@@ -17,6 +17,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RichTextElement
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\RichTextElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
 use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\RichTextMaterializationFixture;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
 $assertions = 0;
@@ -57,11 +58,13 @@ $makeConverter = static function (array $overrides = array()): RichTextElementCo
     return new RichTextElementConverter(new RichTextElementContext(
         new ElementPresentationResolverFixture($c['presentationAttributes']),
         $c['createBlock'],
-        $c['richTextContent'],
-        $c['headingRichTextContent'],
-        $c['richTextWithMaterializedSvgImages'],
-        $c['requiresHtmlFallback'],
-        $c['containsNativeSvgImageObject'],
+        new RichTextMaterializationFixture(array(
+            'content' => $c['richTextContent'],
+            'headingContent' => $c['headingRichTextContent'],
+            'contentWithMaterializedSvgImages' => $c['richTextWithMaterializedSvgImages'],
+            'requiresHtmlFallback' => $c['requiresHtmlFallback'],
+            'containsNativeSvgImageObject' => $c['containsNativeSvgImageObject'],
+        )),
         $c['htmlPreservationBlock'],
         $c['authoredMarqueeBlock'],
         $c['hasEmptyVisualInlineChild'],

--- a/php-transformer/tests/unit/rich-text-svg-transaction.php
+++ b/php-transformer/tests/unit/rich-text-svg-transaction.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$result = ( new HtmlTransformer() )->transform(
+    '<p>One <svg viewBox="0 0 1 1"><path d="M0 0h1v1z"/></svg> Two <svg><script>alert(1)</script></svg></p>'
+)->toArray();
+
+$failures = array();
+if ( 'core/html' !== ($result['blocks'][0]['blockName'] ?? '') ) {
+    $failures[] = 'RichText with an unsafe later SVG falls back to core/html.';
+}
+if ( array() !== ($result['assets'] ?? array()) ) {
+    $failures[] = 'A failed later SVG restores assets materialized for earlier RichText SVGs.';
+}
+if ( ! str_contains((string) ($result['blocks'][0]['attrs']['content'] ?? ''), '<svg') ) {
+    $failures[] = 'Fallback content retains the source SVG markup.';
+}
+
+if ( array() !== $failures ) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo "RichText SVG transaction contract passed.\n";

--- a/php-transformer/tests/unit/text-leaf-element-converter.php
+++ b/php-transformer/tests/unit/text-leaf-element-converter.php
@@ -17,6 +17,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TextLeafElement
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Elements\TextLeafElementConverter;
 use Automattic\BlocksEngine\PhpTransformer\Tests\Support\ElementPresentationResolverFixture;
 use Automattic\BlocksEngine\PhpTransformer\Tests\Support\SourceBlockCreatorFixture;
+use Automattic\BlocksEngine\PhpTransformer\Tests\Support\RichTextMaterializationFixture;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
 $assertions = 0;
@@ -61,7 +62,7 @@ $makeConverter = static function (array $overrides = array()): TextLeafElementCo
         new SourceElementClassifier(),
         new ElementPresentationResolverFixture($c['presentationAttributes']),
         $c['createBlock'],
-        $c['richTextContent'],
+        new RichTextMaterializationFixture(array( 'content' => $c['richTextContent'] )),
         new Runtime(),
         $c['codePresentationAttributes'],
         $c['codeContent'],


### PR DESCRIPTION
## Summary
- extract RichText serialization, inline presentation, fallback detection, and inline-SVG materialization from `HtmlCompilation` into a focused `RichTextMaterializer`
- replace 13 stored RichText closures and 15 composition-root adapters across element and pattern contexts with one typed `RichTextMaterialization` capability
- retain the two compilation-owned inline decisions behind a narrow `RichTextInlinePolicy` boundary
- add an end-to-end regression proving failed later SVG materialization rolls back earlier generated assets

`HtmlCompilation` loses 275 lines and 17 arrow functions while preserving the existing conversion algorithms and session lifecycle.

## Verification
- `composer test`
- 292 PHP transformer parity fixtures
- 385 serialized-block fixture hashes identical to `origin/trunk` (`0f13fbfc`), with 0 exceptions
- namespace resolution: 252 class-likes, 0 unresolved references
- RichText SVG transaction contract
- `git diff --check`
- Homeboy architecture audit: 0 introduced findings

## AI assistance
OpenAI GPT-5.6 Sol was used through OpenCode to map the RichText dependency graph, extract and review the collaborator, add transaction coverage, and run verification. The resulting diff and evidence were reviewed by the operator.