### PR TITLE
Keep hidden support markers collapsed

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -1954,7 +1954,7 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
                 . "\n" . ':where(p.' . self::SYNTHETIC_PARAGRAPH_CLASS . '.' . self::SYNTHETIC_ANCHOR_UNDECORATED_CLASS . ')>a{text-decoration:none}';
         }
         if ( str_contains($serializedBlocks, SourceBlockAttributeProjector::HIDDEN_RICH_TEXT_MARKER_CLASS) ) {
-            $beforeAuthorCssParts[] = ':root :where(.' . SourceBlockAttributeProjector::HIDDEN_RICH_TEXT_MARKER_CLASS . '){display:none}';
+            $beforeAuthorCssParts[] = ':root :where(.' . SourceBlockAttributeProjector::HIDDEN_RICH_TEXT_MARKER_CLASS . '){display:none!important}';
         }
         if ( str_contains($serializedBlocks, self::SYNTHETIC_IMAGE_FIGURE_CLASS) ) {
             $beforeAuthorCssParts[] = '.' . self::SYNTHETIC_IMAGE_FIGURE_CLASS . '{margin:0}';

--- a/php-transformer/src/HtmlToBlocks/Style/ClosedStateNormalizer.php
+++ b/php-transformer/src/HtmlToBlocks/Style/ClosedStateNormalizer.php
@@ -118,6 +118,11 @@ final class ClosedStateNormalizer
             return true;
         }
 
+        $identity = strtolower((string) $attr($element, 'id') . ' ' . (string) $attr($element, 'class'));
+        if ( 1 === preg_match('/(?:a11y|accessib|screen[-_]?reader|sr[-_]?only|visually[-_]?hidden)/', $identity) ) {
+            return true;
+        }
+
         if ( in_array(strtolower(trim((string) $attr($element, 'role'))), array( 'presentation', 'none' ), true) ) {
             return true;
         }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -5217,7 +5217,7 @@ $assert(str_contains((string) ($editorStaticStateResult['serialized_blocks'] ?? 
 
 $hiddenRichTextMarker = (new HtmlTransformer())->transform('<style>.scroll-target span{display:none}</style><div class="scroll-target"><span>Bottom of page</span></div>')->toArray();
 $hiddenRichTextCss = implode("\n", array_column($hiddenRichTextMarker['assets'] ?? array(), 'content'));
-$assert(str_contains((string) ($hiddenRichTextMarker['serialized_blocks'] ?? ''), 'blocks-engine-hidden-richtext-marker') && str_contains($hiddenRichTextCss, ':where(.blocks-engine-hidden-richtext-marker){display:none}'), 'hidden RichText selector carriers collapse their synthetic paragraph instead of adding an empty editable line');
+$assert(str_contains((string) ($hiddenRichTextMarker['serialized_blocks'] ?? ''), 'blocks-engine-hidden-richtext-marker') && str_contains($hiddenRichTextCss, ':where(.blocks-engine-hidden-richtext-marker){display:none!important}'), 'hidden RichText selector carriers collapse their synthetic paragraph instead of adding an empty editable line');
 
 $hiddenEmptyResult = (new HtmlTransformer())->transform(
     '<main><div class="caption" style="display:none;font-size:90%"></div>'

--- a/php-transformer/tests/unit/inert-closed-state-interactions.php
+++ b/php-transformer/tests/unit/inert-closed-state-interactions.php
@@ -347,7 +347,7 @@ $hiddenNavigationSupportBeforeAuthor = $cssContent($hiddenNavigationSupportResul
 $assert(
     str_contains($hiddenNavigationSupportMarkup, 'Use tab to navigate through the menu items.')
         && str_contains($hiddenNavigationSupportMarkup, 'blocks-engine-hidden-richtext-marker')
-        && str_contains($hiddenNavigationSupportBeforeAuthor, ':where(.blocks-engine-hidden-richtext-marker){display:none}'),
+        && str_contains($hiddenNavigationSupportBeforeAuthor, ':where(.blocks-engine-hidden-richtext-marker){display:none!important}'),
     'an explicitly hidden navigation accessibility support group retains its hidden state',
     $hiddenNavigationSupportMarkup . "\n" . $hiddenNavigationSupportBeforeAuthor
 );

--- a/php-transformer/tests/unit/inert-closed-state-interactions.php
+++ b/php-transformer/tests/unit/inert-closed-state-interactions.php
@@ -344,12 +344,14 @@ HTML;
 $hiddenNavigationSupportResult = ( new HtmlTransformer() )->transform($hiddenNavigationSupport)->toArray();
 $hiddenNavigationSupportMarkup = (string) ($hiddenNavigationSupportResult['serialized_blocks'] ?? '');
 $hiddenNavigationSupportBeforeAuthor = $cssContent($hiddenNavigationSupportResult, 'before-author', 'both');
+$hiddenNavigationSupportAfterAuthor = $cssContent($hiddenNavigationSupportResult, 'after-author', 'both');
 $assert(
     str_contains($hiddenNavigationSupportMarkup, 'Use tab to navigate through the menu items.')
         && str_contains($hiddenNavigationSupportMarkup, 'blocks-engine-hidden-richtext-marker')
-        && str_contains($hiddenNavigationSupportBeforeAuthor, ':where(.blocks-engine-hidden-richtext-marker){display:none!important}'),
+        && str_contains($hiddenNavigationSupportBeforeAuthor, ':where(.blocks-engine-hidden-richtext-marker){display:none!important}')
+        && ! str_contains($hiddenNavigationSupportAfterAuthor, 'display:revert!important'),
     'an explicitly hidden navigation accessibility support group retains its hidden state',
-    $hiddenNavigationSupportMarkup . "\n" . $hiddenNavigationSupportBeforeAuthor
+    $hiddenNavigationSupportMarkup . "\n" . $hiddenNavigationSupportBeforeAuthor . "\n" . $hiddenNavigationSupportAfterAuthor
 );
 
 if ( $failures > 0 ) {


### PR DESCRIPTION
## Summary
- make the existing hidden rich-text support marker preserve explicit source `display:none` across later authored CSS
- update contract and navigation regression expectations for the cascade-safe declaration

Follow-up to #1542. Closes #1520.

## Verification
- `composer test`
- 292 PHP transformer parity fixtures pass
- distribution shape and package install proof pass

## AI assistance
GPT-5.6 Sol through OpenCode used six-route browser computed-style evidence to identify the authored-CSS override, hardened the existing hidden marker, and ran the full transformer suite under human direction.