### PR TITLE
refactor(blocks-engine): remove theme policy duplication and vocabulary hardcoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 **/docs/superpowers/
 node_modules/
 figma-transformer/tmp/
+figma-transformer/build/
 
 # Generated-site candidates (raw generation output; promote to fixtures/websites/ deliberately)
 fixtures/candidates/

--- a/packages/blocks-engine/src/__tests__/theme-assets-static.test.ts
+++ b/packages/blocks-engine/src/__tests__/theme-assets-static.test.ts
@@ -8,6 +8,8 @@ import {
   type StaticImgRef,
 } from '../theme/assets-static.js';
 import { ingest } from '../theme/ingest.js';
+import { rewriteHtmlImageSrcs as rewriteCarriedHtmlImageSrcs } from '../theme/source-assets.js';
+import { themeAssetUrl } from '../theme/theme-asset-url.js';
 import type { SiteModel } from '../theme/types.js';
 
 const fixtureRoot = join(import.meta.dirname, 'fixtures/site');
@@ -70,6 +72,21 @@ describe('theme static assets', () => {
     ).toBe(
       `<img src="/wp-content/themes/calm-theme/assets/logo.png"><img alt="Hero" src='/wp-content/themes/calm-theme/assets/images/hero.jpg'>`
     );
+  });
+
+  it('uses one normalized theme URL policy for static and carried image rewrites', () => {
+    const expected = '/wp-content/themes/calm-theme/assets/logo.png';
+    const refs: StaticImgRef[] = [{
+      ref: 'logo.png',
+      themeRel: '/assets/logo.png',
+      sourcePath: '/tmp/logo.png',
+    }];
+
+    expect(themeAssetUrl('calm-theme', '/assets/logo.png')).toBe(expected);
+    expect(rewriteHtmlImageSrcs('<img src="logo.png">', refs, 'calm-theme')).toContain(expected);
+    expect(
+      rewriteCarriedHtmlImageSrcs('<img src="logo.png">', [{ ref: 'logo.png', themeRel: '/assets/logo.png' }], 'calm-theme'),
+    ).toContain(expected);
   });
 
   it('leaves unrelated src values untouched', () => {

--- a/packages/blocks-engine/src/__tests__/theme-font-faces.test.ts
+++ b/packages/blocks-engine/src/__tests__/theme-font-faces.test.ts
@@ -86,6 +86,25 @@ describe('parseFontFaces', () => {
 
     expect(parseFontFaces(block, block)).toHaveLength(1);
   });
+
+  it('uses the same extensionless format-qualified source in analysis and capture', () => {
+    const css = `@font-face {
+      font-family: "Acme";
+      src: url("https://cdn.example/fonts/acme?id=42") format("woff2"), url(data:font/woff2;base64,abc) format("woff2");
+      font-weight: bold;
+      font-style: italic;
+    }`;
+    const expected = [{
+      family: 'Acme',
+      src: 'https://cdn.example/fonts/acme?id=42',
+      format: 'woff2',
+      weight: '700',
+      style: 'italic',
+    }];
+
+    expect(parseFontFaces(css)).toEqual(expected);
+    expect(parseCapturedFontFaces(css)).toEqual(expected);
+  });
 });
 
 describe('stripUnusedFontFaces', () => {

--- a/packages/blocks-engine/src/__tests__/theme-reveal-neutralizer-contract.test.ts
+++ b/packages/blocks-engine/src/__tests__/theme-reveal-neutralizer-contract.test.ts
@@ -3,28 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
-
-import {
-  assemble,
-  collectSourceAssets,
-  REVEAL_NEUTRALIZER_CSS,
-  REVEAL_NEUTRALIZER_SELECTORS,
-  WP_COMPAT_CSS,
-  type FoundationTokens,
-  type SectionBlocks,
-  type SiteModel,
-  type ThemeMeta,
-} from '../theme/index.js';
-
-const DERIVED_REVEAL_SELECTORS = [
-  '.reveal',
-  '.reveal-up',
-  '.reveal-left',
-  '.reveal-right',
-  '.reveal-scale',
-  '.reveal-stagger > *',
-  '[data-reveal]',
-] as const;
+import { collectSourceAssets } from '../theme/index.js';
 
 function withTempDir<T>(fn: (dir: string) => T): T {
   const dir = mkdtempSync(join(tmpdir(), 'blocks-engine-reveal-neutralizer-'));
@@ -35,212 +14,44 @@ function withTempDir<T>(fn: (dir: string) => T): T {
   }
 }
 
-function writeFixture(dir: string, relPath: string, contents: string): void {
-  const abs = join(dir, relPath);
-  mkdirSync(join(abs, '..'), { recursive: true });
-  writeFileSync(abs, contents, 'utf8');
-}
-
-function sourceCssForRevealFixture(extra = ''): string {
-  return [
-    '.reveal{opacity:0;transform:translateY(36px);transition:opacity .85s,transform .85s}',
-    '.reveal-up{opacity:0;transform:translateY(40px)}',
-    '.reveal-left{opacity:0;transform:translateX(-22px)}',
-    '.reveal-right{opacity:0;transform:translateX(22px)}',
-    '.reveal-scale{opacity:0;transform:scale(.93)}',
-    '.reveal-stagger > *{opacity:0;transform:translateY(22px)}',
-    '[data-reveal]{opacity:0;transform:translateY(26px)}',
-    '.reveal-d1{transition-delay:.10s}',
-    '.not-reveal{opacity:0.42}',
-    extra,
-  ].join('\n');
-}
-
-function siteModel(root: string): SiteModel {
-  return {
-    root,
-    pages: [
-      {
-        relPath: 'index.html',
-        slug: 'home',
-        title: 'Home',
-        html: [
-          '<link rel="stylesheet" href="style.css">',
-          '<section class="reveal">Shown without JS</section>',
-          '<section class="not-reveal">Preserve opacity</section>',
-        ].join(''),
-      },
-    ],
-  };
-}
-
-function foundationTokens(): FoundationTokens {
-  return {
-    palette: [{ name: 'Base', color: '#111111' }],
-    typography: { body: 'Inter', display: 'Inter' },
-    breakpoints: { md: '768px', lg: '1024px', xl: '1280px' },
-  };
-}
-
-function themeMeta(): ThemeMeta {
-  return { name: 'Reveal Fixture', slug: 'reveal-fixture' };
-}
-
-function sectionBlocks(): SectionBlocks[] {
-  return [
-    {
-      spec: {
-        sectionIndex: 0,
-        interactionModel: 'static',
-        top: 0,
-        height: 0,
-        headings: ['Shown without JS'],
-        bodyText: [],
-        buttonLabels: [],
-        images: [],
-        icons: [],
-        backgroundBrightness: 1,
-        backgroundColor: 'transparent',
-        gradient: null,
-        gradientSource: null,
-        motionProfile: {
-          motionClass: 'none',
-          signals: [],
-          animatedElements: 0,
-        },
-        dividerAbove: null,
-        dividerBelow: null,
-        layout: {
-          containerWidth: 0,
-          padding: '0',
-          childLayout: 'stack',
-          columnCount: 1,
-          gap: '0',
-        },
-        sectionHtml: '<section class="reveal">Shown without JS</section>',
-      },
-      blocks: '<!-- wp:paragraph --><p class="reveal">Shown without JS</p><!-- /wp:paragraph -->',
-      coverage: 1,
-    },
-  ];
-}
-
-function assembledRevealStyleCss(sourceCss: string): string {
+function sourceCss(html: string, css: string, js = ''): string {
   return withTempDir((dir) => {
-    writeFixture(dir, 'style.css', sourceCss);
-    const site = siteModel(dir);
-    const sourceAssets = collectSourceAssets(dir, site.pages);
-    return assemble({
-      site,
-      tokens: foundationTokens(),
-      pages: { home: sectionBlocks() },
-      meta: themeMeta(),
-      sourceCss: sourceAssets.css,
-    }).styleCss;
+    writeFileSync(join(dir, 'style.css'), css, 'utf8');
+    if (js) writeFileSync(join(dir, 'main.js'), js, 'utf8');
+    const scripts = js ? '<script src="main.js"></script>' : '';
+    return collectSourceAssets(dir, [{ relPath: 'index.html', html: `<link rel="stylesheet" href="style.css">${scripts}${html}` }]).css;
   });
-}
-
-type Declaration = {
-  order: number;
-  selector: string;
-  property: string;
-  value: string;
-  important: boolean;
-};
-
-function declarationsFor(css: string, property: string): Declaration[] {
-  const declarations: Declaration[] = [];
-  let order = 0;
-  for (const match of css.matchAll(/([^{}]+)\{([^{}]+)\}/g)) {
-    const selector = match[1].replace(/\/\*[\s\S]*?\*\//g, '').trim();
-    const body = match[2];
-    if (!selector) continue;
-    for (const decl of body.matchAll(/(^|;)\s*([a-z-]+)\s*:\s*([^;]+)/g)) {
-      if (decl[2] !== property) continue;
-      const rawValue = decl[3].trim();
-      declarations.push({
-        order,
-        selector,
-        property,
-        value: rawValue.replace(/\s*!important\s*$/i, ''),
-        important: /\s!important\s*$/i.test(rawValue),
-      });
-    }
-    order += 1;
-  }
-  return declarations;
-}
-
-function selectorAppliesToReveal(selector: string): boolean {
-  return selector
-    .split(',')
-    .map((part) => part.trim())
-    .some((part) => part === '.reveal' || part === ':where(.reveal)' || part.includes('.reveal,'));
-}
-
-function winningDeclaration(css: string, property: string): Declaration | undefined {
-  return declarationsFor(css, property)
-    .filter((decl) => selectorAppliesToReveal(decl.selector))
-    .sort((a, b) => Number(a.important) - Number(b.important) || a.order - b.order)
-    .at(-1);
 }
 
 describe('reveal neutralizer contract', () => {
-  it('G1 freezes the corpus-derived reveal selector set and emits it in the carried compat bundle', () => {
-    expect(REVEAL_NEUTRALIZER_SELECTORS).toEqual(DERIVED_REVEAL_SELECTORS);
-    expect(REVEAL_NEUTRALIZER_CSS).toContain(DERIVED_REVEAL_SELECTORS.join(',\n'));
-    expect(WP_COMPAT_CSS).toContain(REVEAL_NEUTRALIZER_CSS);
-  });
-
-  it('G2 proves the neutralizer beats source opacity:0 in assembled style.css', () => {
-    const styleCss = assembledRevealStyleCss(sourceCssForRevealFixture());
-    const sourceRuleIndex = styleCss.indexOf('.reveal{opacity:0');
-    const neutralizerIndex = styleCss.indexOf(REVEAL_NEUTRALIZER_CSS);
-
-    expect(sourceRuleIndex).toBeGreaterThan(-1);
-    expect(neutralizerIndex).toBeGreaterThan(-1);
-
-    const winningOpacity = winningDeclaration(styleCss, 'opacity');
-    const winningTransform = winningDeclaration(styleCss, 'transform');
-    expect(winningOpacity).toMatchObject({ value: '1', important: true });
-    expect(winningTransform).toMatchObject({ value: 'none', important: true });
-  });
-
-  it('G3 scopes the opacity override to reveal selectors only', () => {
-    const styleCss = assembledRevealStyleCss(sourceCssForRevealFixture());
-    const nonRevealOpacityRules = declarationsFor(styleCss, 'opacity').filter((decl) =>
-      decl.selector.includes('.not-reveal')
+  it('neutralizes a source element proven hidden by carried CSS and omitted runtime selector evidence', () => {
+    const css = sourceCss(
+      '<section class="enter">Shown without JS</section>',
+      '.enter{opacity:0;transform:translateY(36px)}',
+      "document.querySelectorAll('.enter').forEach((element) => element.classList.add('visible'));",
     );
 
-    expect(REVEAL_NEUTRALIZER_SELECTORS).not.toContain('.not-reveal');
-    expect(nonRevealOpacityRules).toEqual([
-      expect.objectContaining({
-        selector: '.not-reveal',
-        value: '0.42',
-        important: false,
-      }),
-    ]);
+    expect(css).toContain('.enter {\n  opacity: 1 !important;\n  transform: none !important;\n}');
   });
 
-  it('G4 keeps this slice CSS-only with no script enqueue or JS asset output', () => {
-    const model = withTempDir((dir) => {
-      writeFixture(dir, 'style.css', sourceCssForRevealFixture());
-      writeFixture(dir, 'main.js', 'document.documentElement.classList.add("js");');
-      const site = siteModel(dir);
-      site.pages[0].html += '<script src="main.js"></script>';
-      const sourceAssets = collectSourceAssets(dir, site.pages);
-      return assemble({
-        site,
-        tokens: foundationTokens(),
-        pages: { home: sectionBlocks() },
-        meta: themeMeta(),
-        sourceCss: sourceAssets.css,
-      });
-    });
+  it('leaves permanently hidden and unrelated reveal-named elements untouched', () => {
+    const css = sourceCss(
+      '<section class="reveal">Permanent</section><section class="unrelated">Unrelated</section>',
+      '.reveal,.unrelated{opacity:0;transform:translateY(36px)}',
+      "document.querySelectorAll('.other').forEach(() => {});",
+    );
 
-    expect(model.functionsPhp).toBeDefined();
-    expect(model.functionsPhp).toContain('wp_enqueue_style(');
-    expect(model.functionsPhp).not.toMatch(/\bwp_enqueue_script\s*\(/);
-    expect(model.assets.map((asset) => asset.relPath)).not.toContain('assets/js/source.js');
+    expect(css).not.toContain('opacity: 1 !important');
+    expect(css).toContain('.reveal,.unrelated{opacity:0;transform:translateY(36px)}');
+  });
+
+  it('requires source DOM evidence before neutralizing a runtime-selected hidden selector', () => {
+    const css = sourceCss(
+      '<section class="other">Visible</section>',
+      '.enter{opacity:0;transform:translateY(36px)}',
+      "document.querySelectorAll('.enter').forEach(() => {});",
+    );
+
+    expect(css).not.toContain('opacity: 1 !important');
   });
 });

--- a/packages/blocks-engine/src/__tests__/theme-source-assets-parity.test.ts
+++ b/packages/blocks-engine/src/__tests__/theme-source-assets-parity.test.ts
@@ -10,7 +10,6 @@ import {
   collectSourceAssets,
   buildNavigationAnchorCompatCss,
   localizeCssImages,
-  REVEAL_NEUTRALIZER_CSS,
   rewriteHtmlImageSrcs,
   WP_COMPAT_CSS,
 } from '../theme/index.js';
@@ -67,7 +66,7 @@ nav.wp-block-navigation ul, nav.wp-block-navigation li { display: contents; }
   color: inherit;
   text-decoration: none;
 }
-${REVEAL_NEUTRALIZER_CSS}`;
+`;
 
 function withTempDir<T>(fn: (dir: string) => T): T {
   const dir = mkdtempSync(join(tmpdir(), 'blocks-engine-source-assets-'));

--- a/packages/blocks-engine/src/theme/assets-static.ts
+++ b/packages/blocks-engine/src/theme/assets-static.ts
@@ -1,5 +1,6 @@
 import { statSync } from 'node:fs';
 import { dirname, extname, isAbsolute, relative, resolve, sep } from 'node:path';
+import { themeAssetUrl } from './theme-asset-url.js';
 import type { AssetFile, SiteModel, SitePage } from './types.js';
 
 export interface StaticImgRef {
@@ -188,10 +189,6 @@ function compareAssetFiles(a: AssetFile, b: AssetFile): number {
   const rel = a.relPath.localeCompare(b.relPath);
   if (rel !== 0) return rel;
   return (a.sourcePath ?? '').localeCompare(b.sourcePath ?? '');
-}
-
-function themeAssetUrl(themeSlug: string, themeRel: string): string {
-  return `/wp-content/themes/${themeSlug}/${themeRel.replace(/^\/+/, '')}`;
 }
 
 function isInside(root: string, file: string): boolean {

--- a/packages/blocks-engine/src/theme/font-capture.ts
+++ b/packages/blocks-engine/src/theme/font-capture.ts
@@ -1,16 +1,7 @@
-/** One normalized `@font-face` rule extracted from source CSS. */
-export interface ParsedFontFace {
-  /** Declared font-family name, unquoted (e.g. "Larsseit"). */
-  family: string;
-  /** Absolute (or protocol-relative) URL of the first usable font file. */
-  src: string;
-  /** Lowercased file extension without the dot, e.g. "woff" / "woff2" / "ttf". */
-  format: string;
-  /** font-weight value as written (e.g. "400", "700", "normal", "bold"). */
-  weight: string;
-  /** font-style value as written (e.g. "normal", "italic"). */
-  style: string;
-}
+import { parseFontFaces as parseAllFontFaces } from './font-faces.js';
+import type { ParsedFontFace } from './font-faces.js';
+
+export type { ParsedFontFace } from './font-faces.js';
 
 /** A captured font with a resolved LOCAL asset path inside the theme. */
 export interface LocalFontFace extends ParsedFontFace {
@@ -18,106 +9,13 @@ export interface LocalFontFace extends ParsedFontFace {
   localPath: string;
 }
 
-const FONT_EXTENSIONS = new Set(['woff2', 'woff', 'ttf', 'otf', 'eot', 'svg']);
-
-const GENERIC_FAMILIES = new Set([
-  'serif',
-  'sans-serif',
-  'monospace',
-  'cursive',
-  'fantasy',
-  'system-ui',
-  'ui-sans-serif',
-  'ui-serif',
-  'ui-monospace',
-  'inherit',
-  'initial',
-]);
-
 /** Substrings in a font URL that mark third-party widget fonts (not the site's own). */
 const THIRD_PARTY_FONT_HOST_HINTS = ['klaviyo.com', 'gstatic.com', 'typekit.net', 'use.typekit'];
 
 export function parseFontFaces(...cssOrHtml: string[]): ParsedFontFace[] {
-  const faces: ParsedFontFace[] = [];
-  const seen = new Set<string>();
-
-  for (const input of cssOrHtml) {
-    if (!input) continue;
-    const blockRe = /@font-face\s*\{([^}]*)\}/gi;
-    let block: RegExpExecArray | null;
-    while ((block = blockRe.exec(input)) !== null) {
-      const body = block[1];
-
-      const family = readDeclaration(body, 'font-family');
-      if (!family) continue;
-      const familyClean = family.replace(/^["']|["']$/g, '').trim();
-      if (!familyClean || GENERIC_FAMILIES.has(familyClean.toLowerCase())) continue;
-
-      const srcDecl = readDeclaration(body, 'src');
-      if (!srcDecl) continue;
-      const picked = pickBestFontUrl(srcDecl);
-      if (!picked) continue;
-      if (THIRD_PARTY_FONT_HOST_HINTS.some((h) => picked.url.toLowerCase().includes(h))) continue;
-
-      const weight = normalizeWeight(readDeclaration(body, 'font-weight') ?? '400');
-      const style = normalizeStyle(readDeclaration(body, 'font-style'));
-
-      const key = `${familyClean.toLowerCase()}|${weight}|${style}|${picked.url}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-
-      faces.push({ family: familyClean, src: picked.url, format: picked.format, weight, style });
-    }
-  }
-
-  return faces;
-}
-
-function readDeclaration(body: string, prop: string): string | null {
-  const re = new RegExp(`${prop}\\s*:\\s*([^;]+)`, 'i');
-  const m = re.exec(body);
-  return m ? m[1].trim() : null;
-}
-
-function pickBestFontUrl(srcDecl: string): { url: string; format: string } | null {
-  const urlRe = /url\(\s*(['"]?)([^'")]+)\1\s*\)/gi;
-  const candidates: { url: string; format: string }[] = [];
-  let m: RegExpExecArray | null;
-  while ((m = urlRe.exec(srcDecl)) !== null) {
-    const url = m[2].trim();
-    const ext = fontExtension(url);
-    if (ext) candidates.push({ url, format: ext });
-  }
-  if (candidates.length === 0) return null;
-  const byPref = (c: { format: string }): number =>
-    c.format === 'woff2' ? 0 : c.format === 'woff' ? 1 : 2;
-  candidates.sort((a, b) => byPref(a) - byPref(b));
-  return candidates[0];
-}
-
-function fontExtension(url: string): string | null {
-  // Strip query string + fragment before reading the extension.
-  const clean = url.split('?')[0].split('#')[0];
-  const dot = clean.lastIndexOf('.');
-  if (dot < 0) return null;
-  const ext = clean.slice(dot + 1).toLowerCase();
-  return FONT_EXTENSIONS.has(ext) ? ext : null;
-}
-
-function normalizeWeight(raw: string): string {
-  const v = raw.trim().toLowerCase();
-  if (v === 'normal') return '400';
-  if (v === 'bold') return '700';
-  // Weight ranges ("400 700") - keep the first.
-  const num = /\d{3}/.exec(v);
-  return num ? num[0] : '400';
-}
-
-function normalizeStyle(raw: string | null): string {
-  const v = (raw ?? '').trim().toLowerCase();
-  if (v === 'italic') return 'italic';
-  if (v.startsWith('oblique')) return 'oblique';
-  return 'normal';
+  return parseAllFontFaces(...cssOrHtml).filter(
+    (face) => !THIRD_PARTY_FONT_HOST_HINTS.some((host) => face.src.toLowerCase().includes(host)),
+  );
 }
 
 export function absolutizeFontUrl(src: string, baseUrl?: string): string {
@@ -143,6 +41,14 @@ export function fontFilename(face: ParsedFontFace): string {
   const familySlug = face.family.replace(/[^A-Za-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
   const italic = face.style === 'italic' ? '-italic' : '';
   return `${familySlug}-${face.weight}${italic}.${face.format}`;
+}
+
+function fontExtension(url: string): string | null {
+  const clean = url.split('?')[0].split('#')[0];
+  const dot = clean.lastIndexOf('.');
+  if (dot < 0) return null;
+  const ext = clean.slice(dot + 1).toLowerCase();
+  return ['woff2', 'woff', 'ttf', 'otf', 'eot', 'svg'].includes(ext) ? ext : null;
 }
 
 export function buildFontFaceCss(faces: LocalFontFace[]): string {

--- a/packages/blocks-engine/src/theme/font-faces.ts
+++ b/packages/blocks-engine/src/theme/font-faces.ts
@@ -1,9 +1,9 @@
 export interface ParsedFontFace {
   family: string;
   src: string;
-  format?: string;
-  weight?: string;
-  style?: string;
+  format: string;
+  weight: string;
+  style: string;
 }
 
 const FONT_EXTENSIONS = new Set(['woff2', 'woff', 'ttf', 'otf', 'eot', 'svg']);

--- a/packages/blocks-engine/src/theme/index.ts
+++ b/packages/blocks-engine/src/theme/index.ts
@@ -60,9 +60,8 @@ export {
 } from './source-assets.js';
 export {
   buildRevealNeutralizerCss,
-  REVEAL_NEUTRALIZER_CSS,
-  REVEAL_NEUTRALIZER_SELECTORS,
 } from './reveal-neutralizer.js';
+export { themeAssetUrl } from './theme-asset-url.js';
 export { extractGoogleFontCssUrls } from './google-fonts.js';
 export {
   absolutizeFontUrl,

--- a/packages/blocks-engine/src/theme/reveal-neutralizer.ts
+++ b/packages/blocks-engine/src/theme/reveal-neutralizer.ts
@@ -1,16 +1,11 @@
-export const REVEAL_NEUTRALIZER_SELECTORS = [
-  '.reveal',
-  '.reveal-up',
-  '.reveal-left',
-  '.reveal-right',
-  '.reveal-scale',
-  '.reveal-stagger > *',
-  '[data-reveal]',
-] as const;
-
 export function buildRevealNeutralizerCss(
-  selectors: readonly string[] = REVEAL_NEUTRALIZER_SELECTORS
+  sourceCss: string,
+  sourceHtml: readonly string[],
+  sourceJs: string,
 ): string {
+  const selectors = hiddenRuntimeSelectors(sourceCss, sourceHtml, sourceJs);
+  if (selectors.length === 0) return '';
+
   return `/* wp-compat: reveal gates need JS that is not carried yet, so render them visible */
 ${selectors.join(',\n')} {
   opacity: 1 !important;
@@ -19,4 +14,42 @@ ${selectors.join(',\n')} {
 `;
 }
 
-export const REVEAL_NEUTRALIZER_CSS = buildRevealNeutralizerCss();
+function hiddenRuntimeSelectors(sourceCss: string, sourceHtml: readonly string[], sourceJs: string): string[] {
+  if (!sourceJs.trim()) return [];
+
+  const runtimeSelectors = new Set<string>();
+  for (const match of sourceJs.matchAll(/querySelector(?:All)?\(\s*(['"])(.*?)\1\s*\)/gs)) {
+    runtimeSelectors.add(match[2].trim());
+  }
+
+  const hidden = new Set<string>();
+  for (const match of sourceCss.matchAll(/([^{}@][^{}]*)\{([^{}]*)\}/g)) {
+    if (!/(?:^|;)\s*opacity\s*:\s*0(?:\s*!important)?\s*(?:;|$)/i.test(match[2])) continue;
+    for (const selector of splitSelectorList(match[1])) {
+      if (runtimeSelectors.has(selector) && selectorMatchesSourceHtml(selector, sourceHtml)) {
+        hidden.add(selector);
+      }
+    }
+  }
+
+  return [...hidden];
+}
+
+function splitSelectorList(selectorList: string): string[] {
+  return selectorList.split(',').map((selector) => selector.trim()).filter(Boolean);
+}
+
+function selectorMatchesSourceHtml(selector: string, sourceHtml: readonly string[]): boolean {
+  const classMatch = /^\.([A-Za-z][\w-]*)$/.exec(selector);
+  if (classMatch) {
+    const className = classMatch[1];
+    return sourceHtml.some((html) => new RegExp(`\\bclass\\s*=\\s*(["'])[^"']*\\b${className}\\b[^"']*\\1`, 'i').test(html));
+  }
+
+  const dataMatch = /^\[data-([\w-]+)(?:=[^\]]+)?\]$/.exec(selector);
+  if (dataMatch) {
+    return sourceHtml.some((html) => new RegExp(`\\bdata-${dataMatch[1]}(?:\\s|=|>)`, 'i').test(html));
+  }
+
+  return false;
+}

--- a/packages/blocks-engine/src/theme/site-to-theme.ts
+++ b/packages/blocks-engine/src/theme/site-to-theme.ts
@@ -15,6 +15,7 @@ import { extractSourceLandmarksFromHtml } from './region-census.js';
 import { reconcileRegions, type PlacedRegion, type RegionSelectionReport } from './region-audit.js';
 import { sectionExtract } from './section-extract.js';
 import { collectSourceAssets, type ImgAssetRef, type MediaAsset } from './source-assets.js';
+import { themeAssetUrl } from './theme-asset-url.js';
 import { hasCarriedSourceCss, shouldCarrySourceCss } from './source-css-carry.js';
 import {
   collectRemoteImageAssets,
@@ -351,10 +352,6 @@ function mergeCarriedImgAssets(
   }
 
   return sortAssetFiles([...byRelPath.values()]);
-}
-
-function themeAssetUrl(themeSlug: string, themeRel: string): string {
-  return `/wp-content/themes/${themeSlug}/${themeRel.replace(/^\/+/, '')}`;
 }
 
 function buildRegionAuditDiagnostics(

--- a/packages/blocks-engine/src/theme/source-assets.ts
+++ b/packages/blocks-engine/src/theme/source-assets.ts
@@ -15,7 +15,8 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, posix } from 'node:path';
 import { buildAdminBarAccommodationCss } from './admin-bar-accommodation.js';
-import { REVEAL_NEUTRALIZER_CSS } from './reveal-neutralizer.js';
+import { buildRevealNeutralizerCss } from './reveal-neutralizer.js';
+import { themeAssetUrl } from './theme-asset-url.js';
 
 /** Neutralize WP-injected wrappers so source layout selectors keep working.
  * Prepended (lowest precedence) — source rules always win over it. */
@@ -71,7 +72,7 @@ nav.wp-block-navigation ul, nav.wp-block-navigation li { display: contents; }
   color: inherit;
   text-decoration: none;
 }
-${REVEAL_NEUTRALIZER_CSS}`;
+`;
 
 const GOOGLE_IMPORT_RE = /@import\s+url\(\s*['"]?https:\/\/fonts\.googleapis\.com[^)]*\)\s*;?/g;
 
@@ -277,7 +278,7 @@ export function collectHtmlImages(
 export function rewriteHtmlImageSrcs(html: string, refs: ImgAssetRef[], themeSlug: string): string {
   let out = html;
   for (const { ref, themeRel } of refs) {
-    const themeUrl = `/wp-content/themes/${themeSlug}/${themeRel}`;
+    const themeUrl = themeAssetUrl(themeSlug, themeRel);
     out = out.split(`"${ref}"`).join(`"${themeUrl}"`).split(`'${ref}'`).join(`'${themeUrl}'`);
   }
   return out;
@@ -410,7 +411,12 @@ export function collectSourceAssets(
   // startsWith(WP_COMPAT_CSS) is preserved; Google imports only exist in cssParts.
   const { parts: localizedParts, mediaAssets } = localizeCssImages(cssParts, dir);
   const sourceCss = localizedParts.join('\n\n').replace(GOOGLE_IMPORT_RE, '');
-  const baseCss = WP_COMPAT_CSS + sourceCss + buildNavigationAnchorCompatCss(sourceCss);
+  const revealCss = buildRevealNeutralizerCss(
+    sourceCss,
+    pageHtmls.map((page) => page.html),
+    jsParts.join('\n\n'),
+  );
+  const baseCss = WP_COMPAT_CSS + revealCss + sourceCss + buildNavigationAnchorCompatCss(sourceCss);
   // Append admin-bar accommodation LAST: scan the assembled source CSS for
   // top-anchored fixed/sticky chrome and shift it below the WP admin bar for
   // logged-in viewers (the bar otherwise overlays a `position:fixed; top:0`

--- a/packages/blocks-engine/src/theme/theme-asset-url.ts
+++ b/packages/blocks-engine/src/theme/theme-asset-url.ts
@@ -1,0 +1,3 @@
+export function themeAssetUrl(themeSlug: string, themeRel: string): string {
+  return `/wp-content/themes/${themeSlug}/${themeRel.replace(/^\/+/, '')}`;
+}


### PR DESCRIPTION
Closes #1555
Closes #1557
Closes #1558

## What

- Ignore `figma-transformer/build/` output.
- Share one `@font-face` source parser between analysis and capture, so an extensionless `format()`-qualified URL is accepted consistently.
- Centralize generated theme asset URL construction in `themeAssetUrl()`.
- Emit reveal neutralization only where carried CSS hides an element that omitted source JavaScript actually selects, replacing the unconditional `.reveal*`/`[data-reveal]` vocabulary.

## Why

An architecture review found the reveal layer forcing `opacity`/`transform` overrides on a fixed corpus-derived class list regardless of evidence, two divergent font parsers, and duplicated `/wp-content/themes/...` policy.

## Verification

- `pnpm exec tsc --noEmit` clean.
- Full package suite: 103 files / 496 tests pass (`wp-runtime-bundle` excluded; it requires `pnpm build`).
- Reveal contract now covers a positive case, an unrelated `.reveal`-named counterfactual, and a missing-DOM-evidence case.

## Risk

Neutralization now requires runtime selector evidence via `querySelector`/`querySelectorAll`. Reveal runtimes expressed differently (for example jQuery selectors) will no longer be neutralized and would need follow-up evidence extraction.

## AI assistance

OpenAI `gpt-5.6-sol` running in OpenCode audited the theme pipeline, implemented these changes, and ran the verification above. A human directed the work and reviewed the result.