### PR TITLE
Preserve hidden accessibility support text

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/SourceBlockAttributeProjector.php
+++ b/php-transformer/src/HtmlToBlocks/Style/SourceBlockAttributeProjector.php
@@ -58,6 +58,9 @@ final class SourceBlockAttributeProjector
         if ( 'core/group' === $name && $facts->isAuthorLayoutItem ) {
             $attrs['className'] = SourceDom::mergeClassNames((string) ($attrs['className'] ?? ''), self::CSS_OWNED_LAYOUT_ITEM_CLASS);
         }
+        if ( in_array($name, array( 'core/group', 'core/paragraph' ), true) && self::isHiddenAccessibilitySupportElement($sourceElement) ) {
+            $attrs['className'] = SourceDom::mergeClassNames((string) ($attrs['className'] ?? ''), self::HIDDEN_RICH_TEXT_MARKER_CLASS);
+        }
         if ( 'core/group' === $name && $this->isAtomicInlineChildFlow($sourceElement, $innerBlocks) ) {
             $attrs['className'] = SourceDom::mergeClassNames((string) ($attrs['className'] ?? ''), self::CSS_OWNED_INLINE_FLOW_CLASS);
         }
@@ -88,6 +91,17 @@ final class SourceBlockAttributeProjector
             }
         }
         return $attrs;
+    }
+
+    private static function isHiddenAccessibilitySupportElement(DOMElement $element): bool
+    {
+        $identity = strtolower(SourceDom::attr($element, 'id') . ' ' . SourceDom::attr($element, 'class'));
+        if ( 1 !== preg_match('/(?:a11y|accessib|screen[-_]?reader|sr[-_]?only|visually[-_]?hidden)/', $identity) ) {
+            return false;
+        }
+
+        $style = strtolower(SourceDom::attr($element, 'style'));
+        return 1 === preg_match('/(?:^|;)\s*(?:display\s*:\s*none|visibility\s*:\s*hidden)\s*(?:!important)?\s*(?:;|$)/', $style);
     }
 
     public function sourceProjectionClassName(DOMElement $element, SourceBlockAttributeProjectionContext $context, string $className = ''): string

--- a/php-transformer/tests/unit/inert-closed-state-interactions.php
+++ b/php-transformer/tests/unit/inert-closed-state-interactions.php
@@ -335,6 +335,23 @@ $assert(
     $boundaryMarkerAfterAuthor
 );
 
+$hiddenNavigationSupport = <<<'HTML'
+<wix-dropdown-menu>
+  <nav><ul><li><a href="/">Home</a></li></ul><div id="menu-hiddenA11ySubMenuIndication" style="display:none">Use tab to navigate through the menu items.</div></nav>
+</wix-dropdown-menu>
+HTML;
+
+$hiddenNavigationSupportResult = ( new HtmlTransformer() )->transform($hiddenNavigationSupport)->toArray();
+$hiddenNavigationSupportMarkup = (string) ($hiddenNavigationSupportResult['serialized_blocks'] ?? '');
+$hiddenNavigationSupportBeforeAuthor = $cssContent($hiddenNavigationSupportResult, 'before-author', 'both');
+$assert(
+    str_contains($hiddenNavigationSupportMarkup, 'Use tab to navigate through the menu items.')
+        && str_contains($hiddenNavigationSupportMarkup, 'blocks-engine-hidden-richtext-marker')
+        && str_contains($hiddenNavigationSupportBeforeAuthor, ':where(.blocks-engine-hidden-richtext-marker){display:none}'),
+    'an explicitly hidden navigation accessibility support group retains its hidden state',
+    $hiddenNavigationSupportMarkup . "\n" . $hiddenNavigationSupportBeforeAuthor
+);
+
 if ( $failures > 0 ) {
     fwrite(STDERR, "inert closed-state interactions: {$failures} failed, {$passes} passed\n");
     exit(1);


### PR DESCRIPTION
## Summary
- preserve authored hidden state for explicitly hidden accessibility-support elements lowered to groups or paragraphs
- reuse the existing hidden rich-text support marker so the text remains editable without entering layout
- cover the Wix navigation support-label shape that exposed the visible text regression

Closes #1520.

## Verification
- `composer test`
- 292 PHP transformer parity fixtures pass
- distribution shape and package install proof pass

## AI assistance
GPT-5.6 Sol through OpenCode reproduced the generated-block leak, implemented the source projection repair, and ran the full transformer verification suite under human direction.