### PR TITLE
fix(php-transformer): hoist unique hidden navigation

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -125,6 +125,7 @@
       "php tests/unit/navigation-brand-cue-carrier.php",
       "php tests/unit/navigation-author-rule-memory.php",
       "php tests/unit/navigation-projection-state-isolation.php",
+      "php tests/unit/navigation-hidden-menu-hoist.php",
       "php tests/unit/navigation-direct-cluster-parity.php",
       "php tests/unit/navigation-non-anchor-brand-carrier.php",
       "php tests/unit/navigation-block-normalizer.php",

--- a/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressor.php
+++ b/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressor.php
@@ -57,14 +57,15 @@ final class NavigationToggleSuppressor
                 break;
             }
 
-            if ( $this->context->navigationProjection()->hasTargetForControl($control)
-                || ! $this->hasDialogPopupSemantics($control) ) {
+            if ( $this->context->navigationProjection()->hasTargetForControl($control) ) {
                 continue;
             }
 
             $relationship = $this->implicitHiddenNavigationRelationship($control);
             if ( null !== $relationship ) {
-                $this->context->navigationProjection()->markImplicitDialogControl($control);
+                if ( $this->hasDialogPopupSemantics($control) ) {
+                    $this->context->navigationProjection()->markImplicitDialogControl($control);
+                }
                 $this->recordProjectedNavigationRelationship($control, $relationship['target'], $relationship['navigation']);
             }
         }
@@ -94,22 +95,40 @@ final class NavigationToggleSuppressor
     {
         $depth = 0;
         for ( $scope = $this->menuToggleScope($control); $scope instanceof DOMElement && $depth < 12; $scope = $scope->parentNode, ++$depth ) {
-            $candidates = array();
+            $dialogCandidates = array();
+            $navigationCandidates = array();
             foreach ( $scope->getElementsByTagName('*') as $candidate ) {
-                if ( ! $candidate instanceof DOMElement || $candidate->isSameNode($control) || ! $this->isSemanticDialog($candidate) ) {
+                if ( ! $candidate instanceof DOMElement || $candidate->isSameNode($control) ) {
                     continue;
                 }
 
+                if ( $this->isSemanticDialog($candidate) ) {
+                    $navigation = $this->hiddenNavigationInControlledTarget($candidate);
+                    if ( $navigation instanceof DOMElement ) {
+                        $dialogCandidates[] = array('target' => $candidate, 'navigation' => $navigation);
+                    }
+                    continue;
+                }
+
+                // A capture can retain only the initially closed menu while the
+                // source creates its dialog after a click. A unique hidden nav
+                // in the control's bounded scope is its static counterpart.
                 $navigation = $this->hiddenNavigationInControlledTarget($candidate);
                 if ( $navigation instanceof DOMElement ) {
-                    $candidates[] = array('target' => $candidate, 'navigation' => $navigation);
+                    $navigationCandidates[] = array('target' => $candidate, 'navigation' => $navigation);
                 }
             }
 
-            if ( 1 === count($candidates) ) {
-                return $candidates[0];
+            if ( 1 === count($dialogCandidates) ) {
+                return $dialogCandidates[0];
             }
-            if ( 1 < count($candidates) ) {
+            if ( 1 < count($dialogCandidates) ) {
+                return null;
+            }
+            if ( 1 === count($navigationCandidates) ) {
+                return $navigationCandidates[0];
+            }
+            if ( 1 < count($navigationCandidates) ) {
                 return null;
             }
         }
@@ -650,18 +669,50 @@ final class NavigationToggleSuppressor
             }
 
             for ( $container = $toggle->parentNode; $container instanceof DOMElement && 'body' !== strtolower($container->tagName); $container = $container->parentNode ) {
-                if ( SourceDom::elementContains($container, $navigation) ) {
+                if ( SourceDom::elementContains($container, $navigation) && $this->isUniqueNavigationInScope($container, $navigation) ) {
                     return $this->concreteToggleControl($toggle);
                 }
             }
 
             $scope = $this->menuToggleScope($toggle);
-            if ( 'body' !== strtolower($scope->tagName) && SourceDom::elementContains($scope, $navigation) ) {
+            if ( 'body' !== strtolower($scope->tagName)
+                && SourceDom::elementContains($scope, $navigation)
+                && $this->isUniqueNavigationInScope($scope, $navigation) ) {
                 return $this->concreteToggleControl($toggle);
             }
         }
 
         return null;
+    }
+
+    private function isUniqueNavigationInScope(DOMElement $scope, DOMElement $navigation): bool
+    {
+        $candidates = array();
+        foreach ( $scope->getElementsByTagName('*') as $candidate ) {
+            if ( ! $candidate instanceof DOMElement || ! $this->convertsToCoreNavigation($candidate) ) {
+                continue;
+            }
+
+            $candidates[$candidate->getNodePath()] = $candidate;
+        }
+
+        foreach ( $candidates as $path => $candidate ) {
+            foreach ( $candidates as $otherPath => $other ) {
+                if ( $path !== $otherPath && SourceDom::elementContains($other, $candidate) ) {
+                    unset($candidates[$path]);
+                    break;
+                }
+            }
+        }
+
+        if ( 1 !== count($candidates) ) {
+            return false;
+        }
+
+        $candidate = array_values($candidates)[0];
+        return $candidate->isSameNode($navigation)
+            || SourceDom::elementContains($candidate, $navigation)
+            || SourceDom::elementContains($navigation, $candidate);
     }
 
     private function concreteToggleControl(DOMElement $toggle): DOMElement

--- a/php-transformer/tests/unit/navigation-hidden-menu-hoist.php
+++ b/php-transformer/tests/unit/navigation-hidden-menu-hoist.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$countBlocks = static function (array $blocks, string $name) use (&$countBlocks): int {
+    $count = 0;
+    foreach ( $blocks as $block ) {
+        if ( ! is_array($block) ) {
+            continue;
+        }
+        if ( $name === ($block['blockName'] ?? '') ) {
+            ++$count;
+        }
+        $count += $countBlocks(is_array($block['innerBlocks'] ?? null) ? $block['innerBlocks'] : array(), $name);
+    }
+
+    return $count;
+};
+
+$projected = ( new HtmlTransformer() )->transform(
+    '<header><a href="/" class="brand">Northwind</a><button aria-label="Menu" aria-expanded="false"><span></span><span></span></button><nav aria-label="Site" style="display:none"><a href="/">Home</a><a href="/work">Work</a></nav></header>'
+)->toArray();
+$projectedMarkup = (string) ($projected['serialized_blocks'] ?? '');
+
+$ambiguous = ( new HtmlTransformer() )->transform(
+    '<header><button aria-label="Menu" aria-expanded="false"><span></span><span></span></button><nav aria-label="Main" style="display:none"><a href="/">Home</a><a href="/work">Work</a></nav><nav aria-label="Utility" style="display:none"><a href="/help">Help</a><a href="/contact">Contact</a></nav></header>'
+)->toArray();
+$ambiguousMarkup = (string) ($ambiguous['serialized_blocks'] ?? '');
+
+$assertions = array(
+    array(1 === $countBlocks($projected['blocks'] ?? array(), 'core/navigation'), 'a unique hidden navigation is emitted once at its visible menu control'),
+    array(str_contains($projectedMarkup, '"overlayMenu":"mobile"'), 'a projected hidden navigation uses Core responsive overlay behavior'),
+    array(! str_contains($projectedMarkup, '<!-- wp:button'), 'the superseded source menu control is not emitted as a dead button'),
+    array(str_contains($projectedMarkup, 'Northwind') && str_contains($projectedMarkup, '"label":"Home"') && str_contains($projectedMarkup, '"label":"Work"'), 'projection preserves surrounding shell content and editable navigation destinations'),
+    array(2 === $countBlocks($ambiguous['blocks'] ?? array(), 'core/navigation'), 'ambiguous hidden navigation candidates remain unprojected'),
+    array(! str_contains($ambiguousMarkup, '"overlayMenu":"mobile"'), 'ambiguous candidates do not fabricate a responsive menu association'),
+);
+
+$failures = array_map(
+    static fn (array $assertion): string => $assertion[1],
+    array_filter($assertions, static fn (array $assertion): bool => ! $assertion[0])
+);
+if ( array() !== $failures ) {
+    fwrite(STDERR, "Navigation hidden menu hoist contract failed:\n" . implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+fwrite(STDOUT, 'Navigation hidden menu hoist contract passed: ' . count($assertions) . " assertions\n");


### PR DESCRIPTION
Fixes #1161

## Summary
- projects a uniquely associated closed navigation at its qualifying menu control before conversion, so Core responsive navigation occupies the visible control position
- preserves explicit controlled-target and semantic-dialog precedence
- declines ambiguous navigation candidates rather than assigning a responsive overlay

## Evidence
At 390px, the Busy Bears source has a visible `Menu` control and an initially hidden desktop nav; clicking source creates a dialog containing the same links. The supplied imported probe shows its responsive container stays hidden after clicking. The capture/conversion loss is therefore the missing static control-to-closed-nav association, not the desktop presentation path addressed by merged #1496 / #1482.

## Verification
- `php tests/unit/navigation-hidden-menu-hoist.php`
- `php tests/unit/navigation-projection-state-isolation.php`
- `php tests/contract/run.php`
- `composer validate --strict`
- `composer test` (passed: canonical, 301 parity fixtures, packaging/install proof)

## Self-review
Scoped to `php-transformer` navigation projection. The contract proves a unique hidden menu becomes one editable `core/navigation` with `overlayMenu: mobile`, preserves surrounding shell content and destinations, and leaves two hidden candidates unprojected.

AI assistance: OpenAI GPT-6 Astra via OpenCode orchestrated OpenAI GPT-5.6 Terra via direct OpenCode for investigation, implementation, verification, and self-review. Chris Huber remains responsible for the result.