### PR TITLE
Preserve generic custom media host semantics

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -9661,7 +9661,7 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
 
     private function customVideoElement(DOMElement $element): ?DOMElement
     {
-        if ( ! str_contains($element->tagName, '-') || '' !== trim($element->textContent ?? '') || ! $this->isSafeTransparentCustomElement($element) ) {
+        if ( ! str_contains($element->tagName, '-') || '' !== trim($element->textContent ?? '') || ! $this->isSafeTransparentCustomElement($element) || ! $this->hasOnlyStructuralCustomVideoHostAttributes($element) ) {
             return null;
         }
 
@@ -9690,7 +9690,7 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
                 continue;
             }
             if ( 'img' === $tagName ) {
-                if ( '' === $poster || '' !== $this->attr($descendant, 'alt') || $poster !== $this->imageSourceUrl($descendant) ) {
+                if ( '' === $poster || ! $this->isRedundantCustomVideoPosterImage($descendant, $poster) ) {
                     return false;
                 }
                 continue;
@@ -9699,6 +9699,32 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
                 return false;
             }
             if ( $descendant->hasAttributes() ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function hasOnlyStructuralCustomVideoHostAttributes(DOMElement $element): bool
+    {
+        foreach ( $element->attributes as $attribute ) {
+            if ( ! in_array(strtolower($attribute->name), array( 'class', 'style' ), true) ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isRedundantCustomVideoPosterImage(DOMElement $image, string $poster): bool
+    {
+        if ( ! $image->hasAttribute('alt') || '' !== $this->attr($image, 'alt') || $poster !== $this->imageSourceUrl($image) ) {
+            return false;
+        }
+
+        foreach ( $image->attributes as $attribute ) {
+            if ( ! in_array(strtolower($attribute->name), array( 'src', 'alt' ), true) ) {
                 return false;
             }
         }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -91,7 +91,7 @@ $assert(
         && array() === ($customHostVideoResult['fallbacks'] ?? array()),
     'a generic custom video host preserves its geometry wrapper and lowers its playable video to core/video'
 );
-$styledCustomVideoResult = ( new HtmlTransformer() )->transform('<wix-video style="display:block;width:320px;overflow:hidden;transform:scale(.9);border:1px solid red"><video src="hero.mp4"></video></wix-video>')->toArray();
+$styledCustomVideoResult = ( new HtmlTransformer() )->transform('<media-host style="display:block;width:320px;overflow:hidden;transform:scale(.9);border:1px solid red"><video src="hero.mp4"></video></media-host>')->toArray();
 $assert(
     'core/group' === ($styledCustomVideoResult['blocks'][0]['blockName'] ?? null)
         && 'core/video' === ($styledCustomVideoResult['blocks'][0]['innerBlocks'][0]['blockName'] ?? null)
@@ -100,26 +100,34 @@ $assert(
         && ! str_contains((string) ($styledCustomVideoResult['serialized_blocks'] ?? ''), '<!-- wp:html'),
     'styled custom video hosts retain their wrapper presentation around editable core/video'
 );
-$ambiguousCustomVideoResult = ( new HtmlTransformer() )->transform('<wix-video><video src="hero.mp4"></video><video src="trailer.mp4"></video></wix-video>')->toArray();
+$ambiguousCustomVideoResult = ( new HtmlTransformer() )->transform('<media-host><video src="hero.mp4"></video><video src="trailer.mp4"></video></media-host>')->toArray();
 $assert(
     'core/video' !== ($ambiguousCustomVideoResult['blocks'][0]['blockName'] ?? null)
         && ! str_contains((string) ($ambiguousCustomVideoResult['serialized_blocks'] ?? ''), '<!-- wp:html'),
     'ambiguous custom media hosts remain typed gaps rather than raw HTML'
 );
-$unsafeCustomVideoResult = ( new HtmlTransformer() )->transform('<wix-video><video src="javascript:alert(1)" poster="hero.jpg"></video></wix-video>')->toArray();
+$unsafeCustomVideoResult = ( new HtmlTransformer() )->transform('<media-host><video src="javascript:alert(1)" poster="hero.jpg"></video></media-host>')->toArray();
 $assert(
     'core/video' !== ($unsafeCustomVideoResult['blocks'][0]['blockName'] ?? null),
     'custom video hosts with an unsafe source remain unpromoted'
 );
 $meaningfulCustomVideoResult = ( new HtmlTransformer() )->transform('<media-host><video src="hero.mp4" poster="hero.jpg"></video><div aria-hidden="true">Poster label</div></media-host>')->toArray();
 $assert(
-    'core/video' !== ($meaningfulCustomVideoResult['blocks'][0]['blockName'] ?? null),
+    'media-host' === ($meaningfulCustomVideoResult['fallbacks'][0]['tag'] ?? null)
+        && str_contains((string) ($meaningfulCustomVideoResult['fallbacks'][0]['html'] ?? ''), 'Poster label'),
     'aria-hidden alone does not discard meaningful custom video descendants'
 );
-$runtimePosterCustomVideoResult = ( new HtmlTransformer() )->transform('<wix-video><video src="hero.mp4" poster="hero.jpg"></video><wow-image data-image-info="bounded"><img src="hero.jpg" alt=""></wow-image></wix-video>')->toArray();
+$ariaHiddenPosterCustomVideoResult = ( new HtmlTransformer() )->transform('<media-host><video src="hero.mp4" poster="hero.jpg"></video><img src="hero.jpg" alt="" aria-hidden="true"></media-host>')->toArray();
 $assert(
-    'core/video' !== ($runtimePosterCustomVideoResult['blocks'][0]['blockName'] ?? null),
-    'data-bearing provider poster components remain preserved typed gaps pending provider normalization'
+    str_starts_with((string) ($ariaHiddenPosterCustomVideoResult['blocks'][0]['blockName'] ?? ''), 'custom/')
+        && str_contains((string) ($ariaHiddenPosterCustomVideoResult['blocks'][0]['attrs']['content'] ?? ''), 'aria-hidden="true"'),
+    'aria-hidden poster media remains preserved instead of being discarded as redundant'
+);
+$accessibleCustomVideoHostResult = ( new HtmlTransformer() )->transform('<media-host aria-label="Featured video"><video src="hero.mp4"></video></media-host>')->toArray();
+$assert(
+    'media-host' === ($accessibleCustomVideoHostResult['fallbacks'][0]['tag'] ?? null)
+        && str_contains((string) ($accessibleCustomVideoHostResult['fallbacks'][0]['html'] ?? ''), 'aria-label="Featured video"'),
+    'accessible custom video hosts remain preserved when their wrapper semantics cannot be represented by core/group'
 );
 
 $runtimeMediaMaskFixture = file_get_contents(dirname(__DIR__) . '/fixtures/unsupported-runtime-media-mask.html');


### PR DESCRIPTION
## Summary

Follow-up to merged #1570.

- Restricts custom-media-host promotion to hosts whose attributes are representable as CSS presentation (`class` and `style`).
- Promotes a poster image only when it is exactly the native video poster with an explicit empty `alt` and no other attributes.
- Keeps host geometry in a `core/group` around the editable `core/video`; poster, tracks, and native playback attributes remain on the video.
- Preserves meaningful, accessible, and runtime/data-bearing descendants through the generic fallback/custom-block contracts. Provider normalization remains owned by Data Liberation Agent.
- Replaces remaining Wix-specific contract fixtures with generic `media-host` examples and counterexamples.

## Validation

- `composer test`
- `npm test` in `php-transformer/tools/visual-parity`
- `composer test:wordpress-integration` (explicit local skip: `WP_TESTS_DIR` is unavailable)

The browser suite proves the source and editor wrapper geometries match and that transferring host presentation to the video loses wrapper geometry.

## AI assistance

OpenAI GPT-5.6-terra via OpenCode inspected the merged PR and existing implementation, implemented the provider-neutral media-host contract and counterexamples, and ran the validation commands. Chris Huber directed the scope.