### PR TITLE
fix(php-transformer): propagate wrapper text alignment to generated paragraphs

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -3760,6 +3760,10 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             );
         }
 
+        if ( $sourceElement instanceof DOMElement && in_array($name, array( 'core/group', 'core/quote' ), true) ) {
+            $innerBlocks = $this->withPropagatedWrapperTextAlignment($innerBlocks, $sourceElement);
+        }
+
         return $this->blockMaterializer->materialize(
             $name,
             $attrs,
@@ -3767,6 +3771,51 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             $sourceMaterializationFacts,
             $this->transformationProvenance()
         );
+    }
+
+    /**
+     * Give a text wrapper's generated inner RichText blocks the wrapper's own
+     * alignment.
+     *
+     * A wrapper that owns box chrome stays a core/group, and a quoted wrapper
+     * stays a core/quote; neither carries a native text alignment, and the source
+     * alignment reaches neither the block tree nor the generated stylesheet (see
+     * StyleResolver::generatedRichTextAlignment()). The paragraph generated for
+     * the wrapper's own text is where the alignment belongs natively.
+     *
+     * Scoped to phrasing-only wrappers, so the inner blocks ARE that wrapper's own
+     * text rather than an arbitrary layout subtree, and only the text alignment
+     * inheritance the source already expressed is restated. A block that resolved
+     * its own alignment keeps it: explicit descendant alignment wins.
+     *
+     * @param array<int, array<string, mixed>> $innerBlocks
+     * @return array<int, array<string, mixed>>
+     */
+    private function withPropagatedWrapperTextAlignment(array $innerBlocks, DOMElement $sourceElement): array
+    {
+        if ( array() === $innerBlocks || ! $this->sourceElementClassifier->hasOnlyPhrasingChildren($sourceElement) ) {
+            return $innerBlocks;
+        }
+
+        $alignment = $this->styleResolver->generatedRichTextAlignment($sourceElement);
+        if ( '' === $alignment ) {
+            return $innerBlocks;
+        }
+
+        foreach ( $innerBlocks as $index => $innerBlock ) {
+            if ( ! is_array($innerBlock)
+                || ! in_array((string) ($innerBlock['blockName'] ?? ''), array( 'core/paragraph', 'core/heading' ), true)
+                || '' !== trim((string) ($innerBlock['attrs']['align'] ?? ''))
+            ) {
+                continue;
+            }
+            $innerBlocks[ $index ] = $this->rebuildBlock(
+                $innerBlock,
+                array_merge(is_array($innerBlock['attrs'] ?? null) ? $innerBlock['attrs'] : array(), array( 'align' => $alignment ))
+            );
+        }
+
+        return $innerBlocks;
     }
 
     private function sourceElementStartsHidden(DOMElement $element): bool
@@ -11062,7 +11111,8 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
     /**
      * Rebuild a converted block with updated attributes so its innerHTML and
      * innerContent stay consistent with the stored attrs after an in-place edit
-     * (e.g. a propagated link). Source-provenance linkage is preserved; no new
+     * (e.g. a propagated link). Engine metadata the materializer attached —
+     * source-provenance linkage and editability ownership — is preserved; no new
      * provenance is recorded for the rebuild.
      *
      * @param array<string, mixed> $block
@@ -11074,8 +11124,10 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
         $name = (string) ($block['blockName'] ?? '');
         $innerBlocks = is_array($block['innerBlocks'] ?? null) ? $block['innerBlocks'] : array();
         $rebuilt = $this->blockFactory->create($name, $attrs, $innerBlocks);
-        if ( isset($block['_source_provenance_id']) ) {
-            $rebuilt['_source_provenance_id'] = $block['_source_provenance_id'];
+        foreach ( $block as $key => $value ) {
+            if ( is_string($key) && str_starts_with($key, '_') ) {
+                $rebuilt[$key] = $value;
+            }
         }
 
         return $rebuilt;

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
@@ -1068,6 +1068,40 @@ final class StyleResolver implements ElementPresentationResolver
     }
 
     /**
+     * The alignment a text wrapper's GENERATED inner RichText blocks must carry
+     * so the source's own alignment survives, or '' when nothing is at risk.
+     *
+     * A wrapper that stays a core/group or core/quote because it owns box chrome
+     * has no native alignment attribute, and its inline `text-align` only reaches
+     * the generated stylesheet when the wrapper already mints a geometry carrier
+     * for some other property. Padding, borders and radii are consumed into block
+     * supports rather than a carrier, so the common "boxed, centred intro copy"
+     * wrapper mints none and the alignment is dropped outright. The inner
+     * paragraph the engine generates for that wrapper's own text is the native
+     * carrier for it.
+     *
+     * The gate is the same one `inlineInheritedTextAlignDeclaration()` applies:
+     * an alignment already reproduced by the wrapper's OWN preserved author rule,
+     * or inherited from a preserved ancestor, is not at risk and is not restated.
+     * Only `left`/`center`/`right` are returned, because `align` is what the
+     * generated block carries and that attribute has no `start`/`end` spelling.
+     */
+    public function generatedRichTextAlignment(DOMElement $element): string
+    {
+        $value = strtolower($this->carriedDeclarationValue((string) ($this->presentationDeclarations($element)['text-align'] ?? '')));
+        if ( ! in_array($value, array( 'left', 'center', 'right' ), true) ) {
+            return '';
+        }
+
+        $rightToLeft = $this->isRightToLeftElement($element);
+        if ( $this->comparableTextAlignment($value, $rightToLeft) === $this->effectiveTextAlignmentWithoutInline($element, $rightToLeft) ) {
+            return '';
+        }
+
+        return $value;
+    }
+
+    /**
      * What this element's alignment would resolve to if the inline declaration
      * were removed: its OWN author-declared `text-align` when it has one, and
      * only otherwise the value inherited from its ancestors.

--- a/php-transformer/tests/fixtures/parity/html-box-chrome-wrapper-text-alignment.json
+++ b/php-transformer/tests/fixtures/parity/html-box-chrome-wrapper-text-alignment.json
@@ -1,0 +1,36 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-box-chrome-wrapper-text-alignment",
+  "description": "Gives the generated inner paragraphs of a text wrapper that stays a core/group for its box chrome the wrapper's own text alignment, while a leaf that resolved its own alignment keeps it.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-box-chrome-wrapper-text-alignment.json",
+    "notes": "Padding, borders and radii are consumed into block supports rather than a geometry carrier, so the wrapper minted no carrier for its inline text-align to ride and centred intro copy rendered start-aligned."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<!doctype html><html><head><style>.intro{padding:24px;border:1px solid #d8d2c8;border-radius:12px}.accent{color:#b45309}</style></head><body><main><div class=\"intro\" style=\"text-align:center\">Book a consultation with <span class=\"accent\">our team</span> today.</div><div class=\"intro\" style=\"text-align:center\"><span class=\"accent\" style=\"text-align:right\">Explicit leaf alignment.</span></div></main></body></html>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "intro" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "Book a consultation with", "align": "center" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "className": "blocks-engine-synthetic-paragraph", "align": "center" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.2", "name": "core/paragraph", "attrs": { "content": "today.", "align": "center" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "blocks-engine-synthetic-paragraph", "align": "right" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"has-text-align-center\">Book a consultation with</p>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"has-text-align-center blocks-engine-synthetic-paragraph\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"has-text-align-right blocks-engine-synthetic-paragraph\">" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "wp:html" },
+    { "path": "source_reports.wp_block_validity.status", "assert": "equals", "value": "pass" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-quote-wrapper-text-alignment.json
+++ b/php-transformer/tests/fixtures/parity/html-quote-wrapper-text-alignment.json
@@ -1,0 +1,34 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-quote-wrapper-text-alignment",
+  "description": "Gives a quoted text wrapper's generated inner paragraph the wrapper's own text alignment, and leaves an alignment the wrapper's preserved author rule already carries unrestated.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-quote-wrapper-text-alignment.json",
+    "notes": "core/quote carries no native text alignment, so a blockquote whose own text-align is inline lost it entirely: the generated paragraph is where it belongs natively. Reproduced on centred Wix testimonial copy that renders start-aligned after import."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<!doctype html><html><head><style>.pull{text-align:center}</style></head><body><main><blockquote class=\"testimonial\" style=\"text-align:center\">Her plans transformed my life.<cite>Emma</cite></blockquote><blockquote class=\"pull\">Author rule keeps this centred on the source tag.</blockquote></main></body></html>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0.innerBlocks.0", "name": "core/quote", "attrs": { "className": "testimonial", "citation": "Emma" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "blocks-engine-synthetic-paragraph", "align": "center" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/quote", "attrs": { "className": "pull" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "blocks-engine-synthetic-paragraph", "align": null } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"has-text-align-center blocks-engine-synthetic-paragraph\">Her plans transformed my life.</p>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"blocks-engine-synthetic-paragraph\">Author rule keeps this centred on the source tag.</p>" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "wp:html" },
+    { "path": "source_reports.wp_block_validity.status", "assert": "equals", "value": "pass" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}


### PR DESCRIPTION
Fixes #751.

## Problem

A source text wrapper that must stay a `core/group` (it owns box chrome) or a `core/quote` (it is a `<blockquote>`) carries no native text alignment. Its own `text-align` also fails to reach the generated stylesheet, for a reason that is easy to miss:

- `StyleResolver::inlineInheritedTextAlignDeclaration()` deliberately rides an **existing** geometry carrier and never mints one, because minting a carrier promotes a bare wrapper into a `core/group` and changes the block tree.
- Padding, borders and radii — the very properties that make an element a "visual text wrapper" worth keeping as a group — are consumed into **block supports**, not into a geometry carrier.

So the common "boxed, centred intro copy" wrapper mints no carrier at all, and its alignment is dropped outright. The generated inner paragraph resets its margins but never receives the alignment, and centred source copy renders start-aligned.

`createBlock()` already projects `text-align` to an `align` attribute, but only for `core/paragraph` / `core/heading` built **from that element itself** — a synthesized inner paragraph has no source element of its own, and a paragraph whose source element is a bare inner `<span>` has no alignment of its own to project.

## Second reproduction

Independently reproduced on a different source site from the one in #751.

Source: `https://www.wix.com/sgtemplates/sophja-j-pierce?experimentsoff=specs.thunderbolt.viewport_hydration_extended_react_18`
Imported through WordPress Studio PR 3952 + Static Site Importer `adbd6cad` + Blocks Engine `973284e8`.

Client-testimonials section of the home page, measured with Playwright computed styles:

| | `text-align` |
| --- | --- |
| source | `center` |
| import | `start` |

The source markup is:

```html
<div id="comp-m8cu99rv7" class="N8MGzv _v6ohL PO9MfV AWXfZq comp-m8cu99rv7 wixui-rich-text" data-testid="richTextElement">
  <blockquote class="font_7 wixui-rich-text__text" style="font-size:20px; text-align:center;">
    <span style="font-size:20px;" class="wixui-rich-text__text">" Sophja's personalized workout plans …"</span>
  </blockquote>
</div>
```

Running that page through `HtmlTransformer` reproduces the reported import chain exactly — `div.wp-block-group.blocks-engine-css-owned-layout` › `div.wp-block-group` › `blockquote.wp-block-quote.font_7` › `p.blocks-engine-synthetic-paragraph` › `mark.wixui-rich-text__text` — with the blockquote's inline `text-align:center` present in the source and absent everywhere in the output.

## Change

Give the RichText blocks generated for such a wrapper's own text the wrapper's alignment, which is where it belongs natively (#751's stated direction).

- `StyleResolver::generatedRichTextAlignment()` — a new public style-projection API that answers "what alignment is at risk of being lost here", applying the **same** redundancy gate `inlineInheritedTextAlignDeclaration()` already uses. An alignment reproduced by the wrapper's own preserved author rule, or inherited from a preserved ancestor, is not at risk and is not restated.
- `HtmlCompilation::createBlock()` — one choke point covering every `core/group` and `core/quote` construction site, rather than special-casing each place a paragraph is synthesized.
- Scoped to **phrasing-only** wrappers, so the inner blocks are that wrapper's own text rather than an arbitrary layout subtree.
- A block that already resolved its own alignment keeps it, so **explicit descendant alignment continues to win**.

Also carries the materializer's engine metadata (not only its provenance id) through `rebuildBlock()`, so editability ownership survives an in-place attribute rewrite.

## Acceptance (#751)

- Intro/testimonial text stays centred — covered by both new fixtures, which fail on `trunk` and pass here.
- Explicit descendant alignment continues to win — `html-box-chrome-wrapper-text-alignment` asserts a leaf that resolved `right` inside a `center` wrapper keeps `right`.
- Generated markup remains editor-valid — both fixtures assert `source_reports.wp_block_validity.status == "pass"` and `not_contains wp:html`.
- Transformer contracts and parity fixtures pass.

## Not in scope: the font-size delta

The parity evidence also showed a `20px → 18px` font-size delta on the same section. It is **not** the same defect and there is no evidence it is a blocks-engine defect at all:

- Transforming the real page at `973284e8` preserves the source 20px twice over — `core/quote` gets `style.typography.fontSize: "20px"` (rendering `<blockquote style="font-size:20px">`) and the inner `<mark>` keeps `font-size:20px` inline.
- The projected stylesheet keeps `.font_7{font:var(--font_7)}` and defines `--font_7: … 20px/1.5em madefor-text …` on `:root`, so the class resolves to 20px too. The only `font-size:…!important` rule in the projected CSS is `._Kekmv{font-size:18px!important}`, which matches nothing on this chain.
- The section contains an obvious false-match candidate: each testimonial is immediately followed by `<p class="font_8 …" style="text-align:center; font-size:18px;">Emma</p>` — 18px, `madefor-text`, the exact reported import values. That paragraph transforms correctly (keeps `align: center` and `18px`).

Left as a separate question rather than folded into this fix.

## Testing

`composer test` from `php-transformer/` — green, exit 0 (302 parity fixtures, all contract and unit suites, packaging). `php tests/contract/production-acceptance-matrix.php` — passed. `composer validate --strict` — valid. Both new fixtures verified to fail on `trunk` without the source change.

Note for local runs: `tests/unit/html-transformer-shared-analysis-cache.php` exhausts a 128M `memory_limit` on `trunk` as well as on this branch; runs above used `memory_limit=2G`. Pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155NCyT5ZBK9s39KaLdSPjp
