### PR TITLE
fix(php-transformer): ignore inert live-region scaffolding

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -2954,6 +2954,12 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             return null;
         }
 
+        // Client-side routers add an empty, visually clipped live region to
+        // announce navigation. It has no editable static content to retain.
+        if ( $this->isInertRouteAnnouncerScaffolding($element) ) {
+            return null;
+        }
+
         // A direct phrasing child participates in its parent's flex or grid
         // layout. Preserve that source element as the editable leaf rather
         // than introducing a paragraph wrapper with core paragraph margins.
@@ -3439,6 +3445,49 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
         }
 
         return true;
+    }
+
+    private function isInertRouteAnnouncerScaffolding(DOMElement $element): bool
+    {
+        if ( ! str_ends_with(strtolower($element->tagName), '-route-announcer')
+            || '' !== trim($element->textContent ?? '')
+            || ! $this->isSafeTransparentCustomElement($element)
+            || array() !== $this->safeDataAttributes($element) ) {
+            return false;
+        }
+
+        $liveRegion = $this->soleElementChild($element);
+        if ( ! $liveRegion instanceof DOMElement
+            || 0 !== $this->childElementCount($liveRegion)
+            || ! in_array(strtolower($liveRegion->tagName), array( 'div', 'p', 'span' ), true)
+            || ! in_array(strtolower(trim($this->attr($liveRegion, 'role'))), array( 'alert', 'log', 'status' ), true)
+            || ! in_array(strtolower(trim($this->attr($liveRegion, 'aria-live'))), array( 'assertive', 'polite' ), true)
+            || ! $this->isVisuallyClippedLiveRegion($liveRegion)
+            || array() !== $this->safeDataAttributes($liveRegion) ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function isVisuallyClippedLiveRegion(DOMElement $element): bool
+    {
+        $declarations = $this->styleResolver->structuralPresentationDeclarations($element);
+        $width = trim((string) ($declarations['width'] ?? ''));
+        $height = trim((string) ($declarations['height'] ?? ''));
+        $clip = strtolower(trim((string) ($declarations['clip'] ?? '')));
+        $clipPath = strtolower(trim((string) ($declarations['clip-path'] ?? '')));
+
+        return 'absolute' === strtolower(trim((string) ($declarations['position'] ?? '')))
+            && 'hidden' === strtolower(trim((string) ($declarations['overflow'] ?? '')))
+            && $this->isAtMostOnePixelLength($width)
+            && $this->isAtMostOnePixelLength($height)
+            && (str_starts_with($clip, 'rect(') || str_starts_with($clipPath, 'inset('));
+    }
+
+    private function isAtMostOnePixelLength(string $value): bool
+    {
+        return 1 === preg_match('/^(?:0|1)px$/i', $value);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -2954,9 +2954,9 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             return null;
         }
 
-        // Client-side routers add an empty, visually clipped live region to
-        // announce navigation. It has no editable static content to retain.
-        if ( $this->isInertRouteAnnouncerScaffolding($element) ) {
+        // Empty, visually clipped live regions are runtime accessibility
+        // scaffolding with no editable static content to retain.
+        if ( $this->isInertLiveRegionScaffolding($element) ) {
             return null;
         }
 
@@ -3447,12 +3447,12 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
         return true;
     }
 
-    private function isInertRouteAnnouncerScaffolding(DOMElement $element): bool
+    private function isInertLiveRegionScaffolding(DOMElement $element): bool
     {
-        if ( ! str_ends_with(strtolower($element->tagName), '-route-announcer')
+        if ( ! str_contains(strtolower($element->tagName), '-')
             || '' !== trim($element->textContent ?? '')
             || ! $this->isSafeTransparentCustomElement($element)
-            || array() !== $this->safeDataAttributes($element) ) {
+            || 0 !== $element->attributes->length ) {
             return false;
         }
 
@@ -3465,6 +3465,13 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             || ! $this->isVisuallyClippedLiveRegion($liveRegion)
             || array() !== $this->safeDataAttributes($liveRegion) ) {
             return false;
+        }
+
+        $allowedAttributes = array( 'aria-atomic', 'aria-live', 'class', 'id', 'role', 'style' );
+        foreach ( $liveRegion->attributes as $attribute ) {
+            if ( ! in_array(strtolower($attribute->name), $allowedAttributes, true) ) {
+                return false;
+            }
         }
 
         return true;

--- a/php-transformer/tests/unit/inert-capture-scaffolding.php
+++ b/php-transformer/tests/unit/inert-capture-scaffolding.php
@@ -20,6 +20,16 @@ $assert(array() === ($inertIframe['fallbacks'] ?? array()), 'hidden sourceless i
 $assert(array() === ($inertIframe['source_reports']['runtime_islands'] ?? array()), 'hidden sourceless iframe emits no runtime island');
 $assert(str_contains((string) ($inertIframe['serialized_blocks'] ?? ''), 'Visible copy') && ! str_contains((string) ($inertIframe['serialized_blocks'] ?? ''), 'archetype'), 'hidden sourceless iframe emits no block');
 
+$routeAnnouncers = $transform('<main><next-route-announcer><p aria-live="assertive" id="__next-route-announcer__" role="alert" style="border:0;clip:rect(0 0 0 0);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;white-space:nowrap;width:1px;word-wrap:normal"></p></next-route-announcer><next-route-announcer><p aria-live="assertive" id="__next-route-announcer__" role="alert" style="border:0;clip:rect(0 0 0 0);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;white-space:nowrap;width:1px;word-wrap:normal"></p></next-route-announcer><h1>Visible heading</h1></main>');
+$assert(array() === ($routeAnnouncers['fallbacks'] ?? array()), 'empty visually clipped route announcers emit no fallback');
+$assert(str_contains((string) ($routeAnnouncers['serialized_blocks'] ?? ''), 'Visible heading') && ! str_contains((string) ($routeAnnouncers['serialized_blocks'] ?? ''), 'next-route-announcer'), 'route announcers emit no editable block');
+
+$announcerWithContent = $transform('<main><next-route-announcer><p aria-live="assertive" role="alert" style="clip:rect(0 0 0 0);height:1px;overflow:hidden;position:absolute;width:1px">Page changed</p></next-route-announcer></main>');
+$assert(str_contains((string) ($announcerWithContent['serialized_blocks'] ?? ''), 'Page changed'), 'route announcers with captured content remain editable');
+
+$customElement = $transform('<main><custom-widget aria-label="Custom control"></custom-widget></main>');
+$assert('custom-widget' === ($customElement['fallbacks'][0]['tag'] ?? ''), 'unrelated custom elements remain explicit fallbacks');
+
 $unreferencedStore = $transform('<main><svg data-dom-store style="display:none"><defs><symbol id="unused"><path d="M0 0h1v1z"/></symbol></defs></svg><p>Visible copy</p></main>');
 $assert(array() === ($unreferencedStore['fallbacks'] ?? array()), 'hidden unreferenced SVG store emits no fallback');
 $assert(! str_contains((string) ($unreferencedStore['serialized_blocks'] ?? ''), 'unused'), 'hidden unreferenced SVG store emits no raw HTML');

--- a/php-transformer/tests/unit/inert-capture-scaffolding.php
+++ b/php-transformer/tests/unit/inert-capture-scaffolding.php
@@ -20,12 +20,15 @@ $assert(array() === ($inertIframe['fallbacks'] ?? array()), 'hidden sourceless i
 $assert(array() === ($inertIframe['source_reports']['runtime_islands'] ?? array()), 'hidden sourceless iframe emits no runtime island');
 $assert(str_contains((string) ($inertIframe['serialized_blocks'] ?? ''), 'Visible copy') && ! str_contains((string) ($inertIframe['serialized_blocks'] ?? ''), 'archetype'), 'hidden sourceless iframe emits no block');
 
-$routeAnnouncers = $transform('<main><next-route-announcer><p aria-live="assertive" id="__next-route-announcer__" role="alert" style="border:0;clip:rect(0 0 0 0);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;white-space:nowrap;width:1px;word-wrap:normal"></p></next-route-announcer><next-route-announcer><p aria-live="assertive" id="__next-route-announcer__" role="alert" style="border:0;clip:rect(0 0 0 0);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;white-space:nowrap;width:1px;word-wrap:normal"></p></next-route-announcer><h1>Visible heading</h1></main>');
-$assert(array() === ($routeAnnouncers['fallbacks'] ?? array()), 'empty visually clipped route announcers emit no fallback');
-$assert(str_contains((string) ($routeAnnouncers['serialized_blocks'] ?? ''), 'Visible heading') && ! str_contains((string) ($routeAnnouncers['serialized_blocks'] ?? ''), 'next-route-announcer'), 'route announcers emit no editable block');
+$inertLiveRegions = $transform('<main><capture-shell><p aria-live="assertive" id="captured-live-region" role="alert" style="border:0;clip:rect(0 0 0 0);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;white-space:nowrap;width:1px;word-wrap:normal"></p></capture-shell><next-route-announcer><p aria-live="assertive" id="__next-route-announcer__" role="alert" style="border:0;clip:rect(0 0 0 0);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;white-space:nowrap;width:1px;word-wrap:normal"></p></next-route-announcer><h1>Visible heading</h1></main>');
+$assert(array() === ($inertLiveRegions['fallbacks'] ?? array()), 'empty visually clipped custom-element live regions emit no fallback regardless of wrapper name');
+$assert(str_contains((string) ($inertLiveRegions['serialized_blocks'] ?? ''), 'Visible heading') && ! str_contains((string) ($inertLiveRegions['serialized_blocks'] ?? ''), 'capture-shell') && ! str_contains((string) ($inertLiveRegions['serialized_blocks'] ?? ''), 'next-route-announcer'), 'inert live-region scaffolding emits no editable block');
 
-$announcerWithContent = $transform('<main><next-route-announcer><p aria-live="assertive" role="alert" style="clip:rect(0 0 0 0);height:1px;overflow:hidden;position:absolute;width:1px">Page changed</p></next-route-announcer></main>');
-$assert(str_contains((string) ($announcerWithContent['serialized_blocks'] ?? ''), 'Page changed'), 'route announcers with captured content remain editable');
+$liveRegionWithContent = $transform('<main><capture-shell><p aria-live="assertive" role="alert" style="clip:rect(0 0 0 0);height:1px;overflow:hidden;position:absolute;width:1px">Page changed</p></capture-shell></main>');
+$assert(str_contains((string) ($liveRegionWithContent['serialized_blocks'] ?? ''), 'Page changed'), 'live regions with captured content remain editable');
+
+$namedWrapper = $transform('<main><capture-shell aria-label="Notifications"><p aria-live="polite" role="status" style="clip-path:inset(50%);height:1px;overflow:hidden;position:absolute;width:1px"></p></capture-shell></main>');
+$assert('capture-shell' === ($namedWrapper['fallbacks'][0]['tag'] ?? ''), 'semantically named custom wrappers remain explicit fallbacks');
 
 $customElement = $transform('<main><custom-widget aria-label="Custom control"></custom-widget></main>');
 $assert('custom-widget' === ($customElement['fallbacks'][0]['tag'] ?? ''), 'unrelated custom elements remain explicit fallbacks');


### PR DESCRIPTION
Closes #1548

## Summary
- classify empty custom-element live-region scaffolding exclusively from observable DOM semantics
- require an attribute-free custom wrapper with one empty, bounded, visually clipped ARIA live region
- omit qualifying runtime scaffolding instead of generating empty HTML fallbacks
- preserve wrappers with captured text, semantic names, unexpected attributes, runtime metadata, or unrelated custom-element structure
- keep the source platform wrapper only as regression input proving wrapper-name independence

## Verification
- `php tests/unit/inert-capture-scaffolding.php` (21 assertions)
- `composer test` (292 parity fixtures plus package-install proof)
- production-shaped 102-page import: removed 204 empty live-region fallbacks while retaining zero content-loss findings
- production source contains no platform or wrapper-name condition
- `git diff --check origin/trunk...HEAD`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode inspected repeated fallback evidence, replaced the initial platform-specific condition with a bounded semantic classifier, added wrapper-independent and fail-closed tests, and ran the focused, full, package, and import verification under Chris Huber's direction.