### PR TITLE
Preserve external SVG media masks

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Classification/SourceElementClassifier.php
+++ b/php-transformer/src/HtmlToBlocks/Classification/SourceElementClassifier.php
@@ -30,6 +30,8 @@ use DOMElement;
  */
 final class SourceElementClassifier
 {
+    private const MAX_SVG_FRAGMENT_DEPENDENCY_CANDIDATES = 512;
+
     public function hasRepeatedDirectChildTags(DOMElement $element): bool
     {
         $counts = array();
@@ -112,6 +114,91 @@ final class SourceElementClassifier
         }
 
         return $items >= 2;
+    }
+
+    public function hasExternalSvgFragmentDependencyBoundary(DOMElement $element): bool
+    {
+        $candidates = array($element);
+        foreach ( $element->getElementsByTagName('*') as $candidate ) {
+            if ( $candidate instanceof DOMElement ) {
+                $candidates[] = $candidate;
+                if ( count($candidates) > self::MAX_SVG_FRAGMENT_DEPENDENCY_CANDIDATES ) {
+                    return false;
+                }
+            }
+        }
+
+        $definitions = array();
+        $definitionSvgs = array();
+        $ambiguousIds = array();
+        foreach ( $candidates as $svg ) {
+            if ( 'svg' !== strtolower($svg->tagName) ) {
+                continue;
+            }
+            foreach ( $svg->getElementsByTagName('*') as $definition ) {
+                if ( ! $definition instanceof DOMElement ) {
+                    continue;
+                }
+                $id = trim(SourceDom::attr($definition, 'id'));
+                if ( '' === $id || isset($ambiguousIds[$id]) ) {
+                    continue;
+                }
+                if ( isset($definitions[$id]) ) {
+                    unset($definitions[$id], $definitionSvgs[$id]);
+                    $ambiguousIds[$id] = true;
+                    continue;
+                }
+                $definitions[$id] = $definition;
+                $definitionSvgs[$id] = $svg;
+            }
+        }
+
+        foreach ( $candidates as $candidate ) {
+            if ( $this->nearestAncestorSvg($candidate) instanceof DOMElement ) {
+                continue;
+            }
+            $references = array();
+            foreach ( array('clip-path', 'filter', 'fill', 'mask', 'marker', 'marker-end', 'marker-mid', 'marker-start', 'stroke', 'style') as $attributeName ) {
+                $references = array_merge($references, $this->localSvgFragmentReferences(SourceDom::attr($candidate, $attributeName)));
+            }
+            foreach ( array_unique($references) as $id ) {
+                if ( isset($definitions[$id]) && $this->lowestCommonElementAncestor($definitions[$id], $candidate) === $element ) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /** @return array<int, string> */
+    private function localSvgFragmentReferences(string $value): array
+    {
+        $count = preg_match_all('/url\(\s*["\']?#([A-Za-z_][A-Za-z0-9_.:-]*)["\']?\s*\)/i', $value, $matches);
+        return false === $count || 0 === $count ? array() : $matches[1];
+    }
+
+    private function nearestAncestorSvg(DOMElement $element): ?DOMElement
+    {
+        for ( $current = $element; $current instanceof DOMElement; $current = $current->parentNode ) {
+            if ( 'svg' === strtolower($current->tagName) ) {
+                return $current;
+            }
+        }
+        return null;
+    }
+
+    private function lowestCommonElementAncestor(DOMElement $left, DOMElement $right): ?DOMElement
+    {
+        $leftAncestors = array();
+        for ( $current = $left; $current instanceof DOMElement; $current = $current->parentNode ) {
+            $leftAncestors[spl_object_id($current)] = true;
+        }
+        for ( $current = $right; $current instanceof DOMElement; $current = $current->parentNode ) {
+            if ( isset($leftAncestors[spl_object_id($current)]) ) {
+                return $current;
+            }
+        }
+        return null;
     }
 
     /** @param array<string, string> $declarations */

--- a/php-transformer/src/HtmlToBlocks/Elements/FlowContainerElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FlowContainerElementContext.php
@@ -18,6 +18,7 @@ final class FlowContainerElementContext
         private readonly Closure $recognizePatterns,
         private readonly Closure $flankedSeparatorBlock,
         private readonly Closure $capturedMediaLayoutBlock,
+        private readonly Closure $canCaptureExternalSvgFragmentDependency,
         private readonly SourceElementClassifier $sourceElementClassifier,
         private readonly Closure $responsiveMediaBlock,
         private readonly Closure $isDirectChildOfAuthorOwnedLayout,
@@ -64,6 +65,7 @@ final class FlowContainerElementContext
     public function flankedSeparatorBlock(DOMElement $element): ?array { return ($this->flankedSeparatorBlock)($element); }
     /** @return array<string, mixed>|null */
     public function capturedMediaLayoutBlock(DOMElement $element): ?array { return ($this->capturedMediaLayoutBlock)($element); }
+    public function hasExternalSvgFragmentDependencyBoundary(DOMElement $element): bool { return ($this->canCaptureExternalSvgFragmentDependency)($element) && $this->sourceElementClassifier->hasExternalSvgFragmentDependencyBoundary($element); }
     public function hasResponsiveImageSources(DOMElement $element): bool { return $this->sourceElementClassifier->hasResponsiveImageSources($element); }
     public function hasGalleryMediaItems(DOMElement $element): bool { return $this->sourceElementClassifier->hasGalleryMediaItems($element); }
     /** @return array<string, mixed> */

--- a/php-transformer/src/HtmlToBlocks/Elements/FlowContainerElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FlowContainerElementConverter.php
@@ -68,6 +68,9 @@ final class FlowContainerElementConverter implements ElementConverter
         if ( null !== $block ) {
             return ConversionOutcome::handled($block);
         }
+        if ( $this->context->hasExternalSvgFragmentDependencyBoundary($element) ) {
+            return ConversionOutcome::handled($this->context->responsiveMediaBlock($element));
+        }
 
         if ( $this->context->hasResponsiveImageSources($element) && $this->context->hasGalleryMediaItems($element) ) {
             return ConversionOutcome::handled($this->context->responsiveMediaBlock($element));

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -791,6 +791,7 @@ final class HtmlCompilation
             recognizePatterns: fn (DOMElement $element, array &$fallbacks, array $patterns): ?array => $this->recognizePatterns($element, $fallbacks, $patterns),
             flankedSeparatorBlock: fn (DOMElement $element): ?array => $this->flankedSeparatorBlockFromElement($element),
             capturedMediaLayoutBlock: fn (DOMElement $element): ?array => $this->capturedMediaLayoutBoundaryBlock($element),
+            canCaptureExternalSvgFragmentDependency: fn (DOMElement $element): bool => ! $this->runtimeIslands->isRuntimeDomTarget($element) && ! $this->hasRuntimeTargetInSubtree($element),
             sourceElementClassifier: $this->sourceElementClassifier,
             responsiveMediaBlock: fn (DOMElement $element): array => $this->responsiveMediaBlock($element),
             isDirectChildOfAuthorOwnedLayout: fn (DOMElement $element): bool => $this->isDirectChildOfAuthorOwnedLayout($element),

--- a/php-transformer/tests/unit/flow-container-element-converter.php
+++ b/php-transformer/tests/unit/flow-container-element-converter.php
@@ -40,6 +40,7 @@ $operations = array(
     },
     'flankedSeparatorBlock' => $null,
     'capturedMediaLayoutBlock' => $null,
+    'canCaptureExternalSvgFragmentDependency' => static fn (): bool => true,
     'sourceElementClassifier' => new SourceElementClassifier(),
     'responsiveMediaBlock' => static fn (): array => array( 'blockName' => 'responsive-media' ),
     'isDirectChildOfAuthorOwnedLayout' => $false,

--- a/php-transformer/tests/unit/responsive-media-block.php
+++ b/php-transformer/tests/unit/responsive-media-block.php
@@ -78,6 +78,23 @@ $assert(str_contains($nestedWrappedContent, '<div class="crop"') && str_contains
 $labeledWrapper = ( new HtmlTransformer() )->transform('<a href="/profile"><div><wow-image><img src="profile.png" alt="Profile"></wow-image><span>Profile</span></div></a>')->toArray();
 $assert('custom/responsive-media' !== ($labeledWrapper['blocks'][0]['blockName'] ?? null), 'a linked image wrapper with authored label content is not collapsed into responsive media');
 
+$maskedVideoSource = '<div class="masked-video"><svg viewBox="0 0 600 120"><defs><clipPath id="clip-masked-video"><text x="0" y="0">LET&apos;S TALK</text></clipPath></defs></svg><div class="fill-layers-wrapper" style="clip-path:url(&quot;#clip-masked-video&quot;)"><video src="footer.mp4" autoplay muted loop></video></div></div>';
+$maskedVideo = ( new HtmlTransformer() )->transform($maskedVideoSource)->toArray();
+$maskedVideoBlock = $maskedVideo['blocks'][0] ?? array();
+$maskedVideoContent = (string) ($maskedVideoBlock['attrs']['content'] ?? '');
+$assert('custom/responsive-media' === ($maskedVideoBlock['blockName'] ?? null), 'a Wix-style video and sibling SVG clip definition remain in one captured media boundary');
+$assert(str_contains($maskedVideoContent, '<clippath id="clip-masked-video">') && str_contains($maskedVideoContent, '<video src="footer.mp4" autoplay muted loop>'), 'the captured boundary preserves the SVG definition and media consumer');
+$assert(! str_contains((string) ($maskedVideo['serialized_blocks'] ?? ''), '<!-- wp:html') && 'pass' === ($maskedVideo['source_reports']['wp_block_validity']['status'] ?? null), 'the dependent composition remains valid generated-block markup');
+
+$nestedMask = ( new HtmlTransformer() )->transform('<div><div><svg><defs><clipPath id="nested-mask"><rect width="10" height="10"></rect></clipPath></defs></svg></div><video src="nested.mp4" style="clip-path:url(#nested-mask)"></video></div>')->toArray();
+$assert('custom/responsive-media' === ($nestedMask['blocks'][0]['blockName'] ?? null), 'a nested definition is discovered within the bounded component');
+
+$localMask = ( new HtmlTransformer() )->transform('<div><svg><defs><clipPath id="local-mask"><rect width="10" height="10"></rect></clipPath></defs><g clip-path="url(#local-mask)"></g></svg><video src="plain.mp4"></video></div>')->toArray();
+$assert('custom/responsive-media' !== ($localMask['blocks'][0]['blockName'] ?? null), 'an SVG-local fragment stays on native image materialization');
+
+$mismatchedMask = ( new HtmlTransformer() )->transform('<div><svg><defs><clipPath id="defined-mask"><rect width="10" height="10"></rect></clipPath></defs></svg><video src="plain.mp4" style="clip-path:url(#other-mask)"></video></div>')->toArray();
+$assert('custom/responsive-media' !== ($mismatchedMask['blocks'][0]['blockName'] ?? null), 'a mismatched fragment stays on native conversion paths');
+
 $layoutHtml = '<main class="puffin-story"><div class="shell">';
 for ($depth = 0; $depth < 21; ++$depth) $layoutHtml .= '<div class="layer-' . $depth . '">';
 $layoutHtml .= '<h1>Deep story</h1><section data-hook="post-list" style="padding:20px"><ol><li><button type="button">Read more</button><a href="/story" aria-label="Story">Read the story</a></li></ol><wow-image data-hook="image"><img src="story.jpg" alt="Story" fetchpriority="high"></wow-image><svg viewBox="0 0 10 10" role="img" aria-label="Mark"><defs><link rel="stylesheet" href="/layout.css"><path id="mark" d="M0 0L10 10"></path></defs><use href="#mark"></use></svg></section>';


### PR DESCRIPTION
## Summary

- detect bounded DOM-local `url(#id)` references in inline styles and presentation attributes
- capture the smallest common media ancestor when an inline SVG definition is consumed by sibling HTML media
- retain existing SVG-local materialization paths and runtime-addressable boundaries
- bound scans to 512 elements and isolate duplicate-ID responsive variants

Fixes #1534.

The generated responsive-media renderer support required for frontend output is tracked by Automattic/static-site-importer#1500. This change intentionally does not introduce a parallel resolved-stylesheet cascade engine.

## Verification

- full PHP transformer suite passes
- regression coverage includes nested definitions, mismatches, SVG-local consumers, and bounded scans
- combined LaTonia Hope import stores and renders two complete SVG/video mask variants
- desktop and mobile wrappers compute `clip-path: url("#clip-comp-mt335hox")`; visible video reaches ready state 4 and advances
- editor loads 269 blocks with zero invalid blocks

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode was used to isolate the cross-element dependency, implement the bounded classifier path, test edge cases, and verify the combined WordPress frontend/editor result.
