### PR TITLE
Pass navigation suppression dependencies directly

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -518,10 +518,6 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             $this->createNavigationStyleProjectionContext(),
             $this->styleResolver
         );
-        $this->navigationToggleSuppressor = new NavigationToggleSuppressor(
-            $this->createNavigationToggleSuppressionContext(),
-            $this->styleResolver
-        );
         $this->svgMaterializer = new SvgMaterializer(
             $this->createSvgMaterializationContext(),
             $this->styleResolver,
@@ -531,6 +527,10 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
         $this->patternContext = $this->createPatternContext(true);
         $this->patternContextWithoutRuntimeDomTarget = $this->createPatternContext(false);
         $this->patternProbeContext = $this->createProbePatternContext();
+        $this->navigationToggleSuppressor = new NavigationToggleSuppressor(
+            $this->createNavigationToggleSuppressionContext(),
+            $this->styleResolver
+        );
         $this->textLeafConverter = new TextLeafElementConverter($this->createTextLeafElementContext());
         $this->richTextConverter = new RichTextElementConverter($this->createRichTextElementContext());
         $svgConverter = new SvgElementConverter(new SvgElementContext(
@@ -911,8 +911,8 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
         return new NavigationToggleSuppressionContext(
             $this->session,
             fn (DOMElement $element): bool => $this->sourceElementStartsHidden($element),
-            fn (): PatternRecognizerRegistry => $this->patternRecognizers,
-            fn (): PatternContext => $this->probePatternContext()
+            $this->patternRecognizers,
+            $this->patternProbeContext
         );
     }
 
@@ -2645,15 +2645,6 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
         // child conversion diagnostics retain their exact order.
         $fallbacks = array_merge($fallbacks, $result->fallbacks());
         return $result->block();
-    }
-
-    /**
-     * A side-effect-free pattern context for probing whether an element would
-     * convert to a given block, without recording provenance or runtime islands.
-     */
-    private function probePatternContext(): PatternContext
-    {
-        return $this->patternProbeContext;
     }
 
     private function createProbePatternContext(): PatternContext

--- a/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionContext.php
+++ b/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionContext.php
@@ -20,15 +20,13 @@ use DOMElement;
 final class NavigationToggleSuppressionContext
 {
     /**
-     * @param Closure(DOMElement): bool            $sourceElementStartsHidden
-     * @param Closure(): PatternRecognizerRegistry $patternRecognizers
-     * @param Closure(): PatternContext            $probePatternContext
+     * @param Closure(DOMElement): bool $sourceElementStartsHidden
      */
     public function __construct(
         private readonly HtmlTransformerSession $session,
         private readonly Closure $sourceElementStartsHidden,
-        private readonly Closure $patternRecognizers,
-        private readonly Closure $probePatternContext
+        private readonly PatternRecognizerRegistry $patternRecognizers,
+        private readonly PatternContext $probePatternContext
     ) {
     }
 
@@ -49,11 +47,11 @@ final class NavigationToggleSuppressionContext
 
     public function patternRecognizers(): PatternRecognizerRegistry
     {
-        return ($this->patternRecognizers)();
+        return $this->patternRecognizers;
     }
 
     public function probePatternContext(): PatternContext
     {
-        return ($this->probePatternContext)();
+        return $this->probePatternContext;
     }
 }


### PR DESCRIPTION
## Summary
- pass the pattern recognizer registry and side-effect-free probe context directly into `NavigationToggleSuppressionContext`
- construct the navigation suppressor after pattern contexts so those typed dependencies are initialized before use
- remove two zero-argument forwarding closures and the redundant probe-context accessor

The transformer-owned navigation callbacks remain deferred; only already-built typed objects now pass directly.

## Verification
- `composer test`
- 292 PHP transformer parity fixtures
- 385 serialized-block fixture hashes byte-identical to `origin/trunk` (`2988fbba`), with 0 exceptions
- navigation projection isolation contract
- staged pattern dispatch: 51 assertions
- namespace resolution: 252 class-likes, 0 unresolved references
- `git diff --check`
- Homeboy architecture audit: 0 introduced findings ([run `a9b85030-80ac-41b6-8eb7-132a24d31ea5`](homeboy://run/a9b85030-80ac-41b6-8eb7-132a24d31ea5))

## AI assistance
OpenAI GPT-5.6 Sol was used through OpenCode to identify the redundant closures, correct constructor ordering, review deferred callback safety, and run verification. The resulting diff and evidence were reviewed by the operator.