### PR TITLE
Provide structured visual iframe editor controls

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Generators/VisualIframeBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/Generators/VisualIframeBlockGenerator.php
@@ -39,9 +39,17 @@ final class VisualIframeBlockGenerator
     {
         $namespace = strstr($blockName, '/', true) ?: '';
         $script = <<<'JS'
-( function( blocks, blockEditor, element ) {
+( function( blocks, blockEditor, components, element ) {
     var createElement = element.createElement;
     var attributes = __BLOCK_ATTRIBUTES__;
+    function isSafeVisualIframeUrl( value ) {
+        try {
+            var url = new URL( value );
+            return url.protocol === 'https:' && !! url.hostname && ! url.username && ! url.password;
+        } catch ( error ) {
+            return false;
+        }
+    }
     function iframeProps( attributes, editor ) {
         var props = editor ? blockEditor.useBlockProps() : {};
         [ 'src', 'title', 'width', 'height', 'allow', 'loading', 'sandbox', 'referrerPolicy' ].forEach( function( name ) { if ( attributes[ name ] ) { props[ name ] = attributes[ name ]; } } );
@@ -49,10 +57,35 @@ final class VisualIframeBlockGenerator
         if ( attributes.allowFullScreen ) { props.allowFullScreen = true; }
         return props;
     }
-    function edit( props ) { return createElement( 'iframe', iframeProps( props.attributes, true ) ); }
+    function edit( props ) {
+        var useState = element.useState;
+        var state = useState( props.attributes.src || '' );
+        var draftSrc = state[ 0 ];
+        var setDraftSrc = state[ 1 ];
+        var setAttribute = function( name ) { return function( value ) { props.setAttributes( { [ name ]: value } ); }; };
+        var inspector = props.isSelected ? createElement( blockEditor.InspectorControls, {},
+            createElement( components.PanelBody, { title: 'Embedded content' },
+                createElement( components.TextControl, {
+                    label: 'URL', value: draftSrc,
+                    help: draftSrc && ! isSafeVisualIframeUrl( draftSrc ) ? 'Enter an HTTPS URL without credentials.' : undefined,
+                    onChange: setDraftSrc,
+                    onBlur: function() { var src = draftSrc.trim(); if ( isSafeVisualIframeUrl( src ) ) { props.setAttributes( { src: src } ); setDraftSrc( src ); } else { setDraftSrc( props.attributes.src || '' ); } }
+                } ),
+                createElement( components.TextControl, { label: 'Title', value: props.attributes.title || '', onChange: setAttribute( 'title' ) } ),
+                createElement( components.TextControl, { label: 'Width', value: props.attributes.width || '', onChange: setAttribute( 'width' ) } ),
+                createElement( components.TextControl, { label: 'Height', value: props.attributes.height || '', onChange: setAttribute( 'height' ) } ),
+                createElement( components.TextControl, { label: 'Allow permissions', value: props.attributes.allow || '', onChange: setAttribute( 'allow' ) } ),
+                createElement( components.SelectControl, { label: 'Loading', value: props.attributes.loading || '', options: [ { label: 'Default', value: '' }, { label: 'Lazy', value: 'lazy' }, { label: 'Eager', value: 'eager' } ], onChange: setAttribute( 'loading' ) } ),
+                createElement( components.TextControl, { label: 'Sandbox', value: props.attributes.sandbox || '', onChange: setAttribute( 'sandbox' ) } ),
+                createElement( components.TextControl, { label: 'Referrer policy', value: props.attributes.referrerPolicy || '', onChange: setAttribute( 'referrerPolicy' ) } ),
+                createElement( components.ToggleControl, { label: 'Allow fullscreen', checked: !! props.attributes.allowFullScreen, onChange: setAttribute( 'allowFullScreen' ) } )
+            )
+        ) : null;
+        return createElement( element.Fragment, {}, inspector, createElement( 'iframe', iframeProps( props.attributes, true ) ) );
+    }
     function save( props ) { return createElement( 'iframe', iframeProps( props.attributes, false ) ); }
     blocks.registerBlockType( '__BLOCK_NAME__', { attributes: attributes, supports: { html: false }, edit: edit, save: save } );
-} )( window.wp.blocks, window.wp.blockEditor, window.wp.element );
+} )( window.wp.blocks, window.wp.blockEditor, window.wp.components, window.wp.element );
 JS;
 
         return array( 'index.js' => str_replace(
@@ -90,7 +123,7 @@ JS;
             'name' => self::LOCAL_NAME,
             'block_json' => $this->blockJson($namespace),
             'assets' => $this->assets($namespace . '/' . self::LOCAL_NAME),
-            'script_dependencies' => array( 'index.js' => array( 'wp-blocks', 'wp-block-editor', 'wp-element' ) ),
+            'script_dependencies' => array( 'index.js' => array( 'wp-blocks', 'wp-block-editor', 'wp-components', 'wp-element' ) ),
         );
     }
 }

--- a/php-transformer/tests/unit/visual-iframe-block.php
+++ b/php-transformer/tests/unit/visual-iframe-block.php
@@ -24,8 +24,24 @@ $assert(false === ($definition['block_json']['supports']['html'] ?? null), 'visu
 $assert(array('src', 'title', 'width', 'height', 'className', 'allow', 'loading', 'sandbox', 'referrerPolicy', 'allowFullScreen') === array_keys($attributes), 'visual iframe has a bounded structured attribute schema');
 $assert('boolean' === ($attributes['allowFullScreen']['type'] ?? null), 'visual iframe fullscreen permission is typed');
 $editor = (string) ($definition['assets']['index.js'] ?? '');
-$assert(str_contains($editor, "registerBlockType( 'ssi-example/visual-iframe'") && str_contains($editor, "createElement( 'iframe'") && ! str_contains($editor, 'RawHTML') && ! str_contains($editor, 'TextareaControl'), 'editor renders a bounded iframe preview instead of raw HTML editing');
-$assert(array('wp-blocks', 'wp-block-editor', 'wp-element') === ($definition['script_dependencies']['index.js'] ?? null), 'visual iframe declares its editor dependencies');
+$assert(str_contains($editor, "registerBlockType( 'ssi-example/visual-iframe'") && str_contains($editor, 'InspectorControls') && str_contains($editor, 'TextControl') && str_contains($editor, 'SelectControl') && str_contains($editor, 'ToggleControl') && str_contains($editor, "createElement( 'iframe'") && ! str_contains($editor, 'RawHTML') && ! str_contains($editor, 'TextareaControl'), 'editor provides structured iframe controls and a bounded preview instead of raw HTML editing');
+$assert(str_contains($editor, "label: 'URL'") && str_contains($editor, "label: 'Title'") && str_contains($editor, "label: 'Width'") && str_contains($editor, "label: 'Height'") && str_contains($editor, "label: 'Allow permissions'") && str_contains($editor, "label: 'Loading'") && str_contains($editor, "label: 'Sandbox'") && str_contains($editor, "label: 'Referrer policy'") && str_contains($editor, "label: 'Allow fullscreen'"), 'editor exposes controls for every bounded iframe attribute');
+$assert(str_contains($editor, 'isSafeVisualIframeUrl') && str_contains($editor, "url.protocol === 'https:'") && str_contains($editor, '! url.username') && str_contains($editor, '! url.password'), 'editor URL changes retain the bounded HTTPS destination admission policy');
+$assert(str_contains($editor, 'iframeProps( props.attributes, true )') && str_contains($editor, 'iframeProps( props.attributes, false )'), 'preview and save share one iframe attribute projection');
+$assert(array('wp-blocks', 'wp-block-editor', 'wp-components', 'wp-element') === ($definition['script_dependencies']['index.js'] ?? null), 'visual iframe declares its editor dependencies');
+$editorSchemaRunner = <<<'JS'
+const vm = require( 'node:vm' );
+let settings;
+vm.runInNewContext( Buffer.from( process.argv[ 1 ], 'base64' ).toString(), {
+    window: { wp: {
+        blocks: { registerBlockType: ( name, blockSettings ) => { settings = blockSettings; } },
+        blockEditor: {}, components: {}, element: {}
+    } }
+} );
+process.stdout.write( JSON.stringify( settings.attributes ) );
+JS;
+$editorAttributes = json_decode((string) shell_exec('node -e ' . escapeshellarg($editorSchemaRunner) . ' ' . escapeshellarg(base64_encode($editor))), true);
+$assert($attributes === $editorAttributes, 'editor registration attribute schema exactly matches generated block metadata');
 $payload = (new CompanionPluginPayload())->fromBlockTypes(array(), array(), array(), array($definition));
 $assert('ssi-example/visual-iframe' === ($payload['blocks'][0]['block_json']['name'] ?? null), 'visual iframe companion definition survives payload packaging');
 


### PR DESCRIPTION
## Summary

Closes #1568.

- Adds inspector controls for each typed visual-iframe attribute.
- Keeps raw HTML disabled and validates author-entered URL changes as credential-free HTTPS destinations.
- Uses the same attribute projection for the editor preview and frontend serialization.

## Validation

- `php php-transformer/tests/unit/visual-iframe-block.php`
- Generated-script execution confirms the registered editor schema exactly matches the generated block metadata.
- The package has no Gutenberg browser harness; #1569 tracks reusable isolated select/change/save/reload coverage.

## AI assistance

OpenAI GPT-5.6-terra via OpenCode assisted implementation, test execution, and review. Chris Huber directed the work and reviewed the resulting changes.