### PR TITLE
Recognize state-dependent carousel rails

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Classification/SourceElementClassifier.php
+++ b/php-transformer/src/HtmlToBlocks/Classification/SourceElementClassifier.php
@@ -496,8 +496,21 @@ final class SourceElementClassifier
 
     public function isCarouselList(DOMElement $element): bool
     {
-        return 'list' === strtolower(trim(SourceDom::attr($element, 'role')))
-            || in_array(strtolower($element->tagName), array('ol', 'ul'), true);
+        if ( 'list' === strtolower(trim(SourceDom::attr($element, 'role')))
+            || in_array(strtolower($element->tagName), array('ol', 'ul'), true)
+        ) {
+            return true;
+        }
+
+        $identity = strtolower(implode(' ', array(
+            $element->tagName,
+            SourceDom::attr($element, 'id'),
+            SourceDom::attr($element, 'class'),
+            SourceDom::attr($element, 'data-hook'),
+            SourceDom::attr($element, 'data-testid'),
+        )));
+
+        return 1 === preg_match('/(?:^|[^a-z0-9])(?:track|rail|scroll(?:er)?|slides?)(?:[^a-z0-9]|$)/', $identity);
     }
 
     public function isExpandedCarouselState(DOMElement $element, DOMElement $root): bool

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -10254,13 +10254,19 @@ final class HtmlCompilation
             if ( ! $candidate instanceof DOMElement || ! in_array(strtolower($candidate->tagName), array('a', 'button'), true) ) {
                 continue;
             }
-            $identity = strtolower(implode(' ', array(
+            $metadataIdentity = strtolower(implode(' ', array(
                 $this->attr($candidate, 'aria-label'),
                 $this->attr($candidate, 'title'),
                 $this->attr($candidate, 'class'),
                 $this->attr($candidate, 'data-hook'),
-                $candidate->textContent ?? '',
             )));
+            $text = strtolower(trim($candidate->textContent ?? ''));
+            if ( 1 !== preg_match('/(?:^|[^a-z0-9])(?:slide|item|carousel|gallery|nav[^a-z0-9]*arrow|arrow[^a-z0-9]*nav)(?:[^a-z0-9]|$)/', $metadataIdentity)
+                && 1 !== preg_match('/^(?:prev|previous|next)$/', $text)
+            ) {
+                continue;
+            }
+            $identity = $metadataIdentity . ' ' . $text;
             $hasPrevious = $hasPrevious || 1 === preg_match('/(?:^|[^a-z])(?:prev|previous)(?:[^a-z]|$)/', $identity);
             $hasNext = $hasNext || 1 === preg_match('/(?:^|[^a-z])next(?:[^a-z]|$)/', $identity);
         }
@@ -10367,7 +10373,7 @@ final class HtmlCompilation
         $attributes = array(
             'ariaLabel' => trim($this->attr($element, 'aria-label')) ?: 'Carousel',
             'itemsPerView' => 'slideshow' === $presentation ? 1 : min(4, count($slides)),
-            'wrap' => true,
+            'wrap' => $hasPrevious && $hasNext,
             'presentation' => $presentation,
             'slideCount' => count($slides),
             'initialSlide' => $initialSlide,

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -10264,7 +10264,8 @@ final class HtmlCompilation
             $hasPrevious = $hasPrevious || 1 === preg_match('/(?:^|[^a-z])(?:prev|previous)(?:[^a-z]|$)/', $identity);
             $hasNext = $hasNext || 1 === preg_match('/(?:^|[^a-z])next(?:[^a-z]|$)/', $identity);
         }
-        if ( ! $hasPrevious || ! $hasNext ) {
+        // Boundary-state carousels commonly omit the unavailable direction.
+        if ( ! $hasPrevious && ! $hasNext ) {
             return null;
         }
 
@@ -10303,14 +10304,15 @@ final class HtmlCompilation
             $slides[] = $slide;
         }
 
-        $listIdentity = strtolower(implode(' ', array($list->tagName, $this->attr($list, 'class'), $this->attr($list, 'role'))));
+        $listIdentity = strtolower(implode(' ', array($list->tagName, $this->attr($list, 'class'), $this->attr($list, 'role'), $this->attr($list, 'data-hook'))));
+        $isTrackList = 1 === preg_match('/(?:^|[^a-z0-9])(?:track|rail|scroll(?:er)?)(?:[^a-z0-9]|$)/', $listIdentity);
         $presentation = 1 === preg_match('/(?:^|[^a-z0-9])slideshow(?:[^a-z0-9]|$)/', $listIdentity) ? 'slideshow' : 'track';
         $initialSlide = 0;
         foreach ( $items as $index => $item ) {
-            if ( '' !== $this->attr($item, 'aria-hidden') || '' !== $this->attr($item, 'data-slideshow-slide') ) {
+            if ( '' !== $this->attr($item, 'data-slideshow-slide') || (! $isTrackList && '' !== $this->attr($item, 'aria-hidden')) ) {
                 $presentation = 'slideshow';
             }
-            if ( 'false' === strtolower(trim($this->attr($item, 'aria-hidden'))) || str_contains(' ' . strtolower($this->attr($item, 'class')) . ' ', ' active ') ) {
+            if ( ('slideshow' === $presentation && 'false' === strtolower(trim($this->attr($item, 'aria-hidden')))) || str_contains(' ' . strtolower($this->attr($item, 'class')) . ' ', ' active ') ) {
                 $initialSlide = $index;
             }
         }
@@ -10396,7 +10398,23 @@ final class HtmlCompilation
     {
         $items = array();
         foreach ( $list->childNodes as $child ) {
-            if ( $child instanceof DOMElement && ('listitem' === strtolower(trim($this->attr($child, 'role'))) || 'li' === strtolower($child->tagName)) ) {
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+            if ( 'listitem' === strtolower(trim($this->attr($child, 'role'))) || 'li' === strtolower($child->tagName) ) {
+                $items[] = $child;
+                continue;
+            }
+
+            $identity = strtolower(implode(' ', array(
+                $child->tagName,
+                $this->attr($child, 'class'),
+                $this->attr($child, 'data-hook'),
+                $this->attr($child, 'data-testid'),
+            )));
+            if ( 1 === preg_match('/(?:^|[^a-z0-9])(?:slide|item|group)(?:[^a-z0-9]|$)/', $identity)
+                && 0 < $child->getElementsByTagName('img')->length
+            ) {
                 $items[] = $child;
             }
         }

--- a/php-transformer/tests/unit/authored-carousel-block.php
+++ b/php-transformer/tests/unit/authored-carousel-block.php
@@ -59,4 +59,15 @@ $assert(720 === ($slideshow['attrs']['viewportHeight'] ?? null) && 500 === ($sli
 $assert(1 === ($slideshow['attrs']['initialSlide'] ?? null) && true === ($slideshow['attrs']['showDots'] ?? null) && true === ($slideshow['attrs']['fullBleed'] ?? null), 'active slide, dot navigation, and viewport breakout survive conversion');
 $assert(str_contains($slideshowMarkup, '--slideshow') && 2 === substr_count($slideshowMarkup, 'data-carousel-index=') && str_contains($slideshowMarkup, '--blocks-engine-carousel-height:720px'), 'slideshow markup carries stacked presentation, indexed dots, and source height');
 
+$boundaryRailSource = '<div class="pro-gallery slider"><div role="region"><div class="gallery-horizontal-scroll"><div class="gallery-horizontal-scroll-inner"><div data-hook="group-view" aria-hidden="false"><div data-idx="0" data-hook="item-container"><img src="award-one.jpg" alt="Award one"></div></div><div data-hook="group-view" aria-hidden="false"><div data-idx="1" data-hook="item-container"><img src="award-two.jpg" alt="Award two"></div></div></div></div><button data-hook="nav-arrow-next" aria-label="Next Item"></button></div></div>';
+$boundaryRailResult = (new HtmlTransformer())->transform($boundaryRailSource)->toArray();
+$boundaryRail = $boundaryRailResult['blocks'][0] ?? array();
+$assert(
+    'custom/authored-carousel' === ($boundaryRail['blockName'] ?? null)
+        && 2 === count($boundaryRail['innerBlocks'] ?? array())
+        && 'track' === ($boundaryRail['attrs']['presentation'] ?? null)
+        && 0 === ($boundaryRail['attrs']['initialSlide'] ?? null),
+    'a repeated scroll rail with one boundary-state direction lowers to an editable track carousel'
+);
+
 fwrite(STDOUT, "Authored carousel companion tests passed\n");

--- a/php-transformer/tests/unit/authored-carousel-block.php
+++ b/php-transformer/tests/unit/authored-carousel-block.php
@@ -59,15 +59,26 @@ $assert(720 === ($slideshow['attrs']['viewportHeight'] ?? null) && 500 === ($sli
 $assert(1 === ($slideshow['attrs']['initialSlide'] ?? null) && true === ($slideshow['attrs']['showDots'] ?? null) && true === ($slideshow['attrs']['fullBleed'] ?? null), 'active slide, dot navigation, and viewport breakout survive conversion');
 $assert(str_contains($slideshowMarkup, '--slideshow') && 2 === substr_count($slideshowMarkup, 'data-carousel-index=') && str_contains($slideshowMarkup, '--blocks-engine-carousel-height:720px'), 'slideshow markup carries stacked presentation, indexed dots, and source height');
 
-$boundaryRailSource = '<div class="pro-gallery slider"><div role="region"><div class="gallery-horizontal-scroll"><div class="gallery-horizontal-scroll-inner"><div data-hook="group-view" aria-hidden="false"><div data-idx="0" data-hook="item-container"><img src="award-one.jpg" alt="Award one"></div></div><div data-hook="group-view" aria-hidden="false"><div data-idx="1" data-hook="item-container"><img src="award-two.jpg" alt="Award two"></div></div></div></div><button data-hook="nav-arrow-next" aria-label="Next Item"></button></div></div>';
+$boundaryItems = '';
+for ( $index = 1; $index <= 6; $index++ ) {
+    $boundaryItems .= '<div data-hook="group-view" aria-hidden="false"><div data-idx="' . ($index - 1) . '" data-hook="item-container"><img src="award-' . $index . '.jpg" alt="Award ' . $index . '"></div></div>';
+}
+$boundaryRailSource = '<div class="pro-gallery slider"><div role="region"><div class="gallery-horizontal-scroll"><div class="gallery-horizontal-scroll-inner">' . $boundaryItems . '</div></div><button data-hook="nav-arrow-next" aria-label="Next Item"></button></div></div>';
 $boundaryRailResult = (new HtmlTransformer())->transform($boundaryRailSource)->toArray();
 $boundaryRail = $boundaryRailResult['blocks'][0] ?? array();
 $assert(
     'custom/authored-carousel' === ($boundaryRail['blockName'] ?? null)
-        && 2 === count($boundaryRail['innerBlocks'] ?? array())
+        && 6 === count($boundaryRail['innerBlocks'] ?? array())
         && 'track' === ($boundaryRail['attrs']['presentation'] ?? null)
-        && 0 === ($boundaryRail['attrs']['initialSlide'] ?? null),
+        && 0 === ($boundaryRail['attrs']['initialSlide'] ?? null)
+        && false === ($boundaryRail['attrs']['wrap'] ?? null),
     'a repeated scroll rail with one boundary-state direction lowers to an editable track carousel'
+);
+
+$unrelatedGallery = (new HtmlTransformer())->transform('<div class="photo-gallery"><div class="product-scroll"><div class="item"><img src="one.jpg"></div><div class="item"><img src="two.jpg"></div></div><a href="/next">Next collection</a></div>')->toArray();
+$assert(
+    'custom/authored-carousel' !== ($unrelatedGallery['blocks'][0]['blockName'] ?? null),
+    'an unrelated gallery link does not turn a repeated scroll collection into a carousel'
 );
 
 fwrite(STDOUT, "Authored carousel companion tests passed\n");


### PR DESCRIPTION
## Summary

- recognize state-dependent horizontal rails as authored carousels
- bind controls to the nearest bounded carousel instead of the whole document
- preserve finite, non-wrapping slide behavior

Fixes #1158.

## Verification

- full PHP transformer suite passes
- LaTonia Hope import renders two six-slide carousels
- desktop next action moves `scrollLeft` from 0 to 261 and status from slide 1 to slide 2
- mobile next action moves `scrollLeft` from 0 to 253 and status from slide 1 to slide 2

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode was used to investigate the source interaction, implement the bounded classifier/compiler changes, run tests, and verify the generated WordPress frontend and editor.
