### PR TITLE
fix(php-transformer): keep compact icon rows editable

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/MediaTextPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/MediaTextPattern.php
@@ -156,7 +156,15 @@ final class MediaTextPattern implements PatternRecognizerInterface
                     return null;
                 }
             }
+            $mediaStyle = $mergedPresentationStyle($resolution['media']);
         } catch ( \Throwable ) {
+            return null;
+        }
+
+        // A small, explicitly sized image beside a heading is an icon lockup,
+        // not a two-pane media/text section. Let normal group lowering retain
+        // the authored row so both the image and heading stay editable.
+        if ( 'img' === $mediaType && $this->isCompactIconHeadingPair($resolution['media'], $elementChildren[ $textIndex ], $mediaStyle) ) {
             return null;
         }
 
@@ -465,6 +473,51 @@ final class MediaTextPattern implements PatternRecognizerInterface
         }
 
         return false;
+    }
+
+    private function isCompactIconHeadingPair(DOMElement $media, DOMElement $text, string $mediaStyle): bool
+    {
+        if ( ! preg_match('/^h[1-6]$/', strtolower($text->tagName)) ) {
+            return false;
+        }
+
+        $width = $this->compactHtmlDimension($this->attr($media, 'width'));
+        $height = $this->compactHtmlDimension($this->attr($media, 'height'));
+        if ( null !== $width
+            && null !== $height
+            && 64 >= $width
+            && 64 >= $height ) {
+            return true;
+        }
+
+        $declarations = $this->styleDeclarations($mediaStyle);
+        $width = $this->compactPixelDimension($this->normalizedCssValue((string) ($declarations['width'] ?? '')));
+        $heightValue = strtolower($this->normalizedCssValue((string) ($declarations['height'] ?? 'auto')));
+        $height = $this->compactPixelDimension($heightValue);
+
+        return null !== $width
+            && 64 >= $width
+            && ( 'auto' === $heightValue || ( null !== $height && 64 >= $height ) );
+    }
+
+    private function compactPixelDimension(string $value): ?float
+    {
+        if ( ! preg_match('/^\s*(\d+(?:\.\d+)?)\s*px\s*$/i', $value, $matches) ) {
+            return null;
+        }
+
+        $dimension = (float) $matches[1];
+        return 0 < $dimension ? $dimension : null;
+    }
+
+    private function compactHtmlDimension(string $value): ?float
+    {
+        if ( ! preg_match('/^\s*(\d+(?:\.\d+)?)\s*$/', $value, $matches) ) {
+            return null;
+        }
+
+        $dimension = (float) $matches[1];
+        return 0 < $dimension ? $dimension : null;
     }
 
     /**

--- a/php-transformer/tests/unit/media-text-pattern.php
+++ b/php-transformer/tests/unit/media-text-pattern.php
@@ -209,6 +209,20 @@ $assertSame('core/media-text', $headingMediaText['blockName'] ?? null, 'Heading 
 $assertSame('core/heading', $headingMediaText['innerBlocks'][0]['blockName'] ?? null, 'Heading text side keeps core/heading identity.');
 $assertTrue(! array_key_exists('mediaAlt', $headingMediaText['attrs'] ?? array()), 'Empty image alt is omitted from media-text attrs.');
 
+// Compact, explicitly sized icons beside direct headings are row lockups, not
+// split media/text sections. Their normal lowering remains entirely editable.
+$iconHeadingResult = $transformHtml('<section style="display:flex;align-items:center;gap:12px"><figure><img src="icon.png" width="88" height="87" style="width:41px;height:auto" alt=""></figure><h2>Plush 2</h2></section>');
+$iconHeadingBlock = $iconHeadingResult['blocks'][0] ?? array();
+$iconHeadingAssets = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), $iconHeadingResult['assets'] ?? array()));
+$assertSame('core/group', $iconHeadingBlock['blockName'] ?? null, 'Compact icon plus heading falls through to native group lowering.');
+$assertContains('display:flex !important', $iconHeadingAssets, 'Compact icon lockup retains the authored row layout in its CSS carrier.');
+$assertSame('core/image', $iconHeadingBlock['innerBlocks'][0]['blockName'] ?? null, 'Compact icon lockup keeps an editable image block.');
+$assertSame('core/heading', $iconHeadingBlock['innerBlocks'][1]['blockName'] ?? null, 'Compact icon lockup keeps an editable heading block.');
+$assertSame(array(), $iconHeadingResult['fallbacks'] ?? array(), 'Compact icon lockup emits no HTML fallback.');
+
+$largeHeadingResult = $transformHtml('<section style="display:flex"><img src="feature.jpg" width="640" height="360" alt=""><h2>Feature</h2></section>');
+$assertSame('core/media-text', $largeHeadingResult['blocks'][0]['blockName'] ?? null, 'Legitimate large image plus heading remains media-text.');
+
 $quoteResult = $transformHtml('<section style="display:flex"><img src="x.jpg"><blockquote><p>Quoted</p></blockquote></section>');
 $assertSame('core/quote', $quoteResult['blocks'][0]['innerBlocks'][0]['blockName'] ?? null, 'Blockquote text side keeps core/quote identity.');
 


### PR DESCRIPTION
## Summary
- decline compact, explicitly sized image-and-direct-heading rows in the PHP `MediaTextPattern` recognizer
- let native PHP group lowering retain editable image and heading blocks with the authored flex row
- keep larger image/heading media-text sections eligible

Fixes #1588

## Verification
- `composer test`
- isolated Playwright render of PHP-compiled Aetna-shaped fixture: group computes to `display:flex` with a 41px icon and adjacent heading

AI disclosure: OpenAI gpt-5.6-terra through direct OpenCode implementation.