### PR TITLE
Pass search conversion dependencies directly

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Elements/SearchBlockConversionContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/SearchBlockConversionContext.php
@@ -16,16 +16,14 @@ use DOMElement;
 final class SearchBlockConversionContext
 {
     /**
-     * @param Closure(string): string                                                                $restoreSvgCasing
-     * @param Closure(DOMElement): bool                                                              $isRuntimeDomTarget
-     * @param Closure(DOMElement): array<string, mixed>                                              $htmlPreservationBlock
+     * @param Closure(DOMElement): array<string, mixed> $htmlPreservationBlock
      */
     public function __construct(
         private readonly HtmlTransformerSession $session,
         private readonly ElementPresentationResolver $presentationResolver,
         private readonly SourceBlockCreator $createBlock,
-        private readonly Closure $restoreSvgCasing,
-        private readonly Closure $isRuntimeDomTarget,
+        private readonly SvgElementMaterializer $svgMaterializer,
+        private readonly RuntimeIslandAnalyzer $runtimeIslands,
         private readonly Closure $htmlPreservationBlock
     ) {
     }
@@ -75,7 +73,7 @@ final class SearchBlockConversionContext
 
     public function restoreSvgCasing(string $html): string
     {
-        return ($this->restoreSvgCasing)($html);
+        return $this->svgMaterializer->restoreSvgCasing($html);
     }
 
     public function generatedSupportStyles(): GeneratedSupportStylesheetState
@@ -85,7 +83,7 @@ final class SearchBlockConversionContext
 
     public function isRuntimeDomTarget(DOMElement $element): bool
     {
-        return ($this->isRuntimeDomTarget)($element);
+        return $this->runtimeIslands->isRuntimeDomTarget($element);
     }
 
     /** @return array<string, mixed> */

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -937,8 +937,8 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             $this->session,
             $this->styleResolver,
             $this,
-            fn (string $html): string => $this->svgMaterializer->restoreSvgCasing($html),
-            fn (DOMElement $element): bool => $this->runtimeIslands->isRuntimeDomTarget($element),
+            $this->svgMaterializer,
+            $this->runtimeIslands,
             fn (DOMElement $element): array => $this->htmlPreservationBlock($element)
         );
     }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1700,6 +1700,12 @@ $assert(! str_contains((string) ($runtimeDescendantSearch['serialized_blocks'] ?
 $assert(str_contains((string) ($runtimeDescendantSearch['serialized_blocks'] ?? ''), 'search-status'), 'synthetic search preserves an additional runtime descendant');
 $assert(1 === count($runtimeDescendantSearch['source_reports']['runtime_islands'] ?? array()), 'synthetic search reports its preserved runtime descendant');
 
+$runtimeTargetedSearch = ( new HtmlTransformer() )->transform(
+    '<div class="site-search"><input class="js-search" type="search" name="s" placeholder="Search"></div>',
+    array('runtime_dom_selectors' => array('.js-search'))
+)->toArray();
+$assert(! str_contains((string) ($runtimeTargetedSearch['serialized_blocks'] ?? ''), '<!-- wp:search') && str_contains((string) ($runtimeTargetedSearch['serialized_blocks'] ?? ''), '<input class="js-search"'), 'runtime-targeted standalone search input retains native markup instead of collapsing to core/search');
+
 $runtimeClockCss = '*{margin:0;padding:0}.site-footer{display:flex}.footer-left{display:flex;flex-direction:column}.clock-time{font-size:.75rem;font-weight:700}.clock-date{font-size:.7rem;min-height:1.2em}.blink-colon{animation:blink 1s infinite}#timezone{margin-left:.2rem;opacity:.6}';
 $runtimeClock = ( new HtmlTransformer() )->transform(
     '<footer class="site-footer"><div id="clock-container" class="footer-left"><div id="clock-time" class="clock-time"><!-- Initial State: 00:00 --><span id="hours">12</span><span id="colon" class="blink-colon">:</span><span id="minutes">28</span><span id="ampm">PM</span><span id="timezone">(GMT -4)</span></div><div id="clock-date" class="clock-date">Saturday</div></div></footer>',
@@ -2757,6 +2763,7 @@ $assert(str_contains($expandableHeaderSearchSerialized, '"showLabel":false') && 
 $assert(! str_contains($expandableHeaderSearchSerialized, '/apps/search') && ! str_contains($expandableHeaderSearchSerialized, 'name="q"'), 'native search migration removes provider-specific endpoint semantics');
 $assert(! str_contains($expandableHeaderSearchSerialized, '"className":"provider-search"') && str_contains($expandableHeaderSearchSerialized, 'search-icon blocks-engine-source-search-icon-') && ! str_contains($expandableHeaderSearchSerialized, 'search-close'), 'native search cluster absorbs provider wrappers while carrying the trigger presentation onto core search');
 $assert(str_contains($expandableHeaderSearchCss, 'flex:0 0 24px!important;width:24px!important;height:80px!important') && str_contains($expandableHeaderSearchCss, 'width:12px;height:13px') && str_contains($expandableHeaderSearchCss, 'data:image/svg+xml,'), 'native icon search replays the source trigger flex geometry and exact SVG artwork');
+$assert(str_contains($expandableHeaderSearchCss, 'viewBox%3D') && ! str_contains($expandableHeaderSearchCss, 'viewbox%3D'), 'native search icon data preserves case-sensitive SVG attribute names');
 
 $viewBoxOnlyHeaderSearch = ( new HtmlTransformer() )->transform(
     '<header><form role="search"><input name="s" type="search"></form><button class="search-trigger"><svg viewBox="0 0 12 13"><path d="M1 1"></path></svg></button></header>'


### PR DESCRIPTION
## Summary
- pass `SvgElementMaterializer` and `RuntimeIslandAnalyzer` directly into `SearchBlockConversionContext`
- remove the forwarding closures for SVG casing restoration and runtime DOM target recognition
- retain the transformer-owned HTML preservation operation as the context's remaining closure
- add behavior coverage for case-sensitive SVG search-icon markup and runtime-targeted standalone search rejection

## Verification
- `composer test`
- 292 PHP transformer parity fixtures
- 385 serialized-block fixture hashes byte-identical to `origin/trunk` (`fa50caf5`), with 0 exceptions
- HTML-to-blocks contract, including both migrated search paths
- runtime island analyzer: 35 assertions
- SVG element converter: 13 assertions
- SVG materialized paint cascade: 20 assertions
- namespace resolution: 252 class-likes, 0 unresolved references
- `git diff --check`
- Homeboy architecture audit: 0 introduced findings ([run `c63da3e3-01ab-4601-a139-01fc890599fe`](homeboy://run/c63da3e3-01ab-4601-a139-01fc890599fe))

## AI assistance
OpenAI GPT-5.6 Sol was used through OpenCode to identify and replace the forwarding closures, review initialization and dependency semantics, add behavior-level coverage, and run verification. The resulting diff and evidence were reviewed by the operator.