### PR TITLE
Avoid scaling native navigation labels

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -2903,6 +2903,13 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
         // a longhand found further out should not silently outrank it.
         foreach ( array( 'font', 'color', 'font-family', 'font-size', 'font-weight', 'font-style', 'letter-spacing', 'text-transform' ) as $property ) {
             $value = $this->navigationItemPresentationValue($anchor, $navigation, $property);
+            // The source component resolves this formula against its own width.
+            // Replaying it on Core's replacement anchor changes that reference
+            // and inflates the label. The promoted item retains the source
+            // wrapper class, so the anchor can inherit the original value.
+            if ( in_array($property, array( 'font', 'font-size' ), true) && str_contains($value, '--scaling-factor') ) {
+                continue;
+            }
             if ( '' !== $value ) {
                 $declarations[] = $property . ':' . $this->navigationProjectionValue($value);
             }

--- a/php-transformer/tests/unit/navigation-hidden-menu-hoist.php
+++ b/php-transformer/tests/unit/navigation-hidden-menu-hoist.php
@@ -37,6 +37,14 @@ $intrinsicProjectedCss = implode("\n", array_map(
     static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '',
     is_array($intrinsicProjected['assets'] ?? null) ? $intrinsicProjected['assets'] : array()
 ));
+$containerScaled = ( new HtmlTransformer() )->transform(
+    '<style>.menu-label{font-size:max(.5px,.0410256 * (var(--scaling-factor) - var(--scrollbar-width)))}</style>'
+    . '<nav class="menu"><div class="menu-label"><a href="/">Home</a></div><div class="menu-label"><a href="/work">Work</a></div></nav>'
+)->toArray();
+$containerScaledCss = implode("\n", array_map(
+    static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '',
+    is_array($containerScaled['assets'] ?? null) ? $containerScaled['assets'] : array()
+));
 
 $ambiguous = ( new HtmlTransformer() )->transform(
     '<header><button aria-label="Menu" aria-expanded="false"><span></span><span></span></button><nav aria-label="Main" style="display:none"><a href="/">Home</a><a href="/work">Work</a></nav><nav aria-label="Utility" style="display:none"><a href="/help">Help</a><a href="/contact">Contact</a></nav></header>'
@@ -50,6 +58,7 @@ $assertions = array(
     array(str_contains($projectedCss, 'width:42px!important;height:48px!important') && ! str_contains($projectedCss, '!important!important'), 'the visible source control box projects onto Core\'s responsive open button without duplicating source importance'),
     array(str_contains($intrinsicProjectedCss, 'min-width:44px!important') && str_contains($intrinsicProjectedCss, 'min-height:44px!important') && ! str_contains($intrinsicProjectedCss, '!important!important'), 'intrinsic source toggle dimensions receive a usable native control box without invalid declarations'),
     array(str_contains($projectedCss, '100vw'), 'container-relative inherited navigation typography is rebound after promotion'),
+    array(1 === substr_count($containerScaledCss, 'font-size:max(.5px,.0410256 * (var(--scaling-factor) - var(--scrollbar-width)))'), 'container-scaled label typography is not replayed against a replacement navigation anchor'),
     array(! str_contains($projectedMarkup, '<!-- wp:button'), 'the superseded source menu control is not emitted as a dead button'),
     array(str_contains($projectedMarkup, 'Northwind') && str_contains($projectedMarkup, '"label":"Home"') && str_contains($projectedMarkup, '"label":"Work"'), 'projection preserves surrounding shell content and editable navigation destinations'),
     array(2 === $countBlocks($ambiguous['blocks'] ?? array(), 'core/navigation'), 'ambiguous hidden navigation candidates remain unprojected'),


### PR DESCRIPTION
## Summary
- Do not replay container-relative scaling typography on replacement navigation anchors.
- Retain wrapper-derived type on the promoted navigation item.

## Evidence
Public Busy Bears source resolves desktop navigation labels to 18px. The canonical Studio import previously replayed the source formula against the wider native navigation host and produced 59.0769px labels. The candidate URL import at localhost port 8886 with Studio 4c284c7e, SSI 534eee37, and Blocks Engine 19de97b2 confirms the label now renders at 18px and fits the Contact header.

## Validation
- composer test, including 303 parity fixtures
- php tests/unit/navigation-hidden-menu-hoist.php

## Scope
Draft only. Mobile navigation visibility and CTA background are separate unresolved defects and are not included.

## AI assistance disclosure
Implemented with OpenAI GPT-5.6 Terra through direct OpenCode. Human review remains required.