### PR TITLE
fix(php-transformer): lower linked attachment paragraphs

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Elements/RichTextElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/RichTextElementContext.php
@@ -27,6 +27,7 @@ final class RichTextElementContext
      * @param Closure(DOMElement): bool                                                                      $hasEmptyVisualInlineChild
      * @param Closure(DOMElement): bool                                                                      $hasBoxChromeWrapperStyling
      * @param Closure(DOMElement): bool                                                                      $isRuntimeDomTarget
+     * @param Closure(DOMElement): ?array<string, mixed>                                                     $imageBlockFromParagraph
      * @param Closure(string): array<int, array<string, mixed>>                                              $convertText
      * @param Closure(DOMElement, array<int, array<string, mixed>>, bool): array<int, array<string, mixed>>   $convertChildren
      */
@@ -39,6 +40,7 @@ final class RichTextElementContext
         private readonly Closure $hasEmptyVisualInlineChild,
         private readonly Closure $hasBoxChromeWrapperStyling,
         private readonly Closure $isRuntimeDomTarget,
+        private readonly Closure $imageBlockFromParagraph,
         private readonly Closure $convertText,
         private readonly Runtime $runtime,
         private readonly Closure $convertChildren
@@ -122,6 +124,12 @@ final class RichTextElementContext
     public function isRuntimeDomTarget(DOMElement $element): bool
     {
         return ($this->isRuntimeDomTarget)($element);
+    }
+
+    /** @return array<string, mixed>|null */
+    public function imageBlockFromParagraph(DOMElement $element): ?array
+    {
+        return ($this->imageBlockFromParagraph)($element);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Elements/RichTextElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/RichTextElementConverter.php
@@ -87,6 +87,13 @@ final class RichTextElementConverter implements ElementConverter
             return $marquee;
         }
 
+        // Paragraphs used only as attachment wrappers are common in WordPress
+        // source. Route their image anchor before RichText rejects the <img>.
+        $image = $this->context->imageBlockFromParagraph($element);
+        if ( null !== $image ) {
+            return $image;
+        }
+
         $content         = $this->context->richTextContent($element);
         $withInlineSvg   = $this->context->richTextWithMaterializedSvgImages($element, $content);
         if ( null !== $withInlineSvg ) {

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -1024,6 +1024,7 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             fn (DOMElement $element): bool => $this->hasEmptyVisualInlineChild($element),
             fn (DOMElement $element): bool => $this->hasBoxChromeWrapperStyling($element),
             fn (DOMElement $element): bool => $this->runtimeIslands->isRuntimeDomTarget($element),
+            fn (DOMElement $element): ?array => $this->imageBlockFromParagraph($element),
             fn (string $text): array => $this->convertText($text),
             $this->runtime,
             function (DOMElement $element, array &$fallbacks, bool $captureUnsupported): array {
@@ -9417,6 +9418,36 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             }
         }
         return $image instanceof DOMElement ? $this->responsiveMediaBlock($anchor) : null;
+    }
+
+    /**
+     * A paragraph with exactly one image-only link is presentation-neutral
+     * attachment markup, not RichText. Preserve its native link as core/image.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function imageBlockFromParagraph(DOMElement $paragraph): ?array
+    {
+        $anchor = null;
+        foreach ( $paragraph->childNodes as $child ) {
+            if ( $child instanceof DOMElement ) {
+                if ( $anchor instanceof DOMElement || 'a' !== strtolower($child->tagName) ) {
+                    return null;
+                }
+                $anchor = $child;
+                continue;
+            }
+            if ( '' !== trim($child->textContent ?? '') ) {
+                return null;
+            }
+        }
+
+        if ( ! $anchor instanceof DOMElement || ! $this->isImageOnlyAnchor($anchor) ) {
+            return null;
+        }
+
+        $image = $this->firstChildElement($anchor, 'img');
+        return $image instanceof DOMElement ? $this->convertImageElement($image, null, null, $anchor) : null;
     }
 
     private function isImageOnlyAnchor(DOMElement $anchor): bool

--- a/php-transformer/tests/unit/rich-text-element-converter.php
+++ b/php-transformer/tests/unit/rich-text-element-converter.php
@@ -47,6 +47,7 @@ $makeConverter = static function (array $overrides = array()): RichTextElementCo
         'hasEmptyVisualInlineChild'         => static fn (DOMElement $e): bool => false,
         'hasBoxChromeWrapperStyling'        => static fn (DOMElement $e): bool => false,
         'isRuntimeDomTarget'                => static fn (DOMElement $e): bool => false,
+        'imageBlockFromParagraph'           => static fn (DOMElement $e): ?array => null,
         'convertText'                       => static fn (string $t): array => '' === $t ? array() : array(array('blockName' => 'core/paragraph', 'attrs' => array('content' => $t))),
         'convertChildren'                   => static function (DOMElement $e, array &$f, bool $c): array {
             return array();
@@ -70,6 +71,7 @@ $makeConverter = static function (array $overrides = array()): RichTextElementCo
         $c['hasEmptyVisualInlineChild'],
         $c['hasBoxChromeWrapperStyling'],
         $c['isRuntimeDomTarget'],
+        $c['imageBlockFromParagraph'],
         $c['convertText'],
         new Runtime(),
         $c['convertChildren']
@@ -121,6 +123,9 @@ $assert('NORMALIZED:Title' === ($headingNormalized->convert($elementFrom('<h3>Ti
 // A paragraph recognized as an authored marquee short-circuits everything else.
 $marquee = $makeConverter(array('authoredMarqueeBlock' => static fn (DOMElement $e): ?array => array('blockName' => 'blocks-engine/marquee')));
 $assert('blocks-engine/marquee' === ($marquee->convert($elementFrom('<p>scroll</p>'), 'p', $fallbacks)->block['blockName'] ?? ''), 'paragraph-marquee-short-circuits');
+
+$linkedImage = $makeConverter(array('imageBlockFromParagraph' => static fn (DOMElement $e): ?array => array('blockName' => 'core/image')));
+$assert('core/image' === ($linkedImage->convert($elementFrom('<p><a href="/model"><img src="model.jpg"></a></p>'), 'p', $fallbacks)->block['blockName'] ?? ''), 'paragraph-image-short-circuits-rich-text-fallback');
 
 // Materialized inline SVG replaces the plain rich-text content. The materialized
 // markup strips to an empty string, so it only survives as a paragraph because

--- a/php-transformer/tests/unit/rich-text-source-serialization.php
+++ b/php-transformer/tests/unit/rich-text-source-serialization.php
@@ -5,6 +5,7 @@ require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\BlockFactory;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\BlockValidityValidator;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
 $failures = 0;
@@ -54,6 +55,22 @@ $assert(
     str_contains($secondMarkup, 'color:rgb(var(--light))')
         && ! str_contains($secondMarkup, 'color:rgb(var(--dark))'),
     'Separate RichText fragment documents do not leak an earlier fragment cascade into the same DOM path.'
+);
+
+$linkedAttachment = ( new HtmlTransformer() )->transform(
+    '<p class="attachment"><a class="lightbox" href="https://example.test/model-full.jpg" target="_blank" rel="noopener"><img src="https://example.test/model.jpg" alt="Geological model"></a></p>'
+)->toArray();
+$attachmentMarkup = (string) ($linkedAttachment['serialized_blocks'] ?? '');
+$assert(
+    str_contains($attachmentMarkup, '<!-- wp:image ')
+        && str_contains($attachmentMarkup, '<a href="https://example.test/model-full.jpg" target="_blank" rel="noopener" class="lightbox">')
+        && str_contains($attachmentMarkup, '<img src="https://example.test/model.jpg" alt="Geological model"/>')
+        && ! str_contains($attachmentMarkup, '<!-- wp:html'),
+    'An image-only paragraph link lowers to a native linked image instead of a core/html fallback.'
+);
+$assert(
+    'pass' === ( ( new BlockValidityValidator() )->validateBlocks($linkedAttachment['blocks'] ?? array())['status'] ?? '' ),
+    'A linked image lowered from a paragraph stays Gutenberg-valid.'
 );
 
 if ( 0 === $failures ) {


### PR DESCRIPTION
Closes #1591

## Summary
- lower an image-only paragraph anchor through existing native `core/image` conversion before RichText rejects its `<img>`
- preserve the image link URL, target, rel, class, image URL, and alt text
- keep direct image-anchor responsive-media behavior unchanged

## Evidence
Live `https://aetnageo.com/3d-geological-model/` has an attachment paragraph containing one linked image. The original report has 92 unique capped `block_grammar` projections, dominated by this `<p><a><img>` shape; it is not a general rich-text failure. The transformed representative now serializes as a `core/image`, with no `core/html`, and validates with `BlockValidityValidator`.

Live browser color proof for the separate logo observation: `.site-branding` and `.site-title` compute to `rgb(85, 85, 85)`; nested `.site-title span` computes to `rgb(232, 113, 28)`. Existing RichText mark materialization preserves these captured inline declarations, so no speculative logo change is included.

## Tests
- `composer test`
- representative live Aetna transform plus native block validity check

AI disclosure: OpenAI gpt-5.6-terra through direct OpenCode implementation; OpenAI gpt-6-astra through OpenCode orchestration.