### PR TITLE
fix(php-transformer): preserve projected navigation layout

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -2835,7 +2835,7 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
         foreach ( array( 'font', 'color', 'font-family', 'font-size', 'font-weight', 'font-style', 'letter-spacing', 'text-transform' ) as $property ) {
             $value = $this->navigationItemPresentationValue($anchor, $navigation, $property);
             if ( '' !== $value ) {
-                $declarations[] = $property . ':' . $value;
+                $declarations[] = $property . ':' . $this->navigationProjectionValue($value);
             }
         }
         if ( array() === $declarations ) {
@@ -2847,6 +2847,16 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             $selector,
             $selector . '{' . implode(';', $declarations) . '}'
         );
+    }
+
+    /**
+     * A promoted navigation is no longer inside the source component's query
+     * container. Bind inherited container-width units to the viewport, the
+     * responsive reference shared by the source page and its native replacement.
+     */
+    private function navigationProjectionValue(string $value): string
+    {
+        return preg_replace('/(?<![a-z-])cqw\b/i', 'vw', $value) ?? $value;
     }
 
     /**
@@ -3009,7 +3019,12 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
                 }
                 $block['attrs']['className'] = $this->mergeClassNames(
                     $nativeClassNames,
+                    // The promoted block replaces the hidden menu and its visible
+                    // control, so both class sets and the generated toggle marker
+                    // are needed for item presentation and control geometry.
+                    (string) ($block['attrs']['className'] ?? ''),
                     (string) ($controlAttrs['className'] ?? ''),
+                    $this->responsiveNavigationToggleMarker($projectedNavigation),
                     $this->sourceBlockAttributeProjector->sourceProjectionClassName($element, $this->sourceBlockAttributeProjectionContext())
                 );
                 $block['attrs']['overlayMenu'] = 'mobile';

--- a/php-transformer/tests/unit/navigation-hidden-menu-hoist.php
+++ b/php-transformer/tests/unit/navigation-hidden-menu-hoist.php
@@ -21,9 +21,14 @@ $countBlocks = static function (array $blocks, string $name) use (&$countBlocks)
 };
 
 $projected = ( new HtmlTransformer() )->transform(
-    '<header><a href="/" class="brand">Northwind</a><button aria-label="Menu" aria-expanded="false"><span></span><span></span></button><nav aria-label="Site" style="display:none"><a href="/">Home</a><a href="/work">Work</a></nav></header>'
+    '<style>.menu-toggle{width:42px;height:48px;padding:3px 0}</style>'
+    . '<header><a href="/" class="brand">Northwind</a><button class="menu-toggle" aria-label="Menu" aria-expanded="false"><span></span><span></span></button><nav aria-label="Site" class="source-menu" style="display:none;font:normal 400 max(.5px,.0125 * (100cqw - 0px))/1.2 sans-serif"><a href="/">Home</a><a href="/work">Work</a></nav></header>'
 )->toArray();
 $projectedMarkup = (string) ($projected['serialized_blocks'] ?? '');
+$projectedCss = implode("\n", array_map(
+    static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '',
+    is_array($projected['assets'] ?? null) ? $projected['assets'] : array()
+));
 
 $ambiguous = ( new HtmlTransformer() )->transform(
     '<header><button aria-label="Menu" aria-expanded="false"><span></span><span></span></button><nav aria-label="Main" style="display:none"><a href="/">Home</a><a href="/work">Work</a></nav><nav aria-label="Utility" style="display:none"><a href="/help">Help</a><a href="/contact">Contact</a></nav></header>'
@@ -33,6 +38,9 @@ $ambiguousMarkup = (string) ($ambiguous['serialized_blocks'] ?? '');
 $assertions = array(
     array(1 === $countBlocks($projected['blocks'] ?? array(), 'core/navigation'), 'a unique hidden navigation is emitted once at its visible menu control'),
     array(str_contains($projectedMarkup, '"overlayMenu":"mobile"'), 'a projected hidden navigation uses Core responsive overlay behavior'),
+    array(1 === preg_match('/blocks-engine-native-navigation-toggle-[a-f0-9]{12}/', $projectedMarkup), 'a projected hidden navigation retains its native toggle geometry marker'),
+    array(str_contains($projectedCss, 'width:42px!important;height:48px!important'), 'the visible source control box projects onto Core\'s responsive open button'),
+    array(str_contains($projectedCss, '100vw'), 'container-relative inherited navigation typography is rebound after promotion'),
     array(! str_contains($projectedMarkup, '<!-- wp:button'), 'the superseded source menu control is not emitted as a dead button'),
     array(str_contains($projectedMarkup, 'Northwind') && str_contains($projectedMarkup, '"label":"Home"') && str_contains($projectedMarkup, '"label":"Work"'), 'projection preserves surrounding shell content and editable navigation destinations'),
     array(2 === $countBlocks($ambiguous['blocks'] ?? array(), 'core/navigation'), 'ambiguous hidden navigation candidates remain unprojected'),


### PR DESCRIPTION
## Summary
- retain the hidden menu classes and responsive toggle marker when a visible control is replaced with native `core/navigation`
- rebind inherited navigation `cqw` typography to the viewport after its source query container is replaced
- cover the native overlay marker, 42x48 projected open button, and responsive typography projection

Refs #1482.

## Commit
`920d3bdf61d9d26ba292777eed840b02e0e8e446`

## Validation
- `php tests/unit/navigation-hidden-menu-hoist.php`
- `composer test` (canonical, parity, and packaging sub-gates completed; the umbrella command hit the 120s local runner limit after the dist-shape gate)
- `composer test:packaging`
- `npm test --prefix tools/visual-parity`

## Browser Evidence
Playwright run from `php-transformer/tools/visual-parity`: `https://www.busybearscleaning.com/` reported desktop Get a Quote at `18px` and the 390px hamburger at `41.98x47.95px`. The installed comparison at `http://localhost:8884/` is a pre-repair import and remains `59.08px` desktop / `0x0` mobile; no local re-import endpoint is available, so post-materialization browser proof is blocked rather than claimed.

## AI Assistance
OpenAI GPT-5.6 Terra via direct OpenCode, with Astra orchestration, traced the source capture, CSS projection, native navigation mapping, added the regression coverage, and ran the listed checks.
