### PR TITLE
fix(php-transformer): chunk oversized projected stylesheets

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -100,6 +100,7 @@
       "php tests/unit/media-text-pattern.php",
       "php tests/unit/cover-style-resolver.php",
       "php tests/unit/css-stylesheet-transformer.php",
+       "php tests/unit/stylesheet-selector-budget.php",
       "php tests/unit/admin-bar-accommodation.php",
       "php tests/unit/css-rule-analyzer.php",
       "php tests/unit/css-selector-matcher.php",

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -2814,10 +2814,10 @@ final class ArtifactCompiler
                 $chunk['path'] = $paths[$index];
                 $chunk['content'] = 0 === $index ? $content : $continuationPreamble . $content;
                 unset($chunk['content_base64']);
-                $chunk['bytes'] = strlen($content);
+                $chunk['bytes'] = strlen($chunk['content']);
                 $chunk['encoding'] = 'text';
                 $chunk['binary'] = false;
-                $chunk['provenance']['hash'] = hash('sha256', $content);
+                $chunk['provenance']['hash'] = hash('sha256', $chunk['content']);
                 $output[] = $chunk;
             }
         }

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -17,6 +17,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformerAnalysisC
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\ShellLandmarkPolicy;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AdminBarAccommodation;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssStylesheetTransformer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssStylesheetChunker;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\FormLayoutGraphBuilder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
@@ -63,7 +64,10 @@ final class ArtifactCompiler
     /** Observational only: counts source stylesheet discovery passes. */
     private int $stylesheetAssetDiscoveryCount = 0;
 
-    public function __construct(private readonly bool $cacheHtmlAnalysis = true)
+    public function __construct(
+        private readonly bool $cacheHtmlAnalysis = true,
+        private readonly int $stylesheetSelectorBudget = CssStylesheetChunker::MAX_SELECTOR_RECORDS
+    )
     {
         $this->wordpressCompat = new WordPressCompatCss();
         $this->runtimeScriptEvidenceAnalyzer = new RuntimeScriptEvidenceAnalyzer();
@@ -649,6 +653,14 @@ final class ArtifactCompiler
         $allGutenbergGaps = $this->dedupeRows($allGutenbergGaps);
         $normalized['runtime_declarations'] = $this->runtimeDeclarationsFromFallbacks($normalized['runtime_declarations'], $allFallbacks, $entryPath, $normalized['files']);
         $normalized['files'] = $this->applyAuthorStylesheetProjections($normalized['files'], $authorStylesheetProjections, $entryBlocks['author_stylesheet_projections']);
+        $normalized['files'] = $this->chunkProjectedStylesheets($normalized['files']);
+        foreach ($normalized['files'] as $file) {
+            if ($entryPath === ($file['path'] ?? null) && is_string($file['content'] ?? null)) {
+                $html = $file['content'];
+                break;
+            }
+        }
+        $this->indexFiles($normalized['files']);
         $normalized['files'] = $this->applyRuntimeScriptProjections($normalized['files'], $runtimeScriptProjections);
         $runtimeIslandPackage = $this->applyRuntimeScriptPackageProjections(
             ( new RuntimeIslandPackageBuilder() )->fromRuntimeIslands($entryBlocks['runtime_islands'], $normalized['files'], $entryPath),
@@ -2758,6 +2770,103 @@ final class ArtifactCompiler
         }
         unset($file);
         return $files;
+    }
+
+    /**
+     * Keep transformed selector records below browser engine limits while
+     * retaining the source stylesheet's cascade position and link contract.
+     *
+     * @param array<int, array<string, mixed>> $files
+     * @return array<int, array<string, mixed>>
+     */
+    private function chunkProjectedStylesheets(array $files): array
+    {
+        $reserved = array_fill_keys(array_column($files, 'path'), true);
+        $chunkPaths = array();
+        $chunker = new CssStylesheetChunker();
+        $output = array();
+        foreach ($files as $file) {
+            if ('css' !== ($file['kind'] ?? null) || !is_string($file['content'] ?? null)) {
+                $output[] = $file;
+                continue;
+            }
+            $chunks = $chunker->chunk($file['content'], $this->stylesheetSelectorBudget);
+            if (count($chunks) < 2) {
+                $output[] = $file;
+                continue;
+            }
+            $paths = array((string) $file['path']);
+            for ($index = 1; $index < count($chunks); ++$index) {
+                $paths[] = $this->stylesheetChunkPath((string) $file['path'], $index + 1, $reserved);
+            }
+            $chunkPaths[(string) $file['path']] = $paths;
+            foreach ($chunks as $index => $content) {
+                $chunk = $file;
+                $chunk['path'] = $paths[$index];
+                $chunk['content'] = $content;
+                unset($chunk['content_base64']);
+                $chunk['bytes'] = strlen($content);
+                $chunk['encoding'] = 'text';
+                $chunk['binary'] = false;
+                $chunk['provenance']['hash'] = hash('sha256', $content);
+                $output[] = $chunk;
+            }
+        }
+        if (array() === $chunkPaths) {
+            return $output;
+        }
+        foreach ($output as &$file) {
+            if ('html' === ($file['kind'] ?? null) && is_string($file['content'] ?? null)) {
+                $file['content'] = $this->withChunkedStylesheetLinks($file['content'], (string) $file['path'], $chunkPaths);
+                $file['bytes'] = strlen($file['content']);
+                $file['provenance']['hash'] = hash('sha256', $file['content']);
+            }
+        }
+        unset($file);
+        return $output;
+    }
+
+    /** @param array<string, true> $reserved */
+    private function stylesheetChunkPath(string $path, int $index, array &$reserved): string
+    {
+        $extension = pathinfo($path, PATHINFO_EXTENSION);
+        $base = '' === $extension ? $path : substr($path, 0, -strlen($extension) - 1);
+        $candidate = $base . '.chunk-' . $index . ('' === $extension ? '' : '.' . $extension);
+        $suffix = 2;
+        while (isset($reserved[$candidate])) {
+            $candidate = $base . '.chunk-' . $index . '-' . $suffix++ . ('' === $extension ? '' : '.' . $extension);
+        }
+        $reserved[$candidate] = true;
+        return $candidate;
+    }
+
+    /** @param array<string, list<string>> $chunkPaths */
+    private function withChunkedStylesheetLinks(string $html, string $sourcePath, array $chunkPaths): string
+    {
+        return preg_replace_callback('/<link\b[^>]*>/i', function (array $match) use ($sourcePath, $chunkPaths): string {
+            $tag = $match[0];
+            if (!preg_match('/(?:^|\s)stylesheet(?:\s|$)/i', $this->htmlAttribute($tag, 'rel'))) {
+                return $tag;
+            }
+            $href = $this->htmlAttribute($tag, 'href');
+            $path = $this->stylesheetPathFromHref($href, $sourcePath);
+            $paths = $chunkPaths[$path] ?? array();
+            if (count($paths) < 2) {
+                return $tag;
+            }
+            $tags = array($tag);
+            foreach (array_slice($paths, 1) as $chunkPath) {
+                $tags[] = preg_replace_callback('/\bhref\s*=\s*(["\'])(.*?)\1/i', static function (array $hrefMatch) use ($chunkPath): string {
+                    $href = $hrefMatch[2];
+                    $suffixOffset = strcspn($href, '?#');
+                    $suffix = substr($href, $suffixOffset);
+                    $base = substr($href, 0, $suffixOffset);
+                    $replacement = preg_replace('~[^/]+$~', basename($chunkPath), $base);
+                    return 'href=' . $hrefMatch[1] . $replacement . $suffix . $hrefMatch[1];
+                }, $tag, 1) ?? $tag;
+            }
+            return implode("\n", $tags);
+        }, $html) ?? $html;
     }
 
     /**

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -2795,15 +2795,24 @@ final class ArtifactCompiler
                 $output[] = $file;
                 continue;
             }
-            $paths = array((string) $file['path']);
-            for ($index = 1; $index < count($chunks); ++$index) {
+            $paths = array();
+            for ($index = 0; $index < count($chunks); ++$index) {
                 $paths[] = $this->stylesheetChunkPath((string) $file['path'], $index + 1, $reserved);
             }
             $chunkPaths[(string) $file['path']] = $paths;
+            $loader = $file;
+            $loader['content'] = implode('', array_map(static fn (string $path): string => '@import url("' . basename($path) . '");', $paths));
+            unset($loader['content_base64']);
+            $loader['bytes'] = strlen($loader['content']);
+            $loader['encoding'] = 'text';
+            $loader['binary'] = false;
+            $loader['provenance']['hash'] = hash('sha256', $loader['content']);
+            $output[] = $loader;
+            $continuationPreamble = $chunker->continuationPreamble($file['content']);
             foreach ($chunks as $index => $content) {
                 $chunk = $file;
                 $chunk['path'] = $paths[$index];
-                $chunk['content'] = $content;
+                $chunk['content'] = 0 === $index ? $content : $continuationPreamble . $content;
                 unset($chunk['content_base64']);
                 $chunk['bytes'] = strlen($content);
                 $chunk['encoding'] = 'text';
@@ -2815,14 +2824,6 @@ final class ArtifactCompiler
         if (array() === $chunkPaths) {
             return $output;
         }
-        foreach ($output as &$file) {
-            if ('html' === ($file['kind'] ?? null) && is_string($file['content'] ?? null)) {
-                $file['content'] = $this->withChunkedStylesheetLinks($file['content'], (string) $file['path'], $chunkPaths);
-                $file['bytes'] = strlen($file['content']);
-                $file['provenance']['hash'] = hash('sha256', $file['content']);
-            }
-        }
-        unset($file);
         return $output;
     }
 
@@ -2838,35 +2839,6 @@ final class ArtifactCompiler
         }
         $reserved[$candidate] = true;
         return $candidate;
-    }
-
-    /** @param array<string, list<string>> $chunkPaths */
-    private function withChunkedStylesheetLinks(string $html, string $sourcePath, array $chunkPaths): string
-    {
-        return preg_replace_callback('/<link\b[^>]*>/i', function (array $match) use ($sourcePath, $chunkPaths): string {
-            $tag = $match[0];
-            if (!preg_match('/(?:^|\s)stylesheet(?:\s|$)/i', $this->htmlAttribute($tag, 'rel'))) {
-                return $tag;
-            }
-            $href = $this->htmlAttribute($tag, 'href');
-            $path = $this->stylesheetPathFromHref($href, $sourcePath);
-            $paths = $chunkPaths[$path] ?? array();
-            if (count($paths) < 2) {
-                return $tag;
-            }
-            $tags = array($tag);
-            foreach (array_slice($paths, 1) as $chunkPath) {
-                $tags[] = preg_replace_callback('/\bhref\s*=\s*(["\'])(.*?)\1/i', static function (array $hrefMatch) use ($chunkPath): string {
-                    $href = $hrefMatch[2];
-                    $suffixOffset = strcspn($href, '?#');
-                    $suffix = substr($href, $suffixOffset);
-                    $base = substr($href, 0, $suffixOffset);
-                    $replacement = preg_replace('~[^/]+$~', basename($chunkPath), $base);
-                    return 'href=' . $hrefMatch[1] . $replacement . $suffix . $hrefMatch[1];
-                }, $tag, 1) ?? $tag;
-            }
-            return implode("\n", $tags);
-        }, $html) ?? $html;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Style/CssStylesheetChunker.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssStylesheetChunker.php
@@ -34,6 +34,27 @@ final class CssStylesheetChunker
         return $chunks;
     }
 
+    /**
+     * Return directives that each continuation stylesheet needs before its
+     * first style rule. Imports deliberately stay with the first chunk: they
+     * are only legal before namespace declarations and style rules.
+     */
+    public function continuationPreamble(string $stylesheet): string
+    {
+        $preamble = '';
+        $offset = 0;
+        while (null !== ($boundary = $this->nextBoundary($stylesheet, $offset)) && ';' === $stylesheet[$boundary]) {
+            $statement = substr($stylesheet, $offset, $boundary - $offset + 1);
+            if (1 === preg_match('/^\s*@(?:charset|namespace)\b/i', $statement)) {
+                $preamble .= $statement;
+            } elseif (!preg_match('/^\s*@import\b/i', $statement)) {
+                break;
+            }
+            $offset = $boundary + 1;
+        }
+        return $preamble;
+    }
+
     /** @return list<array{css:string,records:int}> */
     private function units(string $css, int $maxSelectorRecords): array
     {

--- a/php-transformer/src/HtmlToBlocks/Style/CssStylesheetChunker.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssStylesheetChunker.php
@@ -1,0 +1,137 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
+
+/** Splits browser-loaded CSS before selector records approach engine limits. */
+final class CssStylesheetChunker
+{
+    // Blink RuleData positions use 18 bits. Leave headroom for non-selector records.
+    public const MAX_SELECTOR_RECORDS = 200000;
+
+    /** @return list<string> */
+    public function chunk(string $stylesheet, int $maxSelectorRecords = self::MAX_SELECTOR_RECORDS): array
+    {
+        if ($maxSelectorRecords < 1 || '' === $stylesheet) {
+            return array($stylesheet);
+        }
+
+        $chunks = array();
+        $content = '';
+        $records = 0;
+        foreach ($this->units($stylesheet, $maxSelectorRecords) as $unit) {
+            if ('' !== $content && $records + $unit['records'] > $maxSelectorRecords) {
+                $chunks[] = $content;
+                $content = '';
+                $records = 0;
+            }
+            $content .= $unit['css'];
+            $records += $unit['records'];
+        }
+        if ('' !== $content || array() === $chunks) {
+            $chunks[] = $content;
+        }
+        return $chunks;
+    }
+
+    /** @return list<array{css:string,records:int}> */
+    private function units(string $css, int $maxSelectorRecords): array
+    {
+        $units = array();
+        $offset = 0;
+        $length = strlen($css);
+        while ($offset < $length) {
+            $boundary = $this->nextBoundary($css, $offset);
+            if (null === $boundary) {
+                $units[] = array('css' => substr($css, $offset), 'records' => 0);
+                break;
+            }
+            if (';' === $css[$boundary]) {
+                $units[] = array('css' => substr($css, $offset, $boundary - $offset + 1), 'records' => 0);
+                $offset = $boundary + 1;
+                continue;
+            }
+            $end = $this->matchingBrace($css, $boundary);
+            if (null === $end) {
+                return array(array('css' => $css, 'records' => 0));
+            }
+            $prelude = substr($css, $offset, $boundary - $offset);
+            $body = substr($css, $boundary + 1, $end - $boundary - 1);
+            if ('@' === $this->firstSignificantCharacter($prelude) && $this->walksNestedRules($prelude)) {
+                foreach ($this->units($body, $maxSelectorRecords) as $unit) {
+                    $units[] = array('css' => $prelude . '{' . $unit['css'] . '}', 'records' => $unit['records']);
+                }
+            } elseif ('@' === $this->firstSignificantCharacter($prelude)) {
+                $units[] = array('css' => substr($css, $offset, $end - $offset + 1), 'records' => 0);
+            } else {
+                $selectors = CssStylesheetTransformer::splitSelectorList($prelude);
+                if (null === $selectors) {
+                    return array(array('css' => $css, 'records' => 0));
+                }
+                foreach (array_chunk($selectors, $maxSelectorRecords) as $selectorChunk) {
+                    $units[] = array('css' => implode(',', $selectorChunk) . '{' . $body . '}', 'records' => count($selectorChunk));
+                }
+            }
+            $offset = $end + 1;
+        }
+        return $units;
+    }
+
+    private function nextBoundary(string $css, int $offset): ?int
+    {
+        $state = CssSyntaxScanner::state();
+        for ($index = $offset, $length = strlen($css); $index < $length; ) {
+            $topLevel = CssSyntaxScanner::isTopLevel($state);
+            $next = CssSyntaxScanner::consume($css, $index, $state);
+            if (null === $next) {
+                return null;
+            }
+            if ($topLevel && $next === $index + 1 && ('{' === $css[$index] || ';' === $css[$index])) {
+                return $index;
+            }
+            $index = $next;
+        }
+        return null;
+    }
+
+    private function matchingBrace(string $css, int $openingBrace): ?int
+    {
+        $state = CssSyntaxScanner::state();
+        $depth = 0;
+        for ($index = $openingBrace, $length = strlen($css); $index < $length; ) {
+            $topLevel = CssSyntaxScanner::isTopLevel($state);
+            $next = CssSyntaxScanner::consume($css, $index, $state);
+            if (null === $next) {
+                return null;
+            }
+            if ($topLevel && $next === $index + 1 && '{' === $css[$index]) {
+                ++$depth;
+            } elseif ($topLevel && $next === $index + 1 && '}' === $css[$index] && 0 === --$depth) {
+                return $index;
+            }
+            $index = $next;
+        }
+        return null;
+    }
+
+    private function firstSignificantCharacter(string $value): string
+    {
+        $state = CssSyntaxScanner::state();
+        for ($offset = 0, $length = strlen($value); $offset < $length; ) {
+            $next = CssSyntaxScanner::consume($value, $offset, $state);
+            if (null === $next) {
+                return '';
+            }
+            if ($next === $offset + 1 && CssSyntaxScanner::isTopLevel($state) && ! CssSyntaxScanner::isCssWhitespace($value[$offset])) {
+                return $value[$offset];
+            }
+            $offset = $next;
+        }
+        return '';
+    }
+
+    private function walksNestedRules(string $prelude): bool
+    {
+        return 1 === preg_match('/^\s*@(container|layer|media|scope|starting-style|supports)\b/i', $prelude);
+    }
+}

--- a/php-transformer/tests/unit/stylesheet-selector-budget.php
+++ b/php-transformer/tests/unit/stylesheet-selector-budget.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssStylesheetChunker;
+
+$failures = 0;
+$assert = static function (bool $condition, string $message) use (&$failures): void {
+    if ($condition) {
+        return;
+    }
+    ++$failures;
+    fwrite(STDERR, "FAIL: {$message}\n");
+};
+
+$css = '@import url("fonts.css");.one,.two,.three{color:red}@media (max-width:600px){.one,.two,.three{color:blue}}';
+$chunks = (new CssStylesheetChunker())->chunk($css, 2);
+$assert(
+    array(
+        '@import url("fonts.css");.one,.two{color:red}',
+        '.three{color:red}',
+        '@media (max-width:600px){.one,.two{color:blue}}',
+        '@media (max-width:600px){.three{color:blue}}',
+    ) === $chunks,
+    'selector-budget chunking preserves preambles, selector order, and nested media conditions'
+);
+
+$result = (new ArtifactCompiler(stylesheetSelectorBudget: 2))->compile(array(
+    'entrypoint' => 'website/index.html',
+    'files' => array(
+        array('path' => 'website/index.html', 'kind' => 'html', 'content' => '<link rel="stylesheet" href="assets/site.css"><main><p class="one">One</p><p class="two">Two</p><p class="three">Three</p></main>'),
+        array('path' => 'website/assets/site.css', 'kind' => 'css', 'content' => '.one,.two,.three{color:red}@media (max-width:600px){.one,.two,.three{color:blue}}'),
+    ),
+))->toArray();
+$assets = array_values(array_filter($result['assets'] ?? array(), static fn (array $asset): bool => str_starts_with((string) ($asset['path'] ?? ''), 'website/assets/site')));
+$assetsByPath = array_column($assets, null, 'path');
+$expectedPaths = array('website/assets/site.css', 'website/assets/site.chunk-2.css', 'website/assets/site.chunk-3.css', 'website/assets/site.chunk-4.css');
+$assert(
+    '.one,.two{color:red}' === ($assetsByPath['website/assets/site.css']['content'] ?? null)
+        && '.three{color:red}' === ($assetsByPath['website/assets/site.chunk-2.css']['content'] ?? null)
+        && '@media (max-width:600px){.one,.two{color:blue}}' === ($assetsByPath['website/assets/site.chunk-3.css']['content'] ?? null)
+        && '@media (max-width:600px){.three{color:blue}}' === ($assetsByPath['website/assets/site.chunk-4.css']['content'] ?? null),
+    'projected stylesheet chunks retain ordered cascade fragments as distinct assets'
+);
+$planAssets = array_values(array_filter($result['source_reports']['wordpress_site_plan']['assets'] ?? array(), static fn (array $asset): bool => str_starts_with((string) ($asset['source_path'] ?? ''), 'website/assets/site')));
+$planAssetPathsByToken = array();
+foreach ($planAssets as $asset) {
+    $planAssetPathsByToken['{{wordpress-site-plan:asset:' . ($asset['token'] ?? '') . '}}'] = (string) ($asset['source_path'] ?? '');
+}
+$linkPaths = array_map(static fn (array $link): string => (string) ($planAssetPathsByToken[$link['asset_reference'] ?? ''] ?? ''), $result['source_reports']['wordpress_site_plan']['pages'][0]['document_metadata']['links'] ?? array());
+$assert(
+    $expectedPaths === $linkPaths,
+    'stylesheet chunk links are wired into the WordPress site plan in source order'
+);
+
+if (0 < $failures) {
+    exit(1);
+}
+fwrite(STDOUT, "stylesheet selector budget passed\n");

--- a/php-transformer/tests/unit/stylesheet-selector-budget.php
+++ b/php-transformer/tests/unit/stylesheet-selector-budget.php
@@ -15,44 +15,48 @@ $assert = static function (bool $condition, string $message) use (&$failures): v
     fwrite(STDERR, "FAIL: {$message}\n");
 };
 
-$css = '@import url("fonts.css");.one,.two,.three{color:red}@media (max-width:600px){.one,.two,.three{color:blue}}';
+$css = '@charset "UTF-8";@import url("fonts.css");@namespace svg url("http://www.w3.org/2000/svg");svg|a,svg|b,svg|c{color:red}@media (max-width:600px){svg|a,svg|b,svg|c{color:blue}}';
 $chunks = (new CssStylesheetChunker())->chunk($css, 2);
 $assert(
     array(
-        '@import url("fonts.css");.one,.two{color:red}',
-        '.three{color:red}',
-        '@media (max-width:600px){.one,.two{color:blue}}',
-        '@media (max-width:600px){.three{color:blue}}',
+        '@charset "UTF-8";@import url("fonts.css");@namespace svg url("http://www.w3.org/2000/svg");svg|a,svg|b{color:red}',
+        'svg|c{color:red}',
+        '@media (max-width:600px){svg|a,svg|b{color:blue}}',
+        '@media (max-width:600px){svg|c{color:blue}}',
     ) === $chunks,
     'selector-budget chunking preserves preambles, selector order, and nested media conditions'
+);
+$assert(
+    '@charset "UTF-8";@namespace svg url("http://www.w3.org/2000/svg");' === (new CssStylesheetChunker())->continuationPreamble($css),
+    'continuation stylesheets retain their required charset and namespace preamble without repeating imports'
 );
 
 $result = (new ArtifactCompiler(stylesheetSelectorBudget: 2))->compile(array(
     'entrypoint' => 'website/index.html',
     'files' => array(
-        array('path' => 'website/index.html', 'kind' => 'html', 'content' => '<link rel="stylesheet" href="assets/site.css"><main><p class="one">One</p><p class="two">Two</p><p class="three">Three</p></main>'),
-        array('path' => 'website/assets/site.css', 'kind' => 'css', 'content' => '.one,.two,.three{color:red}@media (max-width:600px){.one,.two,.three{color:blue}}'),
+        array('path' => 'website/index.html', 'kind' => 'html', 'content' => '<link rel="stylesheet" href="assets/main.css"><main><p class="one">One</p><p class="two">Two</p><p class="three">Three</p></main>'),
+        array('path' => 'website/assets/main.css', 'kind' => 'css', 'content' => '@import url("imported.css");.root{color:black}'),
+        array('path' => 'website/assets/imported.css', 'kind' => 'css', 'content' => '.one,.two,.three{color:red}'),
     ),
 ))->toArray();
-$assets = array_values(array_filter($result['assets'] ?? array(), static fn (array $asset): bool => str_starts_with((string) ($asset['path'] ?? ''), 'website/assets/site')));
+$assets = array_values(array_filter($result['assets'] ?? array(), static fn (array $asset): bool => str_starts_with((string) ($asset['path'] ?? ''), 'website/assets/')));
 $assetsByPath = array_column($assets, null, 'path');
-$expectedPaths = array('website/assets/site.css', 'website/assets/site.chunk-2.css', 'website/assets/site.chunk-3.css', 'website/assets/site.chunk-4.css');
 $assert(
-    '.one,.two{color:red}' === ($assetsByPath['website/assets/site.css']['content'] ?? null)
-        && '.three{color:red}' === ($assetsByPath['website/assets/site.chunk-2.css']['content'] ?? null)
-        && '@media (max-width:600px){.one,.two{color:blue}}' === ($assetsByPath['website/assets/site.chunk-3.css']['content'] ?? null)
-        && '@media (max-width:600px){.three{color:blue}}' === ($assetsByPath['website/assets/site.chunk-4.css']['content'] ?? null),
-    'projected stylesheet chunks retain ordered cascade fragments as distinct assets'
+    str_contains((string) ($assetsByPath['website/assets/main.css']['content'] ?? ''), '@import url("imported.css");')
+        && '@import url("imported.chunk-1.css");@import url("imported.chunk-2.css");' === ($assetsByPath['website/assets/imported.css']['content'] ?? null)
+        && '.one,.two{color:red}' === ($assetsByPath['website/assets/imported.chunk-1.css']['content'] ?? null)
+        && '.three{color:red}' === ($assetsByPath['website/assets/imported.chunk-2.css']['content'] ?? null),
+    'imported stylesheets load every continuation chunk in original cascade order'
 );
-$planAssets = array_values(array_filter($result['source_reports']['wordpress_site_plan']['assets'] ?? array(), static fn (array $asset): bool => str_starts_with((string) ($asset['source_path'] ?? ''), 'website/assets/site')));
+$planAssets = array_values(array_filter($result['source_reports']['wordpress_site_plan']['assets'] ?? array(), static fn (array $asset): bool => str_starts_with((string) ($asset['source_path'] ?? ''), 'website/assets/')));
 $planAssetPathsByToken = array();
 foreach ($planAssets as $asset) {
     $planAssetPathsByToken['{{wordpress-site-plan:asset:' . ($asset['token'] ?? '') . '}}'] = (string) ($asset['source_path'] ?? '');
 }
 $linkPaths = array_map(static fn (array $link): string => (string) ($planAssetPathsByToken[$link['asset_reference'] ?? ''] ?? ''), $result['source_reports']['wordpress_site_plan']['pages'][0]['document_metadata']['links'] ?? array());
 $assert(
-    $expectedPaths === $linkPaths,
-    'stylesheet chunk links are wired into the WordPress site plan in source order'
+    array('website/assets/main.css') === $linkPaths && 4 === count($planAssets),
+    'site-plan loading retains the source link while imported continuation assets remain packaged'
 );
 
 if (0 < $failures) {

--- a/php-transformer/tests/unit/stylesheet-selector-budget.php
+++ b/php-transformer/tests/unit/stylesheet-selector-budget.php
@@ -58,6 +58,10 @@ $assert(
     array('website/assets/main.css') === $linkPaths && 4 === count($planAssets),
     'site-plan loading retains the source link while imported continuation assets remain packaged'
 );
+foreach ($assets as $asset) {
+    $content = (string) ($asset['content'] ?? '');
+    $assert(strlen($content) === ($asset['bytes'] ?? null) && hash('sha256', $content) === ($asset['provenance']['hash'] ?? null), 'chunk metadata identifies the exact emitted content, including continuation preambles');
+}
 
 if (0 < $failures) {
     exit(1);


### PR DESCRIPTION
Closes #1549

## Summary
- split generated CSS at rule boundaries below a conservative selector-record budget
- preserve selector order, nested conditions, and cascade order
- keep the original stylesheet path as an ordered `@import` loader for continuation chunks
- repeat required charset/namespace preambles without repeating source imports
- report exact emitted bytes and hashes for every generated chunk

## Verification
- `php tests/unit/stylesheet-selector-budget.php`
- `composer test` (292 parity fixtures plus package-install proof)
- production-shaped import: 256,848-rule source projection loaded late matching control rules correctly after chunking
- browser-verified expected control geometry with zero console/page errors
- `git diff --check origin/trunk...HEAD`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode measured the CSSOM/computed-style failure in Chrome, implemented generic selector-budget chunking and exact provenance, added deterministic regression coverage, and ran the focused, full, package, import, and browser verification under Chris Huber's direction.