### PR TITLE
fix(php-transformer): bound social links recognition

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Elements/FlowContainerElementContext.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FlowContainerElementContext.php
@@ -72,6 +72,7 @@ final class FlowContainerElementContext
     public function hasExternalSvgFragmentDependencyBoundary(DOMElement $element): bool { return ($this->canCaptureExternalSvgFragmentDependency)($element) && $this->sourceElementClassifier->hasExternalSvgFragmentDependencyBoundary($element); }
     public function hasResponsiveImageSources(DOMElement $element): bool { return $this->sourceElementClassifier->hasResponsiveImageSources($element); }
     public function hasGalleryMediaItems(DOMElement $element): bool { return $this->sourceElementClassifier->hasGalleryMediaItems($element); }
+    public function hasCapturedMediaContent(DOMElement $element): bool { return $this->sourceElementClassifier->hasCapturedMediaContent($element); }
     /** @return array<string, mixed> */
     public function responsiveMediaBlock(DOMElement $element): array { return ($this->responsiveMediaBlock)($element); }
     public function isDirectChildOfAuthorOwnedLayout(DOMElement $element): bool { return ($this->isDirectChildOfAuthorOwnedLayout)($element); }

--- a/php-transformer/src/HtmlToBlocks/Elements/FlowContainerElementConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FlowContainerElementConverter.php
@@ -130,7 +130,13 @@ final class FlowContainerElementConverter implements ElementConverter
             return ConversionOutcome::handled($navigationSection->block());
         }
         if ( ! $this->context->shouldDeferNavigationPatternToChildren($element) ) {
-            $block = $this->context->recognizePatterns($element, $fallbacks, array( AccordionPattern::class, SocialLinksPattern::class, NavigationPattern::class ));
+            // A broad container can contain a real social cluster plus unrelated
+            // media. Let its children be converted instead of dropping that media.
+            $patterns = array( AccordionPattern::class, NavigationPattern::class );
+            if ( ! $this->context->hasCapturedMediaContent($element) ) {
+                $patterns[] = SocialLinksPattern::class;
+            }
+            $block = $this->context->recognizePatterns($element, $fallbacks, $patterns);
             if ( null !== $block ) {
                 return ConversionOutcome::handled($this->context->rememberAccordionDisclosureRoot($block, $element));
             }

--- a/php-transformer/tests/unit/social-links-boundary.php
+++ b/php-transformer/tests/unit/social-links-boundary.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$source = '<div><section><video src="movie.mp4"></video></section><div><a href="https://x.com">X</a><a href="https://facebook.com">Facebook</a></div></div>';
+$result = (new HtmlTransformer())->transform($source)->toArray();
+$markup = (string) ($result['serialized_blocks'] ?? '');
+
+if (! str_contains($markup, '<!-- wp:video')) {
+    fwrite(STDERR, "FAIL: a social-links descendant must not consume sibling video content\n");
+    exit(1);
+}
+
+echo "Social-links boundary tests passed\n";


### PR DESCRIPTION
## Scope

Prevent a broad container with captured media and social-link descendants from being lowered wholesale as social links.

## Status

Draft. The added `social-links-boundary.php` regression file is not listed in Composer's `test:unit` manifest, so the passing CI suite does not execute it. Add it to the canonical test manifest and rerun CI before review. The solved-site-promotion gate is also still in progress.

## Focused Verification

`php tests/unit/social-links-boundary.php`

The focused fixture verifies that a sibling video is retained. It does not prove imported site playback or responsive layout parity.

## AI Assistance

GPT-5.6 Terra via OpenCode, orchestrated by GPT-6 Astra via OpenCode, was used for focused implementation and verification. Chris Huber remains responsible for the submitted changes.
