### PR TITLE
fix(php-transformer): scan responsive variant styles

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ResponsiveDocumentVariants.php
+++ b/php-transformer/src/ArtifactCompiler/ResponsiveDocumentVariants.php
@@ -7,6 +7,7 @@ use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\CssUrlRewriter;
 use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\SrcsetParser;
 use Automattic\BlocksEngine\PhpTransformer\Css\CssStylesheetTransformer;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
+use Automattic\BlocksEngine\PhpTransformer\Support\StyleTagScanner;
 
 /**
  * Composes typed viewport-specific source documents before artifact normalization.
@@ -192,11 +193,11 @@ final class ResponsiveDocumentVariants
             },
             $html
         );
-        return (string) preg_replace_callback(
-            '~<style\b[^>]*>(.*?)</style\s*>~is',
-            static fn(array $match): string => str_replace($match[1], self::rebaseCss($match[1], $rebase), $match[0]),
-            $html
-        );
+        foreach (array_reverse(StyleTagScanner::scan($html)) as $style) {
+            $contentOffset = $style['offset'] + 6 + strlen($style['attributes']) + 1;
+            $html = substr_replace($html, self::rebaseCss($style['content'], $rebase), $contentOffset, strlen($style['content']));
+        }
+        return $html;
     }
 
     /** @param callable(string):string $rebase */
@@ -283,13 +284,10 @@ final class ResponsiveDocumentVariants
     /** @return array<int,array{css:string,media:string}> */
     private function styles(string $html): array
     {
-        if (!preg_match_all('@<style\b([^>]*)>([\s\S]*?)</style\s*>@i', $html, $matches, PREG_SET_ORDER)) {
-            return array();
-        }
-        return array_map(fn(array $match): array => array(
-            'css' => (string) $match[2],
-            'media' => $this->attribute('<style ' . $match[1] . '>', 'media'),
-        ), $matches);
+        return array_map(fn(array $style): array => array(
+            'css' => $style['content'],
+            'media' => $this->attribute('<style' . $style['attributes'] . '>', 'media'),
+        ), StyleTagScanner::scan($html));
     }
 
     private function attribute(string $tag, string $name): string

--- a/php-transformer/tests/unit/responsive-document-variants.php
+++ b/php-transformer/tests/unit/responsive-document-variants.php
@@ -64,6 +64,31 @@ $assert(str_contains($assetCss, '.card{display:block}'), 'Mobile selectors remai
 $assert(str_contains($blocks, 'site-document-variant-default desktop'), 'Primary body classes are projected onto the default document wrapper.');
 $assert(str_contains($blocks, 'href="calendar/index.html"'), 'Mobile route destinations retain their existing primary-route interpretation.');
 
+$largeVariantCss = '.variant-large-first{color:#123456}' . str_repeat('/* responsive variant payload */', 40000) . '.variant-large-last{color:#654321}';
+$largeVariantArtifact = array(
+    'schema' => ArtifactCompiler::INPUT_SCHEMA,
+    'entrypoint' => 'index.html',
+    'document_variants' => array(array(
+        'source_path' => 'index.html',
+        'variants' => array(array(
+            'id' => 'mobile',
+            'source_path' => '.variants/mobile/index.html',
+            'media' => '(max-width: 768px)',
+        )),
+    )),
+    'files' => array(
+        array('path' => 'index.html', 'content' => '<!doctype html><html><head></head><body><main>Desktop</main></body></html>'),
+        array('path' => '.variants/mobile/index.html', 'content' => '<!doctype html><html><head><style media="screen">' . $largeVariantCss . '</style></head><body><main>Mobile</main></body></html>'),
+    ),
+);
+$assert(strlen($largeVariantCss) > 1048576, 'Responsive variant regression CSS exceeds one megabyte.');
+$largeVariantResult = (new ArtifactCompiler())->compile($largeVariantArtifact)->toArray();
+$largeVariantAssetCss = implode("\n", array_map(
+    static fn(array $asset): string => (string) ($asset['content'] ?? ''),
+    array_filter($largeVariantResult['assets'] ?? array(), 'is_array')
+));
+$assert(str_contains($largeVariantAssetCss, '@scope (.site-document-variant-mobile)') && str_contains($largeVariantAssetCss, '.variant-large-first{color:#123456}') && str_contains($largeVariantAssetCss, '.variant-large-last{color:#654321}'), 'Large variant CSS is fully emitted inside the responsive document scope.');
+
 $sharedPlan = $compiler->prepareShared($artifact);
 $pagePlan = $compiler->preparePage($artifact, $sharedPlan, 'website/index.html');
 $staged = $compiler->compose($sharedPlan, array($pagePlan))->toArray();

--- a/php-transformer/tools/visual-parity/package.json
+++ b/php-transformer/tools/visual-parity/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "install:browsers": "playwright install chromium",
-    "test": "node tests/smoke.mjs && node tests/blockquote-margin-reset.mjs && node tests/exact-fit-inline-flow.mjs && node tests/layout-shell-editor-geometry.mjs && node tests/custom-video-host-editor-geometry.mjs && node tests/issue-1493-reduced-public-fixture.mjs"
+    "test": "node tests/smoke.mjs && node tests/blockquote-margin-reset.mjs && node tests/exact-fit-inline-flow.mjs && node tests/layout-shell-editor-geometry.mjs && node tests/custom-video-host-editor-geometry.mjs && node tests/issue-1493-reduced-public-fixture.mjs && node tests/responsive-document-variants.mjs"
   },
   "devDependencies": {
     "playwright": "^1.56.0"

--- a/php-transformer/tools/visual-parity/tests/responsive-document-variants.mjs
+++ b/php-transformer/tools/visual-parity/tests/responsive-document-variants.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const transformerRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const compiled = JSON.parse(execFileSync('php', ['-r', `
+require $argv[1] . '/vendor/autoload.php';
+use Automattic\\BlocksEngine\\PhpTransformer\\ArtifactCompiler\\ArtifactCompiler;
+
+$result = (new ArtifactCompiler())->compile(array(
+    'schema' => ArtifactCompiler::INPUT_SCHEMA,
+    'entrypoint' => 'index.html',
+    'document_variants' => array(array(
+        'source_path' => 'index.html',
+        'variants' => array(array(
+            'id' => 'mobile',
+            'source_path' => '.variants/mobile/index.html',
+            'media' => '(max-width: 768px)',
+        )),
+    )),
+    'files' => array(
+        array('path' => 'index.html', 'content' => '<!doctype html><html><head></head><body><main><p class="default-rule">Desktop</p></main></body></html>'),
+        array('path' => '.variants/mobile/index.html', 'content' => '<!doctype html><html><head><style>.mobile-rule{display:flex;color:rgb(1, 2, 3)}</style></head><body><main><p class="mobile-rule">Mobile</p></main></body></html>'),
+    ),
+))->toArray();
+
+echo json_encode(array(
+    'css' => implode("\\n", array_map(static fn(array $asset): string => (string) ($asset['content'] ?? ''), array_filter($result['assets'] ?? array(), 'is_array'))),
+    'markup' => (string) ($result['serialized_blocks'] ?? ''),
+));
+`, transformerRoot], { encoding: 'utf8' }));
+
+assert.match(compiled.markup, /site-document-variant-default/);
+assert.match(compiled.markup, /site-document-variant-mobile/);
+assert.match(compiled.css, /@media \(max-width: 768px\)/);
+
+const browser = await chromium.launch({ headless: true });
+try {
+  const capture = async (width) => {
+    const page = await browser.newPage({ viewport: { width, height: 600 } });
+    await page.setContent(`<!doctype html><style>body{margin:0}${compiled.css}</style>${compiled.markup}`);
+    const result = await page.evaluate(() => {
+      const defaultWrapper = document.querySelector('.site-document-variant-default');
+      const mobileWrapper = document.querySelector('.site-document-variant-mobile');
+      const mobileRule = document.querySelector('.mobile-rule');
+      return {
+        defaultDisplay: getComputedStyle(defaultWrapper).display,
+        mobileDisplay: getComputedStyle(mobileWrapper).display,
+        mobileRuleDisplay: getComputedStyle(mobileRule).display,
+        mobileRuleColor: getComputedStyle(mobileRule).color,
+      };
+    });
+    await page.close();
+    return result;
+  };
+
+  const desktop = await capture(1280);
+  assert.notEqual(desktop.defaultDisplay, 'none', 'desktop viewport keeps the default wrapper visible');
+  assert.equal(desktop.mobileDisplay, 'none', 'desktop viewport hides the mobile wrapper');
+
+  const mobile = await capture(390);
+  assert.equal(mobile.defaultDisplay, 'none', 'mobile viewport hides the default wrapper');
+  assert.notEqual(mobile.mobileDisplay, 'none', 'mobile viewport keeps the mobile wrapper visible');
+  assert.equal(mobile.mobileRuleDisplay, 'flex', 'the scoped mobile rule applies at the mobile viewport');
+  assert.equal(mobile.mobileRuleColor, 'rgb(1, 2, 3)', 'the scoped mobile rule retains its computed color');
+} finally {
+  await browser.close();
+}
+
+console.log('Responsive document variant browser regression passed');


### PR DESCRIPTION
## Summary
- route responsive-document variant style extraction and CSS rebasing through `StyleTagScanner`
- retain styles larger than PCRE backtracking limits and cover the browser-visible breakpoint behavior

Closes #1266

## Testing
- `composer test` in `php-transformer` (303 parity fixtures)
- `npm test` in `php-transformer/tools/visual-parity` (including the 390px browser regression)
- WordPress integration suite was not run locally; this change does not alter that suite and CI will verify it.

## AI assistance
GPT-6 Astra via OpenCode was used for orchestration and review. openai/gpt-5.6-terra via direct OpenCode implementation was used to inspect, implement, test, and publish this change.