### PR TITLE
fix(php-transformer): retain permanently hidden source states

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/ClosedStateNormalizer.php
+++ b/php-transformer/src/HtmlToBlocks/Style/ClosedStateNormalizer.php
@@ -22,14 +22,14 @@ final class ClosedStateNormalizer
      * @param array<string, string> $declarations
      * @return array{declarations: array<string, string>, stripped: list<string>}
      */
-    public function strip(array $declarations): array
+    public function strip(array $declarations, array $revealProperties = array()): array
     {
         $stripped = array();
-        if ( isset($declarations['display']) && 'none' === $this->normalizedValue($declarations['display']) ) {
+        if ( isset($revealProperties['display']) && isset($declarations['display']) && 'none' === $this->normalizedValue($declarations['display']) ) {
             unset($declarations['display']);
             $stripped[] = 'display:none';
         }
-        if ( isset($declarations['visibility']) && 'hidden' === $this->normalizedValue($declarations['visibility']) ) {
+        if ( isset($revealProperties['visibility']) && isset($declarations['visibility']) && 'hidden' === $this->normalizedValue($declarations['visibility']) ) {
             unset($declarations['visibility']);
             $stripped[] = 'visibility:hidden';
         }
@@ -42,18 +42,18 @@ final class ClosedStateNormalizer
         $height = strtolower(trim((string) ($declarations['height'] ?? '')));
         $maxHeight = strtolower(trim((string) ($declarations['max-height'] ?? '')));
         $overflow = strtolower(trim((string) ($declarations['overflow'] ?? '')));
-        if ( $this->isZeroLength($height) ) {
+        if ( isset($revealProperties['height']) && $this->isZeroLength($height) ) {
             unset($declarations['height']);
             $stripped[] = 'height:0';
-            if ( $this->isHiddenOverflow($overflow) ) {
+            if ( isset($revealProperties['overflow']) && $this->isHiddenOverflow($overflow) ) {
                 unset($declarations['overflow']);
                 $stripped[] = 'overflow:hidden';
             }
         }
-        if ( $this->isZeroLength($maxHeight) ) {
+        if ( isset($revealProperties['max-height']) && $this->isZeroLength($maxHeight) ) {
             unset($declarations['max-height']);
             $stripped[] = 'max-height:0';
-            if ( $this->isHiddenOverflow($overflow) ) {
+            if ( isset($revealProperties['overflow']) && $this->isHiddenOverflow($overflow) ) {
                 unset($declarations['overflow']);
                 $stripped[] = 'overflow:hidden';
             }

--- a/php-transformer/src/HtmlToBlocks/Style/SourceStyleResolutionState.php
+++ b/php-transformer/src/HtmlToBlocks/Style/SourceStyleResolutionState.php
@@ -5,6 +5,8 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
 
 use Automattic\BlocksEngine\PhpTransformer\Css\CssSelectorMatchCache;
 use Automattic\BlocksEngine\PhpTransformer\Css\CssSelectorMatcher;
+use DOMDocument;
+use DOMElement;
 
 /** Per-transform source stylesheet matching and declaration state. */
 final class SourceStyleResolutionState
@@ -33,6 +35,9 @@ final class SourceStyleResolutionState
     private array $navigationStateRules = array();
 
     /** @var array<int, array<string, mixed>> */
+    private array $revealStateRules = array();
+
+    /** @var array<int, array<string, mixed>> */
     private array $imageShapeRules = array();
 
     /** @var array<int, array<string, mixed>> */
@@ -47,6 +52,9 @@ final class SourceStyleResolutionState
     /** @var array<string, array<string, mixed>|null> */
     private array $parsedSelectors = array();
 
+    /** @var array<int, array<string, true>> */
+    private array $ariaControlledTargetIds = array();
+
     private string $formLayoutCss = '';
 
     public function __construct()
@@ -58,6 +66,7 @@ final class SourceStyleResolutionState
     {
         $this->selectorMatchCache->clear();
         $this->structuralDeclarations = array();
+        $this->ariaControlledTargetIds = array();
     }
 
     /**
@@ -70,6 +79,7 @@ final class SourceStyleResolutionState
         $this->staticRules = $analysis['static'];
         $this->conditionalRules = $analysis['conditional'];
         $this->navigationStateRules = $analysis['navigation_state'];
+        $this->revealStateRules = $analysis['reveal_state'];
         $this->imageShapeRules = $analysis['image_shape'];
         $this->pseudoElementRules = $analysis['pseudo'];
         $this->cascadedValueRules = $analysis['cascaded_values'] ?? array();
@@ -117,6 +127,39 @@ final class SourceStyleResolutionState
     public function navigationStateRules(): array
     {
         return $this->navigationStateRules;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function revealStateRules(): array
+    {
+        return $this->revealStateRules;
+    }
+
+    public function isAriaControlledTarget(DOMElement $element): bool
+    {
+        $id = trim($element->getAttribute('id'));
+        $document = $element->ownerDocument;
+        if ('' === $id || ! $document instanceof DOMDocument) {
+            return false;
+        }
+
+        $key = spl_object_id($document);
+        if (! isset($this->ariaControlledTargetIds[$key])) {
+            $controlled = array();
+            foreach ($document->getElementsByTagName('*') as $control) {
+                if (! $control instanceof DOMElement || ! $control->hasAttribute('aria-expanded')) {
+                    continue;
+                }
+                foreach (preg_split('/\s+/', trim($control->getAttribute('aria-controls'))) ?: array() as $controlledId) {
+                    if ('' !== $controlledId) {
+                        $controlled[$controlledId] = true;
+                    }
+                }
+            }
+            $this->ariaControlledTargetIds[$key] = $controlled;
+        }
+
+        return isset($this->ariaControlledTargetIds[$key][$id]);
     }
 
     /** @return array<int, array<string, mixed>> */

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
@@ -576,6 +576,16 @@ final class StyleResolver implements ElementPresentationResolver
                 )));
             }
         }
+        if ('hidden' === CssValueInspector::comparable((string) ($declarations['visibility'] ?? ''))) {
+            $properties[] = 'visibility';
+        }
+        $collapsedHeight = CssValueInspector::comparable((string) ($declarations['height'] ?? $declarations['max-height'] ?? ''));
+        if (
+            1 === preg_match('/^0(?:px|em|rem|%|vh|vw)?$/', $collapsedHeight)
+            && in_array(CssValueInspector::comparable((string) ($declarations['overflow'] ?? '')), array('hidden', 'clip'), true)
+        ) {
+            $properties[] = 'overflow';
+        }
         $inlineBackground = (string) ($declarations['background'] ?? $declarations['background-image'] ?? '');
         if ( preg_match('/\burl\s*\(/i', $inlineBackground)
             && ( 0 < SourceDom::directElementChildCount($element) || '' !== trim((string) $element->textContent) )
@@ -1858,7 +1868,7 @@ final class StyleResolver implements ElementPresentationResolver
             unset($declarations['display']);
         }
 
-        $normalized = $this->closedStateNormalizer()->strip($declarations);
+        $normalized = $this->closedStateNormalizer()->strip($declarations, $this->sourceRevealProperties($element, $declarations));
         if ( null !== $responsiveDisplay ) {
             $normalized['declarations']['display'] = $responsiveDisplay;
         }
@@ -1887,6 +1897,71 @@ final class StyleResolver implements ElementPresentationResolver
         }
 
         return false;
+    }
+
+    /** @param array<string, string> $declarations @return array<string, true> */
+    private function sourceRevealProperties(DOMElement $element, array $declarations): array
+    {
+        if ($this->context->sourceStyles()->isAriaControlledTarget($element)) {
+            return array(
+                'display' => true,
+                'visibility' => true,
+                'height' => true,
+                'max-height' => true,
+                'overflow' => true,
+            );
+        }
+
+        $revealed = array();
+        foreach ($this->context->sourceStyles()->revealStateRules() as $rule) {
+            if (! $this->matchesCssSelector($element, (string) $rule['base_selector'])) {
+                continue;
+            }
+            $state = (array) ($rule['declarations'] ?? array());
+            if ('none' === CssValueInspector::comparable((string) ($declarations['display'] ?? '')) && $this->isVisibleDisplay((string) ($state['display'] ?? ''))) {
+                $revealed['display'] = true;
+            }
+            if ('hidden' === CssValueInspector::comparable((string) ($declarations['visibility'] ?? '')) && 'visible' === CssValueInspector::comparable((string) ($state['visibility'] ?? ''))) {
+                $revealed['visibility'] = true;
+            }
+            $revealsGeometry = false;
+            foreach (array('height', 'max-height') as $property) {
+                if ($this->isZeroLength((string) ($declarations[$property] ?? '')) && $this->isExpandedLength($property, (string) ($state[$property] ?? ''))) {
+                    $revealed[$property] = true;
+                    $revealsGeometry = true;
+                }
+            }
+            if (
+                $revealsGeometry
+                && 'visible' === CssValueInspector::comparable((string) ($state['overflow'] ?? ''))
+            ) {
+                $revealed['overflow'] = true;
+            }
+        }
+
+        return $revealed;
+    }
+
+    private function isVisibleDisplay(string $value): bool
+    {
+        return in_array(CssValueInspector::comparable($value), array('block', 'contents', 'flex', 'grid', 'inline', 'inline-block', 'inline-flex', 'inline-grid', 'list-item', 'table'), true);
+    }
+
+    private function isZeroLength(string $value): bool
+    {
+        return 1 === preg_match('/^0(?:px|em|rem|%|vh|vw)?$/', CssValueInspector::comparable($value));
+    }
+
+    private function isExpandedLength(string $property, string $value): bool
+    {
+        $value = CssValueInspector::comparable($value);
+        if ('' === $value || $this->isZeroLength($value)) {
+            return false;
+        }
+
+        return ('height' === $property && in_array($value, array('auto', 'fit-content', 'max-content', 'min-content'), true))
+            || ('max-height' === $property && 'none' === $value)
+            || 1 === preg_match('/^(?:\d*\.\d+|\d+)(?:px|em|rem|%|vh|vw)$/', $value);
     }
 
     private function isExplicitlyInactiveState(DOMElement $element): bool
@@ -2306,6 +2381,7 @@ final class StyleResolver implements ElementPresentationResolver
             'static' => array(),
             'conditional' => array(),
             'navigation_state' => array(),
+            'reveal_state' => array(),
             'image_shape' => array(),
             'pseudo' => array(),
             'cascaded_values' => array(),
@@ -2383,6 +2459,7 @@ final class StyleResolver implements ElementPresentationResolver
                         $baseSelector = trim(substr_replace($selector, '', $offset, strlen((string) $stateMatches[0][0][0])));
                         if ('' !== $baseSelector && ! $this->selectorCarriesPseudoState($baseSelector) && $this->isSupportedCssSelector($baseSelector)) {
                             $analysis['navigation_state'][] = array('selector' => $selector, 'base_selector' => $baseSelector, 'state' => $state, 'declarations' => $declarations);
+                            $analysis['reveal_state'][] = array('base_selector' => $baseSelector, 'declarations' => $rawDeclarations);
                         }
                     }
                     if (preg_match('/::?(before|after)\b/i', $selector, $pseudoMatch)) {

--- a/php-transformer/src/HtmlToBlocks/Style/StylesheetAnalysisComposer.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StylesheetAnalysisComposer.php
@@ -86,10 +86,10 @@ final class StylesheetAnalysisComposer
         return array(array('content' => $content, 'source_path' => 'inline-style', 'source_hash' => hash('sha256', $content)));
     }
 
-    /** @param list<string> $payloads @return array{static: array, conditional: array, navigation_state: array, image_shape: array, pseudo: array, cascaded_values: array, custom_properties: array} */
+    /** @param list<string> $payloads @return array{static: array, conditional: array, navigation_state: array, reveal_state: array, image_shape: array, pseudo: array, cascaded_values: array, custom_properties: array} */
     public function composedStyleAnalysis(array $payloads): array
     {
-        $composed = array('static' => array(), 'conditional' => array(), 'navigation_state' => array(), 'image_shape' => array(), 'pseudo' => array(), 'cascaded_values' => array(), 'custom_properties' => array('root' => array(), 'fallback' => array()));
+        $composed = array('static' => array(), 'conditional' => array(), 'navigation_state' => array(), 'reveal_state' => array(), 'image_shape' => array(), 'pseudo' => array(), 'cascaded_values' => array(), 'custom_properties' => array('root' => array(), 'fallback' => array()));
         foreach ( $payloads as $payload ) {
             $key = hash('sha256', $payload);
             $analysis = $this->analysisCache->style($key);
@@ -102,6 +102,7 @@ final class StylesheetAnalysisComposer
                     'static' => $style['static'],
                     'conditional' => $style['conditional'],
                     'navigation_state' => $style['navigation_state'],
+                    'reveal_state' => $style['reveal_state'],
                     'image_shape' => $style['image_shape'],
                     'pseudo' => $style['pseudo'],
                     'cascaded_values' => $style['cascaded_values'],
@@ -111,7 +112,7 @@ final class StylesheetAnalysisComposer
             } else {
                 ++$this->analysisCache->styleHits;
             }
-            foreach ( array('static', 'conditional', 'navigation_state', 'pseudo', 'cascaded_values') as $part ) {
+            foreach ( array('static', 'conditional', 'navigation_state', 'reveal_state', 'pseudo', 'cascaded_values') as $part ) {
                 $composed[$part] = array_merge($composed[$part], $analysis[$part]);
             }
             foreach ( $analysis['image_shape'] as $rule ) {

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -5162,7 +5162,7 @@ if ( ! str_contains($result['serialized_blocks'], '<!-- wp:heading {"level":1} -
 // a block support rides on `className`, and responsive/JS-revealed base hidden
 // states (display:none) are never frozen onto content-bearing elements.
 $canonicalStyleResult = ( new HtmlTransformer() )->transform(
-    '<style>.class-owned-flex{display:flex;flex-direction:column;gap:1rem}</style>'
+    '<style>.class-owned-flex{display:flex;flex-direction:column;gap:1rem}.frozen-panel{display:none;visibility:hidden;height:0;overflow:hidden}.frozen-trigger:hover + .frozen-panel{display:block;visibility:visible;height:auto;overflow:visible}</style>'
     . '<main>'
     . '<h2 class="eyebrow" style="font-size:2rem;color:#c0392b;font-weight:700">Styled heading</h2>'
     . '<p class="lede" style="color:#222;line-height:1.6;text-align:center;font-family:var(--font-mono)">Styled paragraph</p>'
@@ -5170,6 +5170,7 @@ $canonicalStyleResult = ( new HtmlTransformer() )->transform(
     . '<h3>Hero heading</h3><p>Hero content</p></div>'
     . '<div class="class-owned-flex"><p>Class-owned layout</p></div>'
     . '<nav class="main-nav" style="display:none;gap:1.6rem"><a href="/a">Home</a></nav>'
+    . '<div class="frozen-trigger">Reveal panel</div><section id="canonical-frozen-panel" class="frozen-panel"><p>Recovered panel</p></section>'
     . '</main>'
 )->toArray();
 
@@ -5353,15 +5354,16 @@ $classOwnedFlex = $findBlockByClass($canonicalStyleResult['blocks'], 'class-owne
 $assert(is_array($classOwnedFlex), 'class-owned flex container block is emitted');
 $assert(! isset($classOwnedFlex['attrs']['layout']), 'class-owned flex CSS does not synthesize a WordPress layout attribute');
 
-// Hidden-state safety (#259): a base display:none on content-bearing nav is not
-// frozen; it is normalized away and surfaced as a frozen_hidden_state finding.
+// A base display:none without source reveal evidence remains authored rather than
+// being globally repaired into an exposed navigation state.
 $nav = $findBlock($canonicalStyleResult['blocks'], 'core/navigation');
 $assert(is_array($nav), 'navigation block is emitted');
 $assert(! is_string($nav['attrs']['style'] ?? null), 'navigation style is never a raw string');
 $navStyle = $nav['attrs']['style'] ?? array();
 $assert(! (is_array($navStyle) && isset($navStyle['display'])), 'navigation must not freeze display:none');
 $frozen = $canonicalStyleResult['source_reports']['html']['frozen_hidden_state'] ?? array();
-$assert(is_array($frozen) && array() !== $frozen, 'frozen hidden state finding is surfaced for the hidden nav');
+$frozenPanel = array_values(array_filter($frozen, static fn (array $finding): bool => '#canonical-frozen-panel' === ($finding['editor_selector'] ?? '') && array('display:none', 'visibility:hidden', 'height:0', 'overflow:hidden') === ($finding['declarations'] ?? array())));
+$assert(1 === count($frozenPanel), 'the canonical revealable panel is surfaced once with its complete recovery finding');
 
 $editorStaticStateResult = (new HtmlTransformer())->transform(
     '<main><section id="process"><p class="reveal feature-copy">Revealed copy</p><p class="animated-copy">Animated copy</p></section></main>',

--- a/php-transformer/tests/unit/inert-closed-state-interactions.php
+++ b/php-transformer/tests/unit/inert-closed-state-interactions.php
@@ -175,11 +175,81 @@ $assert(
     $hiddenAnswerMarkup
 );
 $assert(
-    str_contains($hiddenAnswerAfterAuthor, 'visibility:visible')
-        || str_contains($hiddenAnswerAfterAuthor, 'display:revert')
-        || str_contains($hiddenAnswerAfterAuthor, 'height:auto'),
-    'author closed-state CSS is repaired on the frontend after behavior is stripped',
+    ! str_contains($hiddenAnswerAfterAuthor, '.answer{display:revert!important}')
+        && ! str_contains($hiddenAnswerAfterAuthor, '.answer{visibility:visible!important}')
+        && ! str_contains($hiddenAnswerAfterAuthor, '.answer{height:auto!important}'),
+    'permanently hidden authored content receives no visibility repair without source reveal evidence',
     $hiddenAnswerAfterAuthor
+);
+
+$permanentHidden = ( new HtmlTransformer() )->transform('<p style="display:none">Screen-reader-only source copy.</p><p style="visibility:hidden">Authored hidden copy.</p><p style="height:0;overflow:hidden">Collapsed authored copy.</p>')->toArray();
+$permanentHiddenMarkup = (string) ($permanentHidden['serialized_blocks'] ?? '');
+$permanentHiddenCss = $cssContent($permanentHidden);
+$permanentHiddenAfterAuthor = $cssContent($permanentHidden, 'after-author', 'both');
+$assert(
+    str_contains($permanentHiddenCss, 'display:none')
+        && str_contains($permanentHiddenCss, 'visibility:hidden')
+        && str_contains($permanentHiddenCss, 'height:0px !important')
+        && str_contains($permanentHiddenCss, 'overflow:hidden')
+        && '' === $permanentHiddenAfterAuthor,
+    'permanent inline display, visibility, and zero-geometry hidden states stay authored without repair CSS',
+    $permanentHiddenMarkup . "\n" . $permanentHiddenCss . "\n" . $permanentHiddenAfterAuthor
+);
+
+$authoredState = ( new HtmlTransformer() )->transform('<style>[data-panel-state="closed"]{display:none;visibility:hidden;height:0;overflow:hidden}</style><p data-panel-state="closed">A deliberately closed authored state.</p>')->toArray();
+$authoredStateAfterAuthor = $cssContent($authoredState, 'after-author', 'both');
+$assert(
+    ! str_contains($authoredStateAfterAuthor, 'display:revert!important')
+        && ! str_contains($authoredStateAfterAuthor, 'visibility:visible!important')
+        && ! str_contains($authoredStateAfterAuthor, 'height:auto!important'),
+    'a source-authored state selector receives no repair without a matching reveal mechanism',
+    $authoredStateAfterAuthor
+);
+
+$cssRevealPanel = ( new HtmlTransformer() )->transform('<style>.frozen-panel{display:none;visibility:hidden;height:0;overflow:hidden}.frozen-trigger:hover + .frozen-panel{display:block;visibility:visible;height:auto;overflow:visible}</style><div class="frozen-trigger">Reveal</div><div id="css-panel" class="frozen-panel"><p>A CSS-revealable panel.</p></div>')->toArray();
+$cssRevealPanelAfterAuthor = $cssContent($cssRevealPanel, 'after-author', 'both');
+$assert(
+    str_contains($cssRevealPanelAfterAuthor, '#css-panel{display:revert!important;height:auto!important;overflow:visible!important;visibility:visible!important}'),
+    'a frozen panel with CSS-only reveal evidence receives static recovery repairs',
+    $cssRevealPanelAfterAuthor
+);
+
+$ariaRevealPanel = ( new HtmlTransformer() )->transform('<style>.frozen-panel{display:none;visibility:hidden;height:0;overflow:hidden}</style><button aria-controls="aria-panel" aria-expanded="false">Reveal</button><div id="aria-panel" class="frozen-panel"><p>An ARIA-revealable panel.</p></div>')->toArray();
+$ariaRevealPanelAfterAuthor = $cssContent($ariaRevealPanel, 'after-author', 'both');
+$assert(
+    str_contains($ariaRevealPanelAfterAuthor, '#aria-panel{display:revert!important;height:auto!important;overflow:visible!important;visibility:visible!important}'),
+    'an exact ARIA-controlled target receives static recovery without CSS reveal rules',
+    $ariaRevealPanelAfterAuthor
+);
+
+$ariaDescendantOnly = ( new HtmlTransformer() )->transform('<style>.hidden-ancestor{display:none;visibility:hidden;height:0;overflow:hidden}</style><button aria-controls="controlled-child" aria-expanded="false">Reveal child</button><div id="hidden-ancestor" class="hidden-ancestor"><p id="controlled-child">Controlled child.</p></div>')->toArray();
+$ariaDescendantOnlyAfterAuthor = $cssContent($ariaDescendantOnly, 'after-author', 'both');
+$assert(
+    ! str_contains($ariaDescendantOnlyAfterAuthor, '#hidden-ancestor{display:revert!important}'),
+    'an ARIA-controlled descendant does not authorize repair of a hidden ancestor',
+    $ariaDescendantOnlyAfterAuthor
+);
+
+$nonProvingConditionals = ( new HtmlTransformer() )->transform('<style>.height-only{display:none}.height-trigger:hover + .height-only{height:auto}.collapsed-visibility{visibility:hidden}.visibility-trigger:hover + .collapsed-visibility{visibility:collapse}</style><div class="height-trigger">Hover</div><p id="height-only" class="height-only">Permanently display-hidden copy.</p><div class="visibility-trigger">Hover</div><p id="collapsed-visibility" class="collapsed-visibility">Permanently visibility-hidden copy.</p>')->toArray();
+$nonProvingAfterAuthor = $cssContent($nonProvingConditionals, 'after-author', 'both');
+$assert(
+    ! str_contains($nonProvingAfterAuthor, '#height-only{display:revert!important}')
+        && ! str_contains($nonProvingAfterAuthor, '#collapsed-visibility{visibility:visible!important}'),
+    'height-only and visibility:collapse conditional rules do not prove hidden barriers revealable',
+    $nonProvingAfterAuthor
+);
+
+$ariaHiddenOverflow = ( new HtmlTransformer() )->transform('<style>.aria-hidden-overflow{height:0;overflow:hidden}</style><p id="aria-hidden-overflow" class="aria-hidden-overflow" aria-hidden="true">Retained hidden overflow content.</p>')->toArray();
+$ariaHiddenOverflowMarkup = (string) ($ariaHiddenOverflow['serialized_blocks'] ?? '');
+$ariaHiddenOverflowCss = $cssContent($ariaHiddenOverflow);
+$ariaHiddenOverflowAfterAuthor = $cssContent($ariaHiddenOverflow, 'after-author', 'both');
+$assert(
+    str_contains($ariaHiddenOverflowMarkup, 'Retained hidden overflow content.')
+        && str_contains($ariaHiddenOverflowCss, 'height:0')
+        && str_contains($ariaHiddenOverflowCss, 'overflow:hidden')
+        && '' === $ariaHiddenOverflowAfterAuthor,
+    'source aria-hidden collapsed overflow content remains retained and receives no repair',
+    $ariaHiddenOverflowMarkup . "\n" . $ariaHiddenOverflowCss . "\n" . $ariaHiddenOverflowAfterAuthor
 );
 
 $alternateLayer = <<<'HTML'

--- a/php-transformer/tools/visual-parity/package.json
+++ b/php-transformer/tools/visual-parity/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "install:browsers": "playwright install chromium",
-    "test": "node tests/smoke.mjs && node tests/blockquote-margin-reset.mjs && node tests/exact-fit-inline-flow.mjs && node tests/layout-shell-editor-geometry.mjs && node tests/custom-video-host-editor-geometry.mjs"
+    "test": "node tests/smoke.mjs && node tests/blockquote-margin-reset.mjs && node tests/exact-fit-inline-flow.mjs && node tests/layout-shell-editor-geometry.mjs && node tests/custom-video-host-editor-geometry.mjs && node tests/issue-1493-reduced-public-fixture.mjs"
   },
   "devDependencies": {
     "playwright": "^1.56.0"

--- a/php-transformer/tools/visual-parity/tests/issue-1493-reduced-public-fixture.mjs
+++ b/php-transformer/tools/visual-parity/tests/issue-1493-reduced-public-fixture.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { chromium } from 'playwright';
@@ -78,7 +79,7 @@ try {
         assert.equal(revealed.visibility, 'visible');
         assert.ok(revealed.height > 0, `${selector} is statically revealed by emitted repair CSS`);
     }
-    await page.screenshot({ path: '/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/issue-1493-reduced-public-fixture-1280x900.png', fullPage: true });
+    await page.screenshot({ path: path.join(tmpdir(), 'blocks-engine-issue-1493-reduced-public-fixture-1280x900.png'), fullPage: true });
 } finally {
     await browser.close();
 }

--- a/php-transformer/tools/visual-parity/tests/issue-1493-reduced-public-fixture.mjs
+++ b/php-transformer/tools/visual-parity/tests/issue-1493-reduced-public-fixture.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+// Reduced public fixture for #1493, not the unavailable /runs/run3-source full import.
+const transformerRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const sourceFixture = `
+  <style>
+    .screen-reader-hint { display: none; }
+    .overflow-menu { height: 0; overflow: hidden; }
+    .aria-hidden-overflow { height: 0; overflow: hidden; }
+    .css-panel { display: none; visibility: hidden; height: 0; overflow: hidden; }
+    .css-trigger:hover + .css-panel, .css-trigger:focus + .css-panel { display: block; visibility: visible; height: auto; overflow: visible; }
+    .aria-panel { display: none; visibility: hidden; height: 0; overflow: hidden; }
+    .height-only { display: none; }
+    .height-trigger:hover + .height-only { height: auto; }
+    .collapsed-visibility { visibility: hidden; }
+    .visibility-trigger:hover + .collapsed-visibility { visibility: collapse; }
+  </style>
+  <main>
+    <p class="screen-reader-hint">Permanent accessibility hint</p>
+    <p id="permanent-overflow" class="overflow-menu">Permanent overflow item</p>
+    <p id="aria-hidden-overflow" class="aria-hidden-overflow" aria-hidden="true">Retained hidden overflow content</p>
+    <div class="css-trigger">CSS reveal</div>
+    <section id="css-panel" class="css-panel"><p>CSS-revealed panel content</p></section>
+    <button aria-controls="aria-panel" aria-expanded="false">ARIA reveal</button>
+    <section id="aria-panel" class="aria-panel"><p>ARIA-revealed panel content</p></section>
+    <div class="height-trigger">Height only</div>
+    <p id="height-only" class="height-only">Permanent display-hidden content</p>
+    <div class="visibility-trigger">Visibility collapse</div>
+    <p id="collapsed-visibility" class="collapsed-visibility">Permanent visibility-hidden content</p>
+  </main>`;
+const transformed = JSON.parse(execFileSync('php', ['-r', `
+require $argv[1] . '/vendor/autoload.php';
+$fixture = <<<'HTML'
+${sourceFixture}
+HTML;
+$result = (new \\Automattic\\BlocksEngine\\PhpTransformer\\HtmlToBlocks\\HtmlTransformer())->transform($fixture)->toArray();
+$css = array_filter($result['assets'] ?? array(), static fn(array $asset): bool => 'css' === ($asset['kind'] ?? ''));
+echo json_encode(array(
+    'serializedBlocks' => (string) ($result['serialized_blocks'] ?? ''),
+    'css' => implode("\\n", array_column($css, 'content')),
+    'afterAuthorCss' => implode("\\n", array_column(array_filter($css, static fn(array $asset): bool => 'after-author' === ($asset['stylesheet_placement'] ?? '')), 'content')),
+));
+`, transformerRoot], { encoding: 'utf8' }));
+
+assert.match(transformed.afterAuthorCss, /#css-panel\{display:revert!important;height:auto!important;overflow:visible!important;visibility:visible!important\}/);
+assert.match(transformed.afterAuthorCss, /#aria-panel\{display:revert!important;height:auto!important;overflow:visible!important;visibility:visible!important\}/);
+assert.doesNotMatch(transformed.afterAuthorCss, /screen-reader-hint[^{}]*\{[^}]*display:revert/);
+assert.doesNotMatch(transformed.afterAuthorCss, /overflow-menu[^{}]*\{[^}]*height:auto/);
+assert.doesNotMatch(transformed.afterAuthorCss, /#height-only\{[^}]*display:revert/);
+assert.doesNotMatch(transformed.afterAuthorCss, /#collapsed-visibility\{[^}]*visibility:visible/);
+assert.doesNotMatch(transformed.afterAuthorCss, /#aria-hidden-overflow\{[^}]*height:auto/);
+
+const browser = await chromium.launch({ headless: true });
+try {
+    const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+    await page.setContent(`<!doctype html><style>body{margin:0;font:16px/1.4 sans-serif}${transformed.css}</style>${transformed.serializedBlocks}`);
+    const geometry = async (selector) => page.locator(selector).evaluate((element) => {
+        const rect = element.getBoundingClientRect();
+        const style = getComputedStyle(element);
+        return { display: style.display, visibility: style.visibility, height: rect.height };
+    });
+    assert.deepEqual(await geometry('.screen-reader-hint'), { display: 'none', visibility: 'visible', height: 0 });
+    assert.deepEqual(await geometry('#permanent-overflow'), { display: 'block', visibility: 'visible', height: 0 });
+    assert.deepEqual(await geometry('#aria-hidden-overflow'), { display: 'block', visibility: 'visible', height: 0 });
+    assert.deepEqual(await geometry('#height-only'), { display: 'none', visibility: 'visible', height: 0 });
+    const permanentlyInvisible = await geometry('#collapsed-visibility');
+    assert.equal(permanentlyInvisible.display, 'block');
+    assert.equal(permanentlyInvisible.visibility, 'hidden');
+    assert.ok(permanentlyInvisible.height > 0, 'visibility:hidden remains non-painted even when it retains layout geometry');
+
+    for (const selector of ['#css-panel', '#aria-panel']) {
+        const revealed = await geometry(selector);
+        assert.equal(revealed.display, 'block');
+        assert.equal(revealed.visibility, 'visible');
+        assert.ok(revealed.height > 0, `${selector} is statically revealed by emitted repair CSS`);
+    }
+    await page.screenshot({ path: '/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/issue-1493-reduced-public-fixture-1280x900.png', fullPage: true });
+} finally {
+    await browser.close();
+}
+
+console.log('Issue #1493 reduced public fixture geometry passed');


### PR DESCRIPTION
## Summary

Fixes #1493 by treating closed-state neutralization as an evidence-based recovery:

- Retain source `display:none`, `visibility:hidden`, and collapsed `height`/`max-height` plus hidden overflow unless the source proves the element can open.
- Recover genuinely frozen panels only for an exact `aria-controls` target or a matching hover/focus selector that reverses the same hidden property.
- Preserve the existing opacity policy, which is outside this issue's display/visibility/collapsed-geometry scope.

## Evidence

Public, reproducible checks from this branch:

```sh
composer --working-dir=php-transformer test:canonical
(cd php-transformer/tools/visual-parity && node tests/issue-1493-reduced-public-fixture.mjs)
```

Both pass. The canonical suite includes 27 closed-state interaction assertions. The Playwright fixture renders at 1280x900 and verifies that permanently hidden content remains non-painted while CSS- and ARIA-revealable panels become statically reachable.

The original full capture at `/runs/run3-source` is unavailable, so this PR intentionally does not claim full-import visual acceptance. Acceptance of the original report requires recapturing that source, importing it through the normal workflow, and confirming that the original hidden menu items and accessibility hint remain hidden without regressing real revealable panels.

## AI Assistance

Implementation and test work used OpenAI GPT-5.6 Terra via OpenCode. GPT-6 Astra orchestrated and reviewed the candidate. A human directed the work and is responsible for the change.