### PR TITLE
Preserve materialized SVG text baselines

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
@@ -2365,6 +2365,7 @@ final class StyleResolver implements ElementPresentationResolver
         $safe = array_flip(array(
             '-webkit-background-clip',
             '-webkit-text-fill-color',
+            'alignment-baseline',
             'background',
             'background-attachment',
             'background-clip',
@@ -2375,6 +2376,7 @@ final class StyleResolver implements ElementPresentationResolver
             'background-repeat',
             'background-size',
             'aspect-ratio',
+            'baseline-shift',
             'border',
             'border-bottom',
             'border-bottom-color',
@@ -2409,6 +2411,7 @@ final class StyleResolver implements ElementPresentationResolver
             'column-gap',
             'direction',
             'display',
+            'dominant-baseline',
             'flex-direction',
             'flex-flow',
             'flex',
@@ -2462,7 +2465,7 @@ final class StyleResolver implements ElementPresentationResolver
 
     /**
      * The subset of a declaration map needed to resolve values outside the
-     * classification allow-list: inheritable SVG paint and custom properties.
+     * classification allow-list: SVG paint/layout and custom properties.
      * Keeping this stream separate lets SVG materialization and structural
      * `var()` resolution share the real matched cascade without changing
      * general classification.
@@ -2472,7 +2475,7 @@ final class StyleResolver implements ElementPresentationResolver
      */
     private function cascadeRelevantDeclarations(array $declarations): array
     {
-        static $paintProperties = array(
+        static $cascadeProperties = array(
             'color' => true,
             'fill' => true,
             'fill-opacity' => true,
@@ -2483,7 +2486,7 @@ final class StyleResolver implements ElementPresentationResolver
 
         $filtered = array();
         foreach ( $declarations as $name => $value ) {
-            if ( str_starts_with($name, '--') || isset($paintProperties[$name]) ) {
+            if ( str_starts_with($name, '--') || isset($cascadeProperties[$name]) ) {
                 $filtered[$name] = $value;
             }
         }
@@ -2980,6 +2983,21 @@ final class StyleResolver implements ElementPresentationResolver
         return false === strpos($declared, 'var(')
             ? $declared
             : $this->expandCssVariableReferences($declared, $this->cascadedCustomProperties($element));
+    }
+
+    public function specificityResolvedSvgCascadeValue(DOMElement $element, string $property): ?string
+    {
+        if ( ! in_array($property, array('alignment-baseline', 'baseline-shift', 'dominant-baseline'), true) ) {
+            return null;
+        }
+
+        $declared = trim((string) ($this->cssDeclarations($this->specificityResolvedPresentationStyle($element))[$property] ?? ''));
+        $declared = trim(preg_replace('/\s*!\s*important\s*$/i', '', $declared) ?? $declared);
+        if ( '' === $declared ) {
+            return null;
+        }
+
+        return $declared;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializer.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializer.php
@@ -61,7 +61,8 @@ final class SvgMaterializer implements SvgElementMaterializer
         $html = $this->cssOwnsMediaBox($element)
             ? $this->ensureInlineSvgBoxStyle($html, $element)
             : $this->ensureInlineSvgSizing($html, $element);
-        $html = $this->restoreSvgCasing($this->inlineSvgMaterializationMarkup($this->resolveMaterializedSvgColors($html, $element), $element));
+        $html = $this->bakeCascadedSvgTextLayout($this->resolveMaterializedSvgColors($html, $element), $element);
+        $html = $this->restoreSvgCasing($this->inlineSvgMaterializationMarkup($html, $element));
         $imageBlock = $this->inlineSvgImageBlockFromMarkup($element, $html);
         if ( null !== $imageBlock ) {
             return $imageBlock;
@@ -224,7 +225,8 @@ final class SvgMaterializer implements SvgElementMaterializer
         $html = $this->cssOwnsMediaBox($element)
             ? $this->ensureInlineSvgBoxStyle($html, $element)
             : $this->ensureInlineSvgSizing($html, $element);
-        $html = $this->restoreSvgCasing($this->inlineSvgMaterializationMarkup($this->resolveMaterializedSvgColors($html, $element), $element));
+        $html = $this->bakeCascadedSvgTextLayout($this->resolveMaterializedSvgColors($html, $element), $element);
+        $html = $this->restoreSvgCasing($this->inlineSvgMaterializationMarkup($html, $element));
         $attrs = $this->inlineSvgImageAttributesFromMarkup($element, $html, true);
         if ( null === $attrs ) {
             return null;
@@ -543,6 +545,85 @@ final class SvgMaterializer implements SvgElementMaterializer
         }
 
         return array() === $paint ? $html : $this->mergeSvgRootStyleDeclarations($html, $paint);
+    }
+
+    /**
+     * Text baseline rules from the host stylesheet cannot cross the standalone
+     * SVG image boundary. Preserve the resolved per-node layout in source order.
+     */
+    private function bakeCascadedSvgTextLayout(string $html, DOMElement $element): string
+    {
+        $sourceTexts = array_values(array_filter(
+            iterator_to_array($element->getElementsByTagName('text')),
+            static fn (DOMNode $node): bool => $node instanceof DOMElement
+        ));
+        if ( array() === $sourceTexts || false === stripos($html, '<text') ) {
+            return $html;
+        }
+
+        $index = 0;
+        return preg_replace_callback('/<text\b[^>]*>/i', function (array $match) use ($element, $sourceTexts, &$index): string {
+            $source = $sourceTexts[$index++] ?? null;
+            if ( ! $source instanceof DOMElement ) {
+                return $match[0];
+            }
+
+            $declarations = array();
+            foreach ( array('dominant-baseline', 'alignment-baseline', 'baseline-shift') as $property ) {
+                $value = $this->resolvedCascadedSvgTextLayout($source, $property);
+                if ( '' !== $value && 1 !== preg_match('/(?:var\s*\(|url\s*\(|[<>])/i', $value) ) {
+                    $declarations[$property] = $value;
+                }
+            }
+
+            return array() === $declarations ? $match[0] : $this->mergeSvgTagStyleDeclarations($match[0], $declarations);
+        }, $html) ?? $html;
+    }
+
+    private function resolvedCascadedSvgTextLayout(DOMElement $element, string $property): string
+    {
+        for ( $current = $element; $current instanceof DOMElement; $current = $current->parentNode instanceof DOMElement ? $current->parentNode : null ) {
+            $value = trim((string) ($this->styleResolver->specificityResolvedSvgCascadeValue($current, $property) ?? ''));
+            if ( '' !== $value ) {
+                if ( false !== strpos($value, 'var(') ) {
+                    return '';
+                }
+                $keyword = strtolower($value);
+                if ( in_array($keyword, array('inherit', 'unset'), true) ) {
+                    continue;
+                }
+                return in_array($keyword, array('initial', 'revert', 'revert-layer'), true) ? '' : $value;
+            }
+            $attribute = trim(SourceDom::attr($current, $property));
+            if ( '' !== $attribute ) {
+                if ( $current->isSameNode($element) ) {
+                    return '';
+                }
+                $keyword = strtolower($attribute);
+                if ( in_array($keyword, array('inherit', 'unset'), true) ) {
+                    continue;
+                }
+                return in_array($keyword, array('initial', 'revert', 'revert-layer'), true) ? '' : $attribute;
+            }
+        }
+
+        return '';
+    }
+
+    /** @param array<string, string> $declarations */
+    private function mergeSvgTagStyleDeclarations(string $tag, array $declarations): string
+    {
+        $existing = '';
+        if ( preg_match('/\sstyle\s*=\s*(["\'])(.*?)\1/i', $tag, $styleMatch) ) {
+            $existing = html_entity_decode($styleMatch[2], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        }
+
+        $style = $this->styleResolver->cssDeclarationString(array_merge($this->styleResolver->cssDeclarations($existing), $declarations));
+        $escaped = htmlspecialchars($style, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+        return preg_match('/\sstyle\s*=\s*(["\'])(.*?)\1/i', $tag)
+            ? (preg_replace('/(\sstyle\s*=\s*)(["\'])(.*?)\2/i', '$1$2' . $escaped . '$2', $tag, 1) ?? $tag)
+            : (preg_replace('/>$/', ' style="' . $escaped . '">', $tag, 1) ?? $tag);
     }
 
     private function resolvedCascadedSvgPaint(DOMElement $element, string $property): ?string

--- a/php-transformer/tests/unit/svg-materialized-paint-cascade.php
+++ b/php-transformer/tests/unit/svg-materialized-paint-cascade.php
@@ -98,4 +98,40 @@ $currentColorAssets = $inlineSvgAssets($currentColorResult);
 $assert(1 === count($currentColorAssets), 'A currentColor shape materializes one asset.');
 $assert(str_contains((string) ($currentColorAssets[0]['content'] ?? ''), '#123456') && ! str_contains((string) ($currentColorAssets[0]['content'] ?? ''), 'currentColor'), 'currentColor is resolved against the ancestor-declared color and baked in, rather than left to fail closed in the isolated asset document.');
 
+$textBaseline = '<style>.text-mask text{dominant-baseline:text-before-edge}</style>
+<main><svg class="text-mask" viewBox="0 0 165 140"><defs><clipPath id="label"><text x="0" y="0em">Let’s</text><text x="0" y="1em">talk</text></clipPath></defs><g><text x="0" y="0em">Let’s</text><text x="0" y="1em">talk</text></g></svg></main>';
+$textBaselineResult = (new HtmlTransformer())->transform($textBaseline)->toArray();
+$textBaselineAssets = $inlineSvgAssets($textBaselineResult);
+$textBaselineContent = (string) ($textBaselineAssets[0]['content'] ?? '');
+$assert(1 === count($textBaselineAssets) && 'core/image' === ($textBaselineResult['blocks'][0]['blockName'] ?? null), 'A stylesheet-positioned text SVG remains an editor-native materialized image.');
+$assert(4 === substr_count($textBaselineContent, 'dominant-baseline:text-before-edge'), 'Resolved text baseline layout is baked into every matching node in the standalone SVG asset.');
+
+$inheritedBaseline = (new HtmlTransformer())->transform('<style>.text-mask{dominant-baseline:hanging}</style><svg class="text-mask" viewBox="0 0 20 20"><text y="0">Label</text></svg>')->toArray();
+$inheritedBaselineContent = (string) ($inlineSvgAssets($inheritedBaseline)[0]['content'] ?? '');
+$assert(str_contains($inheritedBaselineContent, '<text y="0" style="dominant-baseline:hanging">'), 'An inherited baseline declaration is carried from the source SVG root to its standalone text node.');
+
+$specificBaseline = (new HtmlTransformer())->transform('<style>#mask text{dominant-baseline:alphabetic}.late text{dominant-baseline:hanging}</style><svg id="mask" class="late" viewBox="0 0 20 20"><text y="0">Label</text></svg>')->toArray();
+$specificBaselineContent = (string) ($inlineSvgAssets($specificBaseline)[0]['content'] ?? '');
+$assert(str_contains($specificBaselineContent, 'dominant-baseline:alphabetic') && ! str_contains($specificBaselineContent, 'dominant-baseline:hanging'), 'The strongest matching baseline selector wins regardless of source order.');
+
+$importantBaseline = (new HtmlTransformer())->transform('<style>.late text{dominant-baseline:hanging!important}#mask text{dominant-baseline:alphabetic}</style><svg id="mask" class="late" viewBox="0 0 20 20"><text y="0">Label</text></svg>')->toArray();
+$importantBaselineContent = (string) ($inlineSvgAssets($importantBaseline)[0]['content'] ?? '');
+$assert(str_contains($importantBaselineContent, 'dominant-baseline:hanging') && ! str_contains($importantBaselineContent, 'dominant-baseline:alphabetic'), 'An important baseline declaration wins before selector specificity.');
+
+$explicitBaseline = (new HtmlTransformer())->transform('<style>.mask{dominant-baseline:hanging}</style><svg class="mask" viewBox="0 0 20 20"><text y="0" dominant-baseline="alphabetic">Label</text></svg>')->toArray();
+$explicitBaselineContent = (string) ($inlineSvgAssets($explicitBaseline)[0]['content'] ?? '');
+$assert(str_contains($explicitBaselineContent, 'dominant-baseline="alphabetic"') && ! str_contains($explicitBaselineContent, 'dominant-baseline:hanging'), 'A descendant presentation attribute wins over an inherited baseline declaration.');
+
+$variableBaseline = (new HtmlTransformer())->transform('<style>#mask{--baseline:alphabetic}.late{--baseline:hanging}.late text{dominant-baseline:var(--baseline)}</style><svg id="mask" class="late" viewBox="0 0 20 20"><text y="0">Label</text></svg>')->toArray();
+$variableBaselineContent = (string) ($inlineSvgAssets($variableBaseline)[0]['content'] ?? '');
+$assert(! str_contains($variableBaselineContent, 'dominant-baseline:'), 'An unresolved custom-property cascade is not baked as an incorrect baseline winner.');
+
+$blockedInheritance = (new HtmlTransformer())->transform('<style>.mask{dominant-baseline:hanging}</style><svg class="mask" viewBox="0 0 20 20"><text y="0" style="dominant-baseline:var(--baseline)">Label</text></svg>')->toArray();
+$blockedInheritanceContent = (string) ($inlineSvgAssets($blockedInheritance)[0]['content'] ?? '');
+$assert(! str_contains($blockedInheritanceContent, 'dominant-baseline:hanging'), 'An unresolved descendant declaration blocks an ancestor baseline from being baked over it.');
+
+$pageInheritedBaseline = (new HtmlTransformer())->transform('<style>main{dominant-baseline:hanging}</style><main><svg viewBox="0 0 20 20"><text y="0">Label</text></svg></main>')->toArray();
+$pageInheritedBaselineContent = (string) ($inlineSvgAssets($pageInheritedBaseline)[0]['content'] ?? '');
+$assert(str_contains($pageInheritedBaselineContent, 'dominant-baseline:hanging'), 'Baseline inheritance from outside the SVG is baked into the standalone text node.');
+
 fwrite(STDOUT, 'SVG materialized paint cascade tests: ' . $assertions . " passed\n");


### PR DESCRIPTION
## Summary

- resolve SVG descendant text presentation before materialization
- bake inherited and selector-resolved baseline declarations into generated SVG text
- preserve specificity, `!important`, explicit attributes, and unresolved variables

Fixes #1533.

## Verification

- full PHP transformer suite passes
- LaTonia Hope `LET’S TALK` SVG retains baked font size, family, weight, style, anchor, decoration, and transform declarations
- combined WordPress import has zero fallback, HTML, missing, or invalid blocks

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode was used to trace the SVG cascade loss, implement and test baseline materialization, and verify the generated WordPress result.
