### PR TITLE
Fix cross-document selector cache leakage

### DIFF
--- a/php-transformer/src/Css/CssSelectorMatchCache.php
+++ b/php-transformer/src/Css/CssSelectorMatchCache.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\Css;
 
+use DOMDocument;
 use DOMElement;
 use DOMNode;
 use WeakMap;
@@ -37,7 +38,15 @@ final class CssSelectorMatchCache
     /** @var WeakMap<DOMElement, string> */
     private WeakMap $connectedElementKeys;
 
+    /** @var WeakMap<DOMDocument, int> */
+    private WeakMap $connectedDocumentKeys;
+
+    /** @var list<DOMDocument> */
+    private array $connectedDocuments = array();
+
     private int $nextDetachedElementKey = 0;
+
+    private int $nextConnectedDocumentKey = 0;
 
     public int $classTokenBuilds = 0;
 
@@ -79,6 +88,7 @@ final class CssSelectorMatchCache
     {
         $this->detachedElementKeys = new WeakMap();
         $this->connectedElementKeys = new WeakMap();
+        $this->connectedDocumentKeys = new WeakMap();
     }
 
     /** @return list<string> */
@@ -215,6 +225,9 @@ final class CssSelectorMatchCache
         $this->candidateRulesRetained = 0;
         $this->detachedElementKeys = new WeakMap();
         $this->connectedElementKeys = new WeakMap();
+        $this->connectedDocumentKeys = new WeakMap();
+        $this->connectedDocuments = array();
+        $this->nextConnectedDocumentKey = 0;
         $this->nextDetachedElementKey = 0;
     }
 
@@ -230,9 +243,17 @@ final class CssSelectorMatchCache
         // released. A connected node's document path is stable across wrappers
         // and unique within this per-document cache revision.
         for ( $ancestor = $element; $ancestor instanceof DOMNode; $ancestor = $ancestor->parentNode ) {
-            if ( $ancestor instanceof \DOMDocument ) {
+            if ( $ancestor instanceof DOMDocument ) {
                 ++$this->connectedElementKeyBuilds;
-                return $this->connectedElementKeys[$element] = 'path:' . $element->getNodePath();
+                if ( ! isset($this->connectedDocumentKeys[$ancestor]) ) {
+                    $this->connectedDocumentKeys[$ancestor] = ++$this->nextConnectedDocumentKey;
+                    // Retain the wrapper so PHP cannot recycle its object ID for
+                    // another native document during this cache revision.
+                    $this->connectedDocuments[] = $ancestor;
+                }
+                return $this->connectedElementKeys[$element] = 'document:'
+                    . $this->connectedDocumentKeys[$ancestor]
+                    . ':path:' . $element->getNodePath();
             }
         }
 

--- a/php-transformer/tests/unit/css-selector-matcher.php
+++ b/php-transformer/tests/unit/css-selector-matcher.php
@@ -121,6 +121,37 @@ $candidateSelectors = array_column($candidateCache->styleRuleCandidates($byId('t
 $assert(array( '#target', 'span', ':not(.excluded)', 'span[data-value]' ) === $candidateSelectors, 'clearing the immutable revision cache rebuilds class candidates after mutation');
 $assert(4 === $candidateCache->candidateRulesRetained, 'candidate cache accounts for retained rule references');
 
+// RichText normalization parses each fragment into a separate document. Those
+// documents reuse paths such as /html/body/p/span, which must not alias class,
+// selector, or candidate results from an earlier fragment.
+$fragmentOne = new DOMDocument();
+$fragmentOne->loadHTML('<!doctype html><p><span class="font-default">first</span></p>');
+$fragmentTwo = new DOMDocument();
+$fragmentTwo->loadHTML('<!doctype html><p><span class="color-override">second</span></p>');
+$fragmentOneSpan = $fragmentOne->getElementsByTagName('span')->item(0);
+$fragmentTwoSpan = $fragmentTwo->getElementsByTagName('span')->item(0);
+if ( ! $fragmentOneSpan instanceof DOMElement || ! $fragmentTwoSpan instanceof DOMElement ) {
+    throw new RuntimeException('Selector-cache document identity fixture did not produce both spans.');
+}
+$fragmentCache = new CssSelectorMatchCache();
+$fragmentIndex = array(
+    'universal' => array(),
+    'ids' => array(),
+    'classes' => array(
+        'font-default' => array( array( 'order' => 0, 'rule' => array( 'selector' => '.font-default' ) ) ),
+        'color-override' => array( array( 'order' => 1, 'rule' => array( 'selector' => '.color-override' ) ) ),
+    ),
+    'tags' => array(),
+    'attributes' => array(),
+    'total' => 2,
+);
+$fragmentCache->matches($fragmentOneSpan, '.font-default', CssSelectorMatcher::parse('.font-default'));
+$fragmentCache->styleRuleCandidates($fragmentOneSpan, 'fragments', $fragmentIndex);
+$assert(array( 'color-override' ) === $fragmentCache->classTokens($fragmentTwoSpan), 'connected nodes at the same path remain isolated by owner document');
+$assert(! $fragmentCache->matches($fragmentTwoSpan, '.font-default', CssSelectorMatcher::parse('.font-default'))['matches'], 'selector results do not cross connected document boundaries');
+$fragmentSelectors = array_column($fragmentCache->styleRuleCandidates($fragmentTwoSpan, 'fragments', $fragmentIndex), 'selector');
+$assert(array( '.color-override' ) === $fragmentSelectors, 'candidate rules do not cross connected document boundaries');
+
 // DOM nodes are native libxml objects exposed through temporary PHP wrappers.
 // Once a wrapper is released, PHP can immediately reuse its spl_object_id() for
 // a wrapper around a different node. A cache keyed by that bare integer then

--- a/php-transformer/tests/unit/rich-text-source-serialization.php
+++ b/php-transformer/tests/unit/rich-text-source-serialization.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\BlockFactory;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
 $failures = 0;
@@ -37,6 +38,22 @@ $assert(
 $assert(
     'Event notifications' === ($blocks[0]['attrs']['content'] ?? null),
     'Canonical serialization does not mutate transformer working blocks.'
+);
+
+$richTextCascade = ( new HtmlTransformer() )->transform(
+    '<style>:root{--dark:0,0,0;--light:255,255,255}'
+    . '.font-default{color:rgb(var(--dark))}.color-override{color:rgb(var(--light))}</style>'
+    . '<p><span><span><span class="font-default" style="font-family:Arial"><span>First</span></span></span></span></p>'
+    . '<p><span><span class="color-override"><span style="font-family:Arial"><span>Second</span></span></span></span></p>'
+)->toArray();
+$richTextMarkup = (string) ($richTextCascade['serialized_blocks'] ?? '');
+$secondOffset = strpos($richTextMarkup, 'Second');
+$secondStart = false === $secondOffset ? false : strrpos(substr($richTextMarkup, 0, $secondOffset), '<!-- wp:paragraph');
+$secondMarkup = false === $secondStart || false === $secondOffset ? '' : substr($richTextMarkup, $secondStart, $secondOffset - $secondStart);
+$assert(
+    str_contains($secondMarkup, 'color:rgb(var(--light))')
+        && ! str_contains($secondMarkup, 'color:rgb(var(--dark))'),
+    'Separate RichText fragment documents do not leak an earlier fragment cascade into the same DOM path.'
 );
 
 if ( 0 === $failures ) {


### PR DESCRIPTION
## Summary

- scope connected-node selector cache keys by owner document as well as DOM path
- prevent temporary RichText documents with identical paths from reusing another fragment's classes, selector results, and candidate rules
- add cache-boundary and rendered RichText regressions

## Evidence

Separate RichText fragments can place different class tokens at identical DOM paths such as `/html/body/p/span/span`. Keying connected nodes by path alone allowed an earlier fragment's class result to leak into a later fragment. The cache now includes owner-document identity, and the regression proves class tokens, selector matches, candidate rules, and serialized inherited color remain isolated across documents.

## Verification

- `composer test`
- 297 parity fixtures
- dist shape and package install proof

## AI assistance

OpenAI gpt-5.6-sol through OpenCode traced the cross-document cache collision, implemented the document-scoped key, added platform-neutral regressions, and ran the verification. Chris Huber reviewed and orchestrated the work and remains responsible for the submitted changes.