### PR TITLE
refactor(blocks-engine): add a provider-neutral form materializer seam

### DIFF
--- a/packages/blocks-engine/src/__tests__/theme-contracts.test.ts
+++ b/packages/blocks-engine/src/__tests__/theme-contracts.test.ts
@@ -16,6 +16,7 @@ import {
   hoistVariations,
   HOIST_MIN_INSTANCES,
   ingest,
+  jetpackFormMaterializer,
   landmarkRoleForHtmlRoot,
   planTemplates,
   reconstruct,
@@ -32,6 +33,7 @@ import {
   type FoundationAggregates,
   type FoundationTokens,
   type FormBlocksResult,
+  type FormMaterializer,
   type HoistedVariation,
   type HoistPage,
   type HoistResult,
@@ -712,6 +714,40 @@ describe('fallback diagnostics DLA parity', () => {
 });
 
 describe('formToBlocks DLA parity', () => {
+  it('lets a consumer supply a provider-neutral form materializer', () => {
+    const custom: FormMaterializer = {
+      name: 'custom-provider',
+      materialize: (form) => ({
+        markup: `<!-- wp:custom/form {"submit":"${form.submitLabel}"} /-->`,
+        unsupported: form.fields
+          .filter((field) => field.kind === 'file')
+          .map((field) => ({ kind: field.kind, label: field.label, reason: 'provider has no file control' })),
+        diagnostics: [],
+      }),
+    };
+
+    const result = custom.materialize(
+      sectionForm([formField({ kind: 'email', label: 'Email' }), formField({ kind: 'file', label: 'Resume' })]),
+    );
+
+    expect(result.markup).toContain('wp:custom/form');
+    expect(result.markup).not.toContain('jetpack/');
+    expect(result.unsupported).toEqual([
+      { kind: 'file', label: 'Resume', reason: 'provider has no file control' },
+    ]);
+  });
+
+  it('keeps Jetpack output behind an opt-in adapter with explicit unsupported-control diagnostics', () => {
+    const result = jetpackFormMaterializer.materialize(
+      sectionForm([formField({ kind: 'email', label: 'Email' }), formField({ kind: 'file', label: 'Resume' })]),
+    );
+
+    expect(result.markup).toContain('wp:jetpack/contact-form');
+    expect(result.unsupported).toEqual([
+      { kind: 'file', label: 'Resume', reason: 'has no Jetpack form equivalent' },
+    ]);
+  });
+
   it('exports the DLA form-blocks surface and emits jetpack/field-* blocks for every mapped field kind', () => {
     const formToBlocksType: (form: SectionSpecForm) => FormBlocksResult = formToBlocks;
     void formToBlocksType;

--- a/packages/blocks-engine/src/theme/form-blocks.ts
+++ b/packages/blocks-engine/src/theme/form-blocks.ts
@@ -44,6 +44,24 @@
 //
 import type { SectionSpecForm, SectionSpecFormField } from './section-spec.js';
 
+export interface UnsupportedFormControl {
+  kind: SectionSpecFormField['kind'];
+  label: string;
+  reason: string;
+}
+
+export interface FormMaterialization {
+  markup: string;
+  unsupported: UnsupportedFormControl[];
+  diagnostics: string[];
+}
+
+/** Consumer-selected policy for turning captured forms into block markup. */
+export interface FormMaterializer {
+  name: string;
+  materialize(form: SectionSpecForm): FormMaterialization;
+}
+
 export interface FormBlocksResult {
   /** jetpack/contact-form block markup (wrapper + field blocks + submit button). */
   markup: string;
@@ -157,3 +175,19 @@ export function formToBlocks(form: SectionSpecForm): FormBlocksResult {
 
   return { markup, skipped };
 }
+
+/** Opt-in adapter for sites that provide Jetpack Forms. */
+export const jetpackFormMaterializer: FormMaterializer = {
+  name: 'jetpack',
+  materialize(form) {
+    const result = formToBlocks(form);
+    return {
+      markup: result.markup,
+      unsupported: result.skipped.map((field) => ({
+        ...field,
+        reason: 'has no Jetpack form equivalent',
+      })),
+      diagnostics: [],
+    };
+  },
+};

--- a/packages/blocks-engine/src/theme/index.ts
+++ b/packages/blocks-engine/src/theme/index.ts
@@ -19,7 +19,11 @@ export { splitPageChrome } from './chrome-split.js';
 export { segmentPage } from './segment.js';
 export { foundation } from './foundation.js';
 export { buildFallbackDiagnostic, buildTriageRemovalDiagnostic } from './fallback-diagnostic.js';
-export { formToBlocks, SKIPPED_FIELD_KINDS } from './form-blocks.js';
+export {
+  formToBlocks,
+  jetpackFormMaterializer,
+  SKIPPED_FIELD_KINDS,
+} from './form-blocks.js';
 export { ingest } from './ingest.js';
 export { detectLayoutOffsetWrapper } from './layout-offset-wrapper.js';
 export { buildAdminBarAccommodationCss } from './admin-bar-accommodation.js';
@@ -127,7 +131,12 @@ export type {
   ThemeFontFamily,
 } from './font-capture.js';
 export type * from './font-faces.js';
-export type { FormBlocksResult } from './form-blocks.js';
+export type {
+  FormBlocksResult,
+  FormMaterialization,
+  FormMaterializer,
+  UnsupportedFormControl,
+} from './form-blocks.js';
 export type { FontFamilyToken } from './page-reconstruct-helpers.js';
 export type {
   ConvertedSectionInput,

--- a/packages/blocks-engine/src/theme/native-reconstruct-types.ts
+++ b/packages/blocks-engine/src/theme/native-reconstruct-types.ts
@@ -2,6 +2,7 @@ import type { FallbackDiagnostic } from './fallback-diagnostic.js';
 import type { FontFamilyToken } from './page-reconstruct-helpers.js';
 import type { CoverageResult } from './section-coverage.js';
 import type { SectionSpec, SectionSpecForm } from './section-spec.js';
+import type { FormMaterializer } from './form-blocks.js';
 
 export interface FormRemainder {
   forms: SectionSpecForm[];
@@ -90,6 +91,8 @@ export interface SectionRenderOptions {
   sourceUrl?: string;
   slug?: string;
   strategy?: SectionStrategy;
+  /** Defaults to source-form preservation; consumers opt into provider adapters. */
+  formMaterializer?: FormMaterializer;
   /**
    * Sink for a strategy's deduped instance CSS (e.g. preserve-dom's content-addressed
    * lib-i rules). Called once per reconstruct with the drained rules so the caller can

--- a/packages/blocks-engine/src/theme/reconstruct.ts
+++ b/packages/blocks-engine/src/theme/reconstruct.ts
@@ -2,7 +2,7 @@ import * as cheerio from 'cheerio';
 import { escapeHtmlAttr } from '../escape.js';
 import type { WorkerPool } from '../pool/types.js';
 import { buildFallbackDiagnostic } from './fallback-diagnostic.js';
-import { formToBlocks, SKIPPED_FIELD_KINDS } from './form-blocks.js';
+import { jetpackFormMaterializer, type FormMaterializer } from './form-blocks.js';
 import { buildHtmlFallbackBlock, selectIslandSource, type HtmlFallbackOpts } from './html-fallback.js';
 import { hasUnmigratedRemoteAsset, scanForInjection } from './injection-scan.js';
 import { preserveDomStrategy } from './preserve-dom/strategy.js';
@@ -272,21 +272,31 @@ function normalizeSections(sections: SectionSpec[], options: SectionRenderOption
   });
 }
 
-function renderSectionForms(section: SectionSpec, expectedText: string[], flags: string[]): string {
+function renderSectionForms(
+  section: SectionSpec,
+  expectedText: string[],
+  flags: string[],
+  materializer: FormMaterializer,
+): string {
   if (!section.forms || section.forms.length === 0) return '';
   const parts: string[] = [];
   for (const form of section.forms) {
-    const formBlocks = formToBlocks(form);
-    parts.push(formBlocks.markup);
+    const materialized = materializer.materialize(form);
+    parts.push(materialized.markup);
     for (const field of form.fields) {
-      if (SKIPPED_FIELD_KINDS.has(field.kind)) continue;
+      if (materialized.unsupported.some((unsupported) => unsupported.kind === field.kind && unsupported.label === field.label)) {
+        continue;
+      }
       expectedText.push(field.label, ...(field.options ?? []));
     }
     expectedText.push(form.submitLabel);
-    for (const skipped of formBlocks.skipped) {
+    for (const unsupported of materialized.unsupported) {
       flags.push(
-        `form-field-skipped#${section.sectionIndex}: ${skipped.kind} field "${skipped.label}" has no Jetpack form equivalent`,
+        `form-field-skipped#${section.sectionIndex}: ${unsupported.kind} field "${unsupported.label}" ${unsupported.reason}`,
       );
+    }
+    for (const diagnostic of materialized.diagnostics) {
+      flags.push(`form-materialization#${section.sectionIndex} (${materializer.name}): ${diagnostic}`);
     }
   }
   return parts.join('\n');
@@ -506,7 +516,12 @@ function convertedDecision(
     bodyText.push(visibleText(match[1]));
   }
 
-  const formBlock = renderSectionForms(section, expectedText, provenanceFlags);
+  const formBlock = renderSectionForms(
+    section,
+    expectedText,
+    provenanceFlags,
+    options.formMaterializer ?? jetpackFormMaterializer,
+  );
   const blocks = formBlock ? `${markup}\n\n${formBlock}` : markup;
   return {
     spec: section,
@@ -526,7 +541,12 @@ function convertedDecision(
 function nativeDecision(section: SectionSpec, options: SectionRenderOptions, ctx: NativeRenderCtx): NativeSectionDecision | null {
   const renderSpec = suppressFormEchoes(section);
   const out = renderSection(renderSpec, ctx);
-  const formBlock = renderSectionForms(section, out.expectedText, out.flags);
+  const formBlock = renderSectionForms(
+    section,
+    out.expectedText,
+    out.flags,
+    options.formMaterializer ?? jetpackFormMaterializer,
+  );
   if (formBlock) {
     appendFormBlock(out, formBlock);
     if (section.forms) out.remainder = { forms: section.forms };

--- a/packages/blocks-engine/src/theme/site-to-theme.ts
+++ b/packages/blocks-engine/src/theme/site-to-theme.ts
@@ -102,6 +102,7 @@ export async function siteToTheme(
         sourceMediaUrlMapsByPage[page.slug]
       );
       const renderOptions = {
+        ...(options?.formMaterializer ? { formMaterializer: options.formMaterializer } : {}),
         ...(baseRenderOptions ?? {}),
         ...(routingStrategy ? { strategy: routingStrategy } : {}),
         // Collect drained lib-i instance CSS from whichever strategy runs — the default

--- a/packages/blocks-engine/src/theme/types.ts
+++ b/packages/blocks-engine/src/theme/types.ts
@@ -3,6 +3,7 @@ import type { ConversionFinding, ConvertReportStatus } from '../report/schema.js
 import type { RegionSelectionReport } from './region-audit.js';
 import type { SectionSpec } from './section-spec.js';
 import type { FormRemainder, SectionRenderOptions } from './native-reconstruct-types.js';
+import type { FormMaterializer } from './form-blocks.js';
 import type { SourceCssCarryOptions } from './source-css-carry.js';
 
 export interface SiteModel {
@@ -128,6 +129,8 @@ export interface SiteToThemeOptions extends SourceCssCarryOptions {
   pool?: WorkerPool;
   sections?: Record<string, SectionSpec[]>;
   renderOptions?: Record<string, SectionRenderOptions>;
+  /** Defaults to source-form preservation; use an adapter such as Jetpack explicitly. */
+  formMaterializer?: FormMaterializer;
   variationHoist?: false;
   foundationAggregates?: FoundationAggregates;
   hooks?: SiteToThemeHooks;


### PR DESCRIPTION
Closes #1554

## What

Introduces a typed `FormMaterializer` contract (`markup`, `unsupported`, `diagnostics`) and threads it through `SiteToThemeOptions` and `SectionRenderOptions`, so a consumer can decide how captured forms are materialized. Jetpack Forms becomes an explicit named adapter (`jetpackFormMaterializer`) rather than logic hardcoded into reconstruction.

## Why

`reconstruct.ts` called `formToBlocks()` directly, so the generic engine could only emit `jetpack/*` blocks and there was no seam for any other provider.

## Default behavior is unchanged

The default remains the Jetpack adapter. An earlier draft defaulted to a reconstructed `core/html` form; that was rejected because this stack treats `core/html` in page content as a conversion-quality bug, #220 explicitly targets working form blocks over preserved-but-dead markup, and the change measurably dropped section coverage from 1 to 0 in the reconstruct suite.

## Verification

- `pnpm exec tsc --noEmit` clean.
- Full package suite: 103 files / 496 tests pass.
- `Engine reconstruct DLA baseline parity: cases=35 diffs=0`, so emitted markup and provenance flags are byte-identical to trunk.
- Added coverage proving a consumer-supplied materializer is honored and reports unsupported controls.

## AI assistance

OpenAI `gpt-5.6-sol` running in OpenCode designed and implemented the seam, corrected the default-behavior regression, and ran the verification above. A human directed the work and reviewed the result.