### PR TITLE
fix(php-transformer): resolve scoped SVG paint variables

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
@@ -2889,20 +2889,9 @@ final class StyleResolver implements ElementPresentationResolver
             return $value;
         }
 
-        $customProperties = $this->context->sourceStyles()->customProperties();
-        if ( $element instanceof DOMElement ) {
-            $ancestors = array();
-            for ( $current = $element; $current instanceof DOMElement; $current = $current->parentNode instanceof DOMElement ? $current->parentNode : null ) {
-                $ancestors[] = $current;
-            }
-            foreach ( array_reverse($ancestors) as $ancestor ) {
-                foreach ( $this->structuralPresentationDeclarations($ancestor) as $name => $propertyValue ) {
-                    if ( str_starts_with($name, '--') ) {
-                        $customProperties[$name] = $propertyValue;
-                    }
-                }
-            }
-        }
+        $customProperties = $element instanceof DOMElement
+            ? $this->cascadedCustomProperties($element)
+            : $this->context->sourceStyles()->customProperties();
 
         return $this->expandCssVariableReferences($value, $customProperties);
     }

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializer.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializer.php
@@ -510,7 +510,7 @@ final class SvgMaterializer implements SvgElementMaterializer
 
     private function resolveMaterializedSvgColors(string $html, DOMElement $element): string
     {
-        $html = $this->styleResolver->resolveCssVariablesInValue($html);
+        $html = $this->styleResolver->resolveCssVariablesInValue($html, $element);
         if ( false !== stripos($html, 'currentColor') ) {
             $html = preg_replace('/\bcurrentColor\b/i', $this->inheritedSvgColor($element), $html) ?? $html;
         }

--- a/php-transformer/tests/unit/svg-materialized-paint-cascade.php
+++ b/php-transformer/tests/unit/svg-materialized-paint-cascade.php
@@ -62,6 +62,26 @@ $distinctContents = array_map(static fn (array $asset): string => (string) ($ass
 $assert((bool) array_filter($distinctContents, static fn (string $content): bool => str_contains($content, 'fill:#e1402a')), 'The first shape bakes its own resolved fill.');
 $assert((bool) array_filter($distinctContents, static fn (string $content): bool => str_contains($content, 'fill:#2a6fe1')), 'The second shape bakes its own, different, resolved fill.');
 
+// SVG presentation attributes are copied into the standalone image payload
+// directly. Resolve their variables at the SVG's own ancestor scope rather
+// than from the lossy document-wide custom-property collection.
+$scopedAttributePaint = '<style>
+#orange-one{--orange-icon:#e1402a}
+#orange-two{--orange-icon:#f58220}
+</style>
+<main>
+<div id="orange-one"><svg viewBox="0 0 10 10" width="10" height="10"><path fill="var(--orange-icon)" d="M0 0h10v10H0z"></path></svg></div>
+<div id="orange-two"><svg viewBox="0 0 10 10" width="10" height="10"><path fill="var(--orange-icon)" d="M0 0h10v10H0z"></path></svg></div>
+</main>';
+$scopedAttributeResult = (new HtmlTransformer())->transform($scopedAttributePaint)->toArray();
+$scopedAttributeAssets = $inlineSvgAssets($scopedAttributeResult);
+$scopedAttributeContents = array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), $scopedAttributeAssets);
+$assert(2 === count($scopedAttributeAssets), 'Scoped SVG presentation attributes produce distinct native image assets for distinct ancestor values.');
+$assert((bool) array_filter($scopedAttributeContents, static fn (string $content): bool => str_contains($content, 'fill="#e1402a"') && ! str_contains($content, 'var(')), 'The first scoped SVG presentation attribute is baked into its asset.');
+$assert((bool) array_filter($scopedAttributeContents, static fn (string $content): bool => str_contains($content, 'fill="#f58220"') && ! str_contains($content, 'var(')), 'The second scoped SVG presentation attribute is baked into its asset.');
+$assert(2 === substr_count((string) ($scopedAttributeResult['serialized_blocks'] ?? ''), '<!-- wp:image '), 'Scoped SVG presentation attributes retain the editor-native core/image contract.');
+$assert(! str_contains((string) ($scopedAttributeResult['serialized_blocks'] ?? ''), '<!-- wp:html'), 'Scoped SVG presentation attributes do not regress to an HTML fallback.');
+
 // Two shapes that resolve to the SAME cascaded color still dedupe onto one
 // asset -- paint baking must not break existing content-addressed sharing.
 $samePaint = '<style>


### PR DESCRIPTION
## Summary
- resolve inline SVG presentation-attribute custom properties using the SVG ancestor cascade
- reuse the full selector-aware custom-property cascade for element-scoped `var()` resolution
- preserve distinct materialized SVG assets and native `core/image` blocks for separately scoped values

Fixes #1431.

## Scope
This is an independently reproduced PHP Transformer SVG defect. It does not address the Aetna missing orange artwork: retained source audit evidence identifies that item as a 41px PNG, so its visibility remains a PHP layout/materialization investigation.

## Verification
- `composer test`
- `composer test:wordpress-integration` (skipped as expected: `WP_TESTS_DIR` unavailable)

## Security and behavior
- keeps the existing sanitizer and native-image eligibility gates unchanged
- unresolved variables remain fail-closed rather than becoming an HTML bypass
- regression proves no `core/html` fallback for scoped, passive SVG paint

AI assistance: OpenAI gpt-5.6-terra through OpenCode was used to trace the PHP transformer, implement the fix, and run verification.