### PR TITLE
fix(php-transformer): carry menu chrome presentation core cannot save

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -128,6 +128,7 @@
       "php tests/unit/navigation-direct-cluster-parity.php",
       "php tests/unit/navigation-non-anchor-brand-carrier.php",
       "php tests/unit/navigation-block-normalizer.php",
+      "php tests/unit/menu-chrome-presentation-carry.php",
       "php tests/unit/navigation-inline-margin-carry.php",
       "php tests/unit/navigation-source-provenance.php",
       "php tests/unit/navigation-dropped-anchors.php",

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -2556,7 +2556,8 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
                 function (DOMElement $sourceElement, array $authorClasses): void {
                     $this->recordInheritedNavigationPresentation($sourceElement, $authorClasses);
                     $this->recordNavigationContainerPaintReset($sourceElement, $authorClasses);
-                }
+                },
+                fn (DOMElement $sourceElement): array => $this->authorSemanticMarkersForElement($sourceElement)
             ),
             new MediaPatternContext(
                 fn (DOMElement $sourceElement): string => $this->styleResolver->mergedPresentationStyle($sourceElement),

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -2602,7 +2602,8 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             ),
             fn (DOMElement $sourceElement): bool => $sourceElement->hasAttribute('hidden')
                 || 'true' === strtolower(trim($this->attr($sourceElement, 'aria-hidden')))
-                || $this->sourceElementStartsHidden($sourceElement)
+                || $this->sourceElementStartsHidden($sourceElement),
+            fn (DOMElement $summary): string => $this->disclosureSummaryMarker($summary)
         );
     }
 
@@ -2686,7 +2687,8 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             ),
             sourceElementStartsHidden: fn (DOMElement $sourceElement): bool => $sourceElement->hasAttribute('hidden')
                 || 'true' === strtolower(trim($this->attr($sourceElement, 'aria-hidden')))
-                || $this->sourceElementStartsHidden($sourceElement)
+                || $this->sourceElementStartsHidden($sourceElement),
+            disclosureSummaryMarker: fn (DOMElement $summary): string => $this->disclosureSummaryMarker($summary)
         );
     }
 
@@ -2793,6 +2795,99 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
         $this->generatedSupportStyles()->registerNavigationLinkIcon($marker, $declarations);
 
         return $marker;
+    }
+
+    /**
+     * Marker for a disclosure toggle whose box core/details cannot save.
+     *
+     * core/details renders `<summary>` with no attributes, so a source toggle's
+     * own classes are dropped and every author rule addressing them is left with
+     * nothing to match — an overlay menu button loses its paint, its radius and
+     * its label typography, and drops to the destination theme's defaults.
+     *
+     * Delivered as CSS keyed on a marker the details block carries, not as
+     * markup: adding attributes to `<summary>` would diverge from core's save
+     * shape and invalidate the block.
+     */
+    private function disclosureSummaryMarker(DOMElement $summary): string
+    {
+        $declarations = $this->styleResolver->safeVisualDeclarations(
+            $this->styleResolver->cssDeclarations(
+                $this->styleResolver->resolveCssVariablesInValue(
+                    $this->styleResolver->specificityResolvedPresentationStyle($summary)
+                )
+            )
+        );
+        // Geometry belongs to the box core already lays out. Carry the paint and
+        // type the source put on the toggle, which is what core replaces.
+        $carried = array_filter(
+            $declarations,
+            static fn (string $property): bool => (bool) preg_match(
+                '/^(?:background|border|border-radius|box-shadow|color|font|letter-spacing|line-height|padding|text-transform|text-decoration)(?:-[a-z-]+)?$/',
+                $property
+            ),
+            ARRAY_FILTER_USE_KEY
+        );
+        if ( array() === $carried ) {
+            return '';
+        }
+
+        // The label the source painted keeps its classes but loses the toggle
+        // ancestor those rules were written against. Its type is inheritable, so
+        // restating it on the summary reaches the label again, and any rule the
+        // label still owns keeps winning over it.
+        $carried = array_merge($this->disclosureSummaryLabelTypography($summary), $carried);
+
+        $css = $this->styleResolver->cssDeclarationString($carried);
+        if ( '' === $css ) {
+            return '';
+        }
+
+        $marker = 'blocks-engine-disclosure-summary-' . substr(hash('sha256', $css), 0, 12);
+        $this->generatedSupportStyles()->registerDisclosureSummaryPresentation($marker, $css);
+
+        return $marker;
+    }
+
+    /**
+     * Inheritable type the disclosure label showed, read from the source.
+     *
+     * @return array<string, string>
+     */
+    private function disclosureSummaryLabelTypography(DOMElement $summary): array
+    {
+        $label = null;
+        foreach ( $summary->getElementsByTagName('*') as $descendant ) {
+            if ( ! $descendant instanceof DOMElement ) {
+                continue;
+            }
+            foreach ( $descendant->childNodes as $child ) {
+                if ( XML_TEXT_NODE === $child->nodeType && '' !== trim($child->textContent ?? '') ) {
+                    $label = $descendant;
+                    break 2;
+                }
+            }
+        }
+        if ( ! $label instanceof DOMElement ) {
+            return array();
+        }
+
+        $declarations = $this->styleResolver->safeVisualDeclarations(
+            $this->styleResolver->cssDeclarations(
+                $this->styleResolver->resolveCssVariablesInValue(
+                    $this->styleResolver->specificityResolvedPresentationStyle($label)
+                )
+            )
+        );
+
+        return array_filter(
+            $declarations,
+            static fn (string $property): bool => (bool) preg_match(
+                '/^(?:color|font|font-family|font-size|font-style|font-weight|letter-spacing|line-height|text-transform|text-decoration)$/',
+                $property
+            ),
+            ARRAY_FILTER_USE_KEY
+        );
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -2818,12 +2818,13 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
                 )
             )
         );
-        // Geometry belongs to the box core already lays out. Carry the paint and
-        // type the source put on the toggle, which is what core replaces.
+        // core renders `<summary>` with no box of its own, so the toggle's own
+        // box is carried here alongside its paint and type. Position and margin
+        // stay out: the details block core lays out already holds the slot.
         $carried = array_filter(
             $declarations,
             static fn (string $property): bool => (bool) preg_match(
-                '/^(?:background|border|border-radius|box-shadow|color|font|letter-spacing|line-height|padding|text-transform|text-decoration)(?:-[a-z-]+)?$/',
+                '/^(?:align-items|background|border|border-radius|box-shadow|box-sizing|color|display|font|height|justify-content|letter-spacing|line-height|max-height|max-width|min-height|min-width|padding|text-align|text-decoration|text-transform|width)(?:-[a-z-]+)?$/',
                 $property
             ),
             ARRAY_FILTER_USE_KEY

--- a/php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php
@@ -27,7 +27,8 @@ final class DetailsPattern implements PatternRecognizerInterface
                 },
                 $context->presentationAttributes(...),
                 SourceDom::innerHtml(...),
-                $context->createBlock(...)
+                $context->createBlock(...),
+                $this->summaryMarker($element, $context)
             );
         } else {
             $block = $this->matchDisclosure(
@@ -45,6 +46,20 @@ final class DetailsPattern implements PatternRecognizerInterface
     }
 
     /**
+     * The source toggle's own box, resolved once so core/details can carry it.
+     *
+     * core's `<summary>` is emitted with no attributes, so the source element's
+     * classes cannot ride along and the author rules that address them would
+     * match nothing.
+     */
+    private function summaryMarker(DOMElement $element, PatternContext $context): string
+    {
+        $summary = $this->firstChildElement($element, 'summary');
+
+        return $summary instanceof DOMElement ? $context->disclosureSummaryMarker($summary) : '';
+    }
+
+    /**
      * @param array<int, array<string, mixed>> $fallbacks
      * @param callable(DOMElement, array<int, array<string, mixed>>&, array<int, string>): array<int, array<string, mixed>> $convertChildrenWithoutTags
      * @param callable(DOMElement): array<string, mixed> $presentationAttributes
@@ -52,7 +67,7 @@ final class DetailsPattern implements PatternRecognizerInterface
      * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
      * @return array<string, mixed>|null
      */
-    public function match(DOMElement $element, array &$fallbacks, callable $convertChildrenWithoutTags, callable $presentationAttributes, callable $innerHtml, callable $createBlock): ?array
+    public function match(DOMElement $element, array &$fallbacks, callable $convertChildrenWithoutTags, callable $presentationAttributes, callable $innerHtml, callable $createBlock, string $summaryMarker = ''): ?array
     {
         $summary = $this->firstChildElement($element, 'summary');
         $children = $convertChildrenWithoutTags($element, $fallbacks, array( 'summary' ));
@@ -60,10 +75,15 @@ final class DetailsPattern implements PatternRecognizerInterface
             return null;
         }
 
-        return $createBlock('core/details', array_filter(array_merge($presentationAttributes($element), array(
+        $attrs = array_merge($presentationAttributes($element), array(
             'summary'     => $summary instanceof DOMElement ? $innerHtml($summary) : '',
             'showContent' => $element->hasAttribute('open') ? true : '',
-        )), static fn ($value): bool => '' !== $value), $children, $element);
+        ));
+        if ( '' !== $summaryMarker ) {
+            $attrs['className'] = SourceDom::mergeClassNames((string) ($attrs['className'] ?? ''), $summaryMarker);
+        }
+
+        return $createBlock('core/details', array_filter($attrs, static fn ($value): bool => '' !== $value), $children, $element);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -214,7 +214,10 @@ final class NavigationPattern implements PatternRecognizerInterface
         $links = array();
         foreach ( $anchors as $anchor ) {
             $links[] = $context->createBlock('core/navigation-link', array_filter(array(
-                'label' => SourceDom::innerHtml($anchor),
+                'label' => SourceDom::innerHtmlWithProjectedMarkers(
+                    $anchor,
+                    static fn (DOMElement $labelElement): array => $context->navigationContext()?->labelPresentationMarkers($labelElement) ?? array()
+                ),
                 'url' => SourceDom::safeNavigationUrl(SourceDom::attr($anchor, 'href')),
                 'kind' => 'custom',
             ), static fn ($value): bool => '' !== $value), array(), $anchor);
@@ -1127,7 +1130,7 @@ final class NavigationPattern implements PatternRecognizerInterface
     private function navigationBlockFromItem(DOMElement $element, callable $presentationAttributes, callable $innerHtml, callable $createBlock, ?NavigationPatternContext $navigationContext = null): ?array
     {
         $anchor = $this->primaryNavigationAnchor($element);
-        if ( ! $anchor instanceof DOMElement || '' === $this->anchorLabel($anchor, $innerHtml) ) {
+        if ( ! $anchor instanceof DOMElement || '' === $this->anchorLabel($anchor, $innerHtml, $navigationContext) ) {
             return null;
         }
 
@@ -1144,7 +1147,7 @@ final class NavigationPattern implements PatternRecognizerInterface
             }
 
             $submenuAttrs = array(
-                'label' => $this->anchorLabel($anchor, $innerHtml),
+                'label' => $this->anchorLabel($anchor, $innerHtml, $navigationContext),
                 'url'   => SourceDom::safeNavigationUrl($anchor->hasAttribute('href') ? $anchor->getAttribute('href') : ''),
                 'kind'  => 'custom',
             );
@@ -1162,7 +1165,7 @@ final class NavigationPattern implements PatternRecognizerInterface
     private function navigationLinkBlock(DOMElement $anchor, callable $presentationAttributes, callable $innerHtml, callable $createBlock, ?DOMElement $item = null, ?NavigationPatternContext $navigationContext = null): array
     {
         $linkAttrs = $this->navigationItemAttributes($item ?? $anchor, $anchor, null, array(
-            'label' => $this->anchorLabel($anchor, $innerHtml),
+            'label' => $this->anchorLabel($anchor, $innerHtml, $navigationContext),
             'url'   => SourceDom::safeNavigationUrl($anchor->hasAttribute('href') ? $anchor->getAttribute('href') : ''),
             'kind'  => 'custom',
         ), $presentationAttributes, $navigationContext);
@@ -1175,9 +1178,9 @@ final class NavigationPattern implements PatternRecognizerInterface
         return $createBlock('core/navigation-link', $linkAttrs, array(), $anchor);
     }
 
-    private function anchorLabel(DOMElement $anchor, callable $innerHtml): string
+    private function anchorLabel(DOMElement $anchor, callable $innerHtml, ?NavigationPatternContext $navigationContext = null): string
     {
-        $label = $this->navigationLabel($innerHtml($anchor));
+        $label = $this->navigationLabel($this->labelHtml($anchor, $innerHtml, $navigationContext));
         if ( '' !== $label ) {
             return $label;
         }
@@ -1201,6 +1204,30 @@ final class NavigationPattern implements PatternRecognizerInterface
         }
 
         return '';
+    }
+
+    /**
+     * Serialize an anchor's inner markup for the `label` attribute.
+     *
+     * A label lives inside a block attribute, never in the block tree, so the
+     * marker classes the projected author stylesheet targets are otherwise never
+     * stamped on it and the rewritten rules match nothing. Carry them here so the
+     * source's own menu typography and color survive to the front end.
+     */
+    private function labelHtml(DOMElement $anchor, callable $innerHtml, ?NavigationPatternContext $navigationContext): string
+    {
+        if ( ! $navigationContext instanceof NavigationPatternContext ) {
+            return $innerHtml($anchor);
+        }
+
+        $markered = SourceDom::innerHtmlWithProjectedMarkers(
+            $anchor,
+            static fn (DOMElement $element): array => $navigationContext->labelPresentationMarkers($element)
+        );
+
+        // The transformer's own serializer performs rich-text lowering the plain
+        // clone cannot. Prefer it whenever no marker had to be carried.
+        return $markered === SourceDom::innerHtml($anchor) ? $innerHtml($anchor) : $markered;
     }
 
     private function navigationLabel(string $html): string

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPatternContext.php
@@ -17,6 +17,7 @@ final class NavigationPatternContext
     private readonly ?Closure $responsiveToggleMarker;
     private readonly ?Closure $linkIconMarker;
     private readonly ?Closure $inheritedPresentation;
+    private readonly ?Closure $labelPresentationMarkers;
 
     /**
      * @param callable(DOMElement): bool|null $runtimeDomTarget
@@ -27,6 +28,7 @@ final class NavigationPatternContext
      * @param callable(DOMElement): string|null $responsiveToggleMarker
      * @param callable(DOMElement): string|null $linkIconMarker
      * @param callable(DOMElement, array<int, string>): void|null $inheritedPresentation
+     * @param callable(DOMElement): list<string>|null $labelPresentationMarkers
      */
     public function __construct(
         ?callable $runtimeDomTarget,
@@ -36,16 +38,29 @@ final class NavigationPatternContext
         ?callable $overlayMenu = null,
         ?callable $responsiveToggleMarker = null,
         ?callable $linkIconMarker = null,
-        ?callable $inheritedPresentation = null
+        ?callable $inheritedPresentation = null,
+        ?callable $labelPresentationMarkers = null
     ) {
         $this->linkIconMarker         = null === $linkIconMarker ? null : Closure::fromCallable($linkIconMarker);
         $this->inheritedPresentation  = null === $inheritedPresentation ? null : Closure::fromCallable($inheritedPresentation);
+        $this->labelPresentationMarkers = null === $labelPresentationMarkers ? null : Closure::fromCallable($labelPresentationMarkers);
         $this->runtimeDomTarget       = null === $runtimeDomTarget ? null : Closure::fromCallable($runtimeDomTarget);
         $this->underlineColor         = Closure::fromCallable($underlineColor);
         $this->resolvedStyle          = Closure::fromCallable($resolvedStyle);
         $this->colorInteractionStates = null === $colorInteractionStates ? null : Closure::fromCallable($colorInteractionStates);
         $this->overlayMenu            = null === $overlayMenu ? null : Closure::fromCallable($overlayMenu);
         $this->responsiveToggleMarker = null === $responsiveToggleMarker ? null : Closure::fromCallable($responsiveToggleMarker);
+    }
+
+    /**
+     * Author-selector markers the projected stylesheet targets for an element
+     * that will be inlined into a navigation item's `label` attribute.
+     *
+     * @return list<string>
+     */
+    public function labelPresentationMarkers(DOMElement $element): array
+    {
+        return null === $this->labelPresentationMarkers ? array() : ($this->labelPresentationMarkers)($element);
     }
 
     public function isRuntimeDomTarget(DOMElement $element): bool

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
@@ -22,6 +22,7 @@ final class PatternContext
      * @param LogoPatternContext|null $logoContext
      * @param GalleryPatternContext|null $galleryContext
      * @param Closure(DOMElement): bool|null $sourceElementStartsHidden
+     * @param Closure(DOMElement): string|null $disclosureSummaryMarker
      */
     public function __construct(
         private readonly Closure $presentationAttributes,
@@ -36,8 +37,22 @@ final class PatternContext
         private readonly ?CodeWindowPatternContext $codeWindowContext = null,
         private readonly ?LogoPatternContext $logoContext = null,
         private readonly ?GalleryPatternContext $galleryContext = null,
-        private readonly ?Closure $sourceElementStartsHidden = null
+        private readonly ?Closure $sourceElementStartsHidden = null,
+        private readonly ?Closure $disclosureSummaryMarker = null
     ) {
+    }
+
+    /**
+     * Marker for a disclosure toggle whose presentation core cannot save.
+     *
+     * core/details renders its own bare `<summary>`, so a source toggle's box —
+     * its paint, radius, and typography — has nowhere to live on the block. The
+     * owning transformer registers the resolved presentation and returns an
+     * opaque marker class for the details block to carry.
+     */
+    public function disclosureSummaryMarker(DOMElement $summary): string
+    {
+        return null === $this->disclosureSummaryMarker ? '' : ($this->disclosureSummaryMarker)($summary);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Style/GeneratedSupportStylesheetState.php
+++ b/php-transformer/src/HtmlToBlocks/Style/GeneratedSupportStylesheetState.php
@@ -16,6 +16,9 @@ final class GeneratedSupportStylesheetState
     private array $nativeNavigationToggleRules = array();
 
     /** @var array<string, string> */
+    private array $disclosureSummaryPresentation = array();
+
+    /** @var array<string, string> */
     private array $syntheticHeaderAnchorRules = array();
 
     /** @var array<string, string> */
@@ -111,6 +114,11 @@ final class GeneratedSupportStylesheetState
         return array_values($this->navigationInheritedPresentation);
     }
 
+    public function registerDisclosureSummaryPresentation(string $className, string $declarations): void
+    {
+        $this->disclosureSummaryPresentation[$className] = $declarations;
+    }
+
     public function registerNavigationLinkIcon(string $className, string $declarations): void
     {
         $this->navigationLinkIcons[$className] = $declarations;
@@ -158,6 +166,13 @@ final class GeneratedSupportStylesheetState
         foreach ($this->navigationSubmenuBackgrounds as $className => $color) {
             if (str_contains($serializedBlocks, $className)) {
                 $parts[] = '.wp-block-navigation-item.' . $className . '>.wp-block-navigation__submenu-container{background-color:' . $color . '}';
+            }
+        }
+        foreach ($this->disclosureSummaryPresentation as $className => $declarations) {
+            if (str_contains($serializedBlocks, $className)) {
+                // core/details owns the summary element, so the source toggle's box is
+                // restated on it from here rather than carried as markup.
+                $parts[] = '.wp-block-details.' . $className . '>summary{' . $declarations . '}';
             }
         }
         foreach ($this->navigationSpacing as $className => $declarations) {

--- a/php-transformer/src/HtmlToBlocks/Support/SourceDom.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SourceDom.php
@@ -42,6 +42,56 @@ final class SourceDom
         return trim($html);
     }
 
+    /**
+     * Serialize inner markup destined for a block attribute, carrying the author
+     * selector markers the projected stylesheet already targets.
+     *
+     * Markup inlined into an attribute (a navigation label, a logo lockup) never
+     * reaches the block tree, so {@see SourceBlockAttributeProjector} never merges
+     * its projected marker classes into a `className`. The author rules for those
+     * elements have already been rewritten onto those markers, so without this the
+     * rewritten rule matches nothing and the element renders unstyled.
+     *
+     * Markers are stamped on the serialization clone, never on the source DOM, so
+     * later selector matching still sees the authored classes.
+     *
+     * @param callable(DOMElement): list<string> $markersFor
+     */
+    public static function innerHtmlWithProjectedMarkers(DOMElement $element, callable $markersFor): string
+    {
+        $sourceDescendants = array();
+        foreach ( $element->getElementsByTagName('*') as $descendant ) {
+            if ( $descendant instanceof DOMElement ) {
+                $sourceDescendants[] = $descendant;
+            }
+        }
+
+        $clone = self::canonicalizedSerializationClone($element);
+        $index = 0;
+        foreach ( $clone->getElementsByTagName('*') as $cloned ) {
+            if ( ! $cloned instanceof DOMElement ) {
+                continue;
+            }
+            $source = $sourceDescendants[$index] ?? null;
+            ++$index;
+            if ( ! $source instanceof DOMElement ) {
+                continue;
+            }
+            $markers = array_values(array_filter($markersFor($source), static fn (string $marker): bool => '' !== $marker));
+            if ( array() === $markers ) {
+                continue;
+            }
+            $cloned->setAttribute('class', self::mergeClassNames($cloned->getAttribute('class'), ...$markers));
+        }
+
+        $html = '';
+        foreach ( $clone->childNodes as $child ) {
+            $html .= $clone->ownerDocument->saveHTML($child);
+        }
+
+        return trim($html);
+    }
+
     public static function innerHtmlPreservingWhitespace(DOMElement $element): string
     {
         $element = self::canonicalizedSerializationClone($element);

--- a/php-transformer/tests/unit/menu-chrome-presentation-carry.php
+++ b/php-transformer/tests/unit/menu-chrome-presentation-carry.php
@@ -1,0 +1,149 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Contract for the menu chrome core's own markup cannot carry.
+ *
+ * Two menu surfaces are rebuilt by core rather than emitted from the source, so
+ * the source element that carried the author classes stops existing:
+ *
+ * - `core/navigation-link` stores its label as an attribute, so the label markup
+ *   never reaches the block tree and the projected marker classes the rewritten
+ *   author rules target are never stamped on it.
+ * - `core/details` renders `<summary>` with no attributes at all, so a disclosure
+ *   toggle's own classes are dropped outright.
+ *
+ * In both cases the author rule survives into the stylesheet addressing something
+ * that no longer exists, so the menu silently drops to the destination theme's
+ * defaults on the front end while still looking correct in the editor, which
+ * reads the separate editor-static-state projection.
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$failures = 0;
+$passes = 0;
+
+$assert = static function (bool $condition, string $message, string $detail = ''): void {
+    global $failures, $passes;
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ('' !== $detail ? ' - ' . $detail : '') . PHP_EOL);
+};
+
+$transform = static function (string $html): array {
+    $result = ( new HtmlTransformer() )->transform($html, array())->toArray();
+    $frontend = '';
+    foreach ( (is_array($result['assets'] ?? null) ? $result['assets'] : array()) as $asset ) {
+        if ( ! is_array($asset) || 'editor' === (string) ($asset['stylesheet_target'] ?? '') ) {
+            continue;
+        }
+        if ( 'editor-static-state' === (string) ($asset['source'] ?? '') ) {
+            continue;
+        }
+        $frontend .= (string) ($asset['content'] ?? '');
+    }
+
+    return array( 'blocks' => (string) ($result['serialized_blocks'] ?? ''), 'frontend' => $frontend );
+};
+
+// -- A menu item label keeps the marker its rewritten author rule addresses.
+$menu = $transform(
+    '<style>#comp-nav .menuRoot .Menu__item .Item__label'
+    . '{color:#FF99FE;font-family:montserrat,sans-serif;font-size:14px}</style>'
+    . '<div id="comp-nav"><nav class="menuRoot Menu__menu"><ul>'
+    . '<li class="Item__wrap"><a href="/about/" class="Item__root Menu__item">'
+    . '<div class="Item__container"><span class="Item__label">About</span></div></a></li>'
+    . '<li class="Item__wrap"><a href="/work/" class="Item__root Menu__item">'
+    . '<div class="Item__container"><span class="Item__label">Work</span></div></a></li>'
+    . '</ul></nav></div><p>Body copy.</p>'
+);
+
+preg_match_all('/blocks-engine-semantic-[0-9a-f]+-\d+/', $menu['frontend'], $ruleMarkers);
+$ruleMarkers = array_values(array_unique($ruleMarkers[0]));
+// The label rides inside the block's JSON attributes, so its quotes are escaped.
+$labelled = array_values(array_filter(
+    $ruleMarkers,
+    static fn (string $marker): bool => (bool) preg_match(
+        '/Item__label\b[^<>]{0,80}?\b' . preg_quote($marker, '/') . '\b/',
+        $menu['blocks']
+    )
+));
+
+$assert(
+    array() !== $labelled,
+    'a navigation label carries a marker the frontend stylesheet addresses',
+    substr($menu['blocks'], 0, 300)
+);
+$assert(
+    str_contains($menu['frontend'], '#FF99FE'),
+    'the label presentation reaches a frontend stylesheet, not only the editor'
+);
+
+// -- A disclosure toggle's own box is restated where core renders it.
+$disclosure = $transform(
+    '<style>#comp-tog .style-btn__root'
+    . '{border-radius:50px;background:#1A1A1A;width:107px;height:40px}'
+    . '#comp-tog .style-btn__root .Btn__label{color:#EFFE8B;font-size:18px}</style>'
+    . '<div id="comp-tog"><nav class="Ham__nav"><details class="dla-disclosure">'
+    . '<summary class="style-btn__root"><span class="Btn__label">Menu</span></summary>'
+    . '<div class="dla-dialog" role="dialog"><ul><li><a href="/a/">A</a></li>'
+    . '<li><a href="/b/">B</a></li></ul></div>'
+    . '</details></nav></div><p>Body copy.</p>'
+);
+
+preg_match('/\.wp-block-details\.(blocks-engine-disclosure-summary-[0-9a-f]+)>summary\{([^}]*)\}/', $disclosure['frontend'], $rule);
+
+$assert(
+    array() !== $rule,
+    'a disclosure toggle emits a summary presentation rule',
+    substr($disclosure['frontend'], -300)
+);
+if ( array() !== $rule ) {
+    $assert(
+        str_contains($disclosure['blocks'], $rule[1]),
+        'the details block carries the marker the rule addresses'
+    );
+    $assert(
+        str_contains($rule[2], 'background:#1A1A1A') && str_contains($rule[2], 'border-radius:50px'),
+        'the toggle paint is restated',
+        $rule[2]
+    );
+    $assert(
+        str_contains($rule[2], 'color:#EFFE8B') && str_contains($rule[2], 'font-size:18px'),
+        'the label type rides along, since it lost the same ancestor',
+        $rule[2]
+    );
+    $assert(
+        str_contains($rule[2], 'width:107px') && str_contains($rule[2], 'height:40px'),
+        'the toggle box is restated, since core gives summary none',
+        $rule[2]
+    );
+}
+$assert(
+    ! preg_match('/<summary[^>]+>/', $disclosure['blocks']),
+    'the emitted summary stays attribute-free, matching core\'s save shape'
+);
+
+// -- A disclosure with no authored toggle presentation emits no rule.
+$plain = $transform(
+    '<details><summary>More</summary><p>Detail.</p></details><p>Body copy.</p>'
+);
+$assert(
+    ! str_contains($plain['frontend'], 'blocks-engine-disclosure-summary-'),
+    'an unstyled disclosure emits no summary rule',
+    substr($plain['frontend'], -200)
+);
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, "Menu chrome presentation carry contract: {$failures} failed, {$passes} passed\n");
+    exit(1);
+}
+
+echo "Menu chrome presentation carry contract passed: {$passes} assertions\n";


### PR DESCRIPTION
Fixes #1605.

## Problem

Two menu surfaces are rebuilt by core rather than emitted from the source, so the source element that carried the author classes stops existing and the author rule is left addressing nothing. Both look correct in the **editor**, which reads the separate `editor-static-state` projection, and drop to the destination theme's defaults on the **front end** — which is why this survived four import runs unnoticed.

**1. `core/navigation-link` stores its label as a block attribute.** The label markup never reaches the block tree, so `SourceBlockAttributeProjector` never merges the projected marker classes into a `className`. `AuthorStylesheetProjector` has already rewritten the label's author rule onto those markers, so the rewritten rule matches nothing:

```
frontend  :where(.blocks-engine-semantic-<hash>-3):not(…){color:#FF99FE;font-family:montserrat;font-size:14px}
emitted   <!-- wp:navigation-link {"label":"<span class=\"Item__label\">About</span>", …} /-->
```

**2. `core/details` renders `<summary>` with no attributes.** `BlockFactory` emits a hardcoded `<summary>` and `DetailsPattern` carries only the summary's *inner* HTML, so a disclosure toggle's own classes are dropped outright. On a hamburger site that toggle is the entire visible navigation affordance.

## Approach

**Labels** — `SourceDom::innerHtmlWithProjectedMarkers()` stamps the projected markers while serializing markup destined for a block attribute. Markers are stamped on the serialization clone, never on the source DOM, so later selector matching still sees the authored classes. It falls back to the transformer's own serializer whenever no marker had to be carried, so rich-text lowering is unaffected.

**Toggles** — resolve the toggle's box once, register it under a marker the details block carries, and restate it from `engine-support` CSS as `.wp-block-details.<marker>>summary{…}`, following the existing `navigation-link-icon` projection.

Delivered as CSS rather than markup by necessity: `core/details` declares `summary` as `{"type":"rich-text","source":"rich-text","selector":"summary"}` and saves a bare `<summary>`, so attributes there would diverge from core's save shape and invalidate the block. The emitted `<summary>` stays attribute-free, and the test asserts that.

The label's type rides along on the same rule because it is inheritable and its own rules lost the same ancestor. Position and margin stay out — the details block core lays out already holds the slot.

## Verification — two live sources

Imported through WordPress Studio PR [Automattic/studio#3952](https://github.com/Automattic/studio/pull/3952) `52755397` + Data Liberation Agent PR [Automattic/data-liberation-agent#119](https://github.com/Automattic/data-liberation-agent/pull/119) `16f32f4` + Static Site Importer `881768a`, on WordPress 7.1. Computed styles measured with Playwright, before and after on the same build.

**Horizontal menu** — `https://www.wix.com/sgtemplates/e-ramirez`

| menu label | before | after | source |
| --- | --- | --- | --- |
| `color` | `rgb(0, 0, 0)` | `rgb(255, 153, 254)` | `rgb(255, 153, 254)` |
| `font-family` | Arial | montserrat | montserrat |
| `font-size` | 10px | 14px | 14px |
| `letter-spacing` | normal | 0.7px | 0.7px |
| page height | 5143px | **4917px** | 4917px |

**Overlay toggle** — `https://www.wix.com/sgtemplates/sophja-j-pierce`

| "Menu" toggle | before | after | source |
| --- | --- | --- | --- |
| `background` | transparent | `rgb(26, 26, 26)` | `rgb(26, 26, 26)` |
| `border-radius` | 0px | 50px | 50px |
| label `color` | `rgb(0, 0, 0)` | `rgb(239, 254, 139)` | `rgb(239, 254, 139)` |
| label `font` | Arial 10px | madefor-text 18px | madefor-text 18px |
| label box | 25×11 | **48×23** | 48×23 |
| toggle width | 50px | **107px** | 107px |
| toggle height | 25px | 25px | 40px |

Re-importing the first source on the final build confirms no regression: labels and page height unchanged and still exact.

**Editor: 0 block-validation warnings and 0 `core/html` fallback blocks on both sources**, before and after.

## Known gaps, deliberately not in this PR

- **Toggle height 25px vs 40px.** The source resolves `height:100%` on the toggle; the `<details>` box core lays out does not fill its parent, so the pill is flatter than the source. Paint, radius, width and type are exact.
- **The overlay *panel's* link typography stays unstyled** on the second source (56px syne links render at Arial 10px). Different mechanism: the rewritten rule addresses markers `-58`/`-59`/`-60` while the labels that render carry `-53`–`-56`, i.e. the rule was projected onto source elements that never reach the output. That sits in the responsive-counterpart area, whose most recent change on Data Liberation Agent #119 is a revert of "Preserve responsive counterpart provenance", so it wants a decision there rather than a patch here.

## Note for #1482

This adds one more marker vocabulary (`blocks-engine-disclosure-summary-*`) to the surface #1482 wants to consolidate. It deliberately follows the existing `navigation-link-icon` projection rather than introducing a new mechanism, but it is additional surface for that refactor to absorb.

## Validation

- `composer test:canonical` — 150 tests pass (149 before, plus the new one).
- `composer test:parity` — 300 fixtures pass.
- New `tests/unit/menu-chrome-presentation-carry.php` **fails on `trunk`** for both surfaces (2 of 5 assertions) and passes on this branch.
- `php -l` clean on every changed file.

## AI Assistance

Claude Opus 5 via Claude Code was used to diagnose both failures, reduce each to a minimal reproduction, implement the change, and run verification against two live sources. gmovr remains responsible for the submitted changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W6gpfFTSwSok5vMvLnd5L
