### PR TITLE
fix(php-transformer): clear missing responsive root class width

### DIFF
--- a/php-transformer/src/ArtifactCompiler/WordPressCompatCss.php
+++ b/php-transformer/src/ArtifactCompiler/WordPressCompatCss.php
@@ -35,8 +35,30 @@ final class WordPressCompatCss
      */
     private function responsiveRootCompatCss(string $css): string
     {
+        $rules = $this->responsiveRootCompatCssRules($css);
+        if ( array() === $rules ) {
+            return '';
+        }
+
+        return "\n\n/* wp-compat: WordPress body does not retain the source responsive root class. */\n"
+            . implode("\n", $rules);
+    }
+
+    /** @return array<int, string> */
+    private function responsiveRootCompatCssRules(string $css): array
+    {
         $selectors = array();
-        foreach ( $this->topLevelCssRules($css) as $rule ) {
+        $rules = array();
+        foreach ( $this->topLevelCssRules($css, true) as $rule ) {
+            if ( str_starts_with($rule['selector'], '@') ) {
+                if ( preg_match('/^@(media|supports|container|layer)\b/i', $rule['selector']) ) {
+                    $nested = $this->responsiveRootCompatCssRules($rule['body']);
+                    if ( array() !== $nested ) {
+                        $rules[] = $rule['selector'] . ' {' . implode('', $nested) . '}';
+                    }
+                }
+                continue;
+            }
             if ( ! preg_match('/(?:^|;)\s*min-width\s*:\s*(?!0(?:[a-z%]+)?\s*(?:!important)?\s*(?:;|$))/i', $rule['body']) ) {
                 continue;
             }
@@ -47,12 +69,11 @@ final class WordPressCompatCss
             }
         }
 
-        if ( array() === $selectors ) {
-            return '';
+        if ( array() !== $selectors ) {
+            $rules[] = implode(",\n", array_keys($selectors)) . ' { min-width:0!important }';
         }
 
-        return "\n\n/* wp-compat: WordPress body does not retain the source responsive root class. */\n"
-            . implode(",\n", array_keys($selectors)) . ' { min-width:0!important }';
+        return $rules;
     }
 
     /**

--- a/php-transformer/src/ArtifactCompiler/WordPressCompatCss.php
+++ b/php-transformer/src/ArtifactCompiler/WordPressCompatCss.php
@@ -25,7 +25,34 @@ final class WordPressCompatCss
             . $this->navigationStructureCompatCss($authoredCss)
             . $this->navigationAnchorCompatCss($authoredCss)
             . $this->rootStartupClassCompatCss($authoredCss, $scriptContents)
+            . $this->responsiveRootCompatCss($authoredCss)
             . $this->coreRuntimeCompatCss($authoredCss, $files);
+    }
+
+    /**
+     * WordPress owns the body element, so a source body's responsive class is
+     * not available to disable a captured desktop-only root minimum width.
+     */
+    private function responsiveRootCompatCss(string $css): string
+    {
+        $selectors = array();
+        foreach ( $this->topLevelCssRules($css) as $rule ) {
+            if ( ! preg_match('/(?:^|;)\s*min-width\s*:\s*(?!0(?:[a-z%]+)?\s*(?:!important)?\s*(?:;|$))/i', $rule['body']) ) {
+                continue;
+            }
+            foreach ( $this->splitSelectorList($rule['selector']) as $selector ) {
+                if ( preg_match('/\bbody\s*:not\(\s*\.responsive\s*\)/i', $selector) ) {
+                    $selectors[trim($selector)] = true;
+                }
+            }
+        }
+
+        if ( array() === $selectors ) {
+            return '';
+        }
+
+        return "\n\n/* wp-compat: WordPress body does not retain the source responsive root class. */\n"
+            . implode(",\n", array_keys($selectors)) . ' { min-width:0!important }';
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -3640,12 +3640,12 @@ $artifactResponsiveRoot = $compiler->compile(
         'entry' => 'index.html',
         'files' => array(
             'index.html'  => '<!doctype html><html><head><link rel="stylesheet" href="styles.css"></head><body class="responsive"><main id="site-root">Content</main></body></html>',
-            'styles.css' => ':root{--site-width:980px}body:not(.responsive) #site-root{width:100%;min-width:var(--site-width)}body.responsive #site-root{width:100%}',
+            'styles.css' => ':root{--site-width:980px}body:not(.responsive) #site-root{width:100%;min-width:var(--site-width)}@media (min-width: 800px){body:not(.responsive) .desktop-root{min-width:980px}}body.responsive #site-root{width:100%}',
         ),
     )
 )->toArray();
 $artifactResponsiveRootCss = (string) ($artifactResponsiveRoot['source_reports']['compiled_site']['theme']['static_css'] ?? '');
-$assert(str_contains($artifactResponsiveRootCss, 'wp-compat: WordPress body does not retain the source responsive root class.') && str_contains($artifactResponsiveRootCss, 'body:not(.responsive) #site-root { min-width:0!important }'), 'artifact CSS clears source responsive-root desktop minimum widths when WordPress owns the body class', $artifactResponsiveRootCss);
+$assert(str_contains($artifactResponsiveRootCss, 'wp-compat: WordPress body does not retain the source responsive root class.') && str_contains($artifactResponsiveRootCss, 'body:not(.responsive) #site-root { min-width:0!important }') && str_contains($artifactResponsiveRootCss, '@media (min-width: 800px) {body:not(.responsive) .desktop-root { min-width:0!important }}'), 'artifact CSS clears source responsive-root desktop minimum widths when WordPress owns the body class, including inside supported conditional rules', $artifactResponsiveRootCss);
 
 $artifactMobileNavOverlay = $compiler->compile(
     array(

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -3635,6 +3635,18 @@ $assert(str_contains($artifactNavStructureMarkup, '"overlayMenu":"never"') && ! 
 $assert(! str_contains($artifactNavStructureCompatCss, '.wp-block-navigation__container { visibility:hidden }'), 'artifact navigation projection leaves script-driven list container visibility to core navigation');
 $assert(str_contains($artifactNavStructureCompatCss, '.menu-ready .desktop-nav.site-menu.wp-block-navigation .wp-block-navigation__container { visibility:visible;opacity:1 }'), 'artifact navigation projection materializes the source list stable visible state for core navigation', $artifactNavStructureCompatCss);
 
+$artifactResponsiveRoot = $compiler->compile(
+    array(
+        'entry' => 'index.html',
+        'files' => array(
+            'index.html'  => '<!doctype html><html><head><link rel="stylesheet" href="styles.css"></head><body class="responsive"><main id="site-root">Content</main></body></html>',
+            'styles.css' => ':root{--site-width:980px}body:not(.responsive) #site-root{width:100%;min-width:var(--site-width)}body.responsive #site-root{width:100%}',
+        ),
+    )
+)->toArray();
+$artifactResponsiveRootCss = (string) ($artifactResponsiveRoot['source_reports']['compiled_site']['theme']['static_css'] ?? '');
+$assert(str_contains($artifactResponsiveRootCss, 'wp-compat: WordPress body does not retain the source responsive root class.') && str_contains($artifactResponsiveRootCss, 'body:not(.responsive) #site-root { min-width:0!important }'), 'artifact CSS clears source responsive-root desktop minimum widths when WordPress owns the body class', $artifactResponsiveRootCss);
+
 $artifactMobileNavOverlay = $compiler->compile(
     array(
         'entry' => 'index.html',


### PR DESCRIPTION
## Summary
- reset source desktop root minimum widths guarded by `body:not(.responsive)` when WordPress owns the body class
- cover the generated compatibility CSS contract

## Validation
- `composer test`
- `php -l src/ArtifactCompiler/WordPressCompatCss.php`

AI disclosure: implemented with openai/gpt-5.6-terra using OpenCode.