### PR TITLE
fix(php-transformer): render imported post content

### DIFF
--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
@@ -656,11 +656,11 @@ final class WordPressSitePlan
             }
             $first = $cluster['candidate'];
             foreach ($applicable as $index => $page) if (!in_array($index, $cluster['indexes'], true)) $excluded[$index] = isset($candidates[$index]) ? 'non_equivalent' : 'missing';
-            $templateSlugs = count($cluster['indexes']) === count($applicable) ? array('index', 'page', 'front-page') : array('index');
+            $templateSlugs = count($cluster['indexes']) === count($applicable) ? array('index', 'page', 'front-page', 'single') : array('index');
             if (count($cluster['indexes']) !== count($applicable)) foreach ($applicable as $index => $page) {
                 $selected = in_array($index, $cluster['indexes'], true);
                 if (!empty($page['entrypoint'])) { if ($selected) $templateSlugs[] = 'front-page'; continue; }
-                if ('post' === ($page['post_type'] ?? null)) { if ($selected) $templateSlugs[] = 'index'; } elseif ($selected) $templateSlugs[] = 'page';
+                if ('post' === ($page['post_type'] ?? null)) { if ($selected) $templateSlugs[] = 'single'; } elseif ($selected) $templateSlugs[] = 'page';
                 if (!$selected) {
                     $slug = 'page' === ($page['post_type'] ?? null) ? 'page-' . $page['slug'] : 'single-' . $page['post_type'] . '-' . $page['slug'];
                     if (isset($overrides[$slug])) {
@@ -1297,6 +1297,7 @@ final class WordPressSitePlan
         $make = static function (string $slug, string $target, string $content): array { return array('slug' => $slug, 'target_path' => $target, 'canonical_block_markup' => $content, 'reconciliation_identity' => self::identity('template', 'wordpress-site-plan/' . $target, $target), 'content_hash' => self::contentHash($content)); };
         $templates = array($make('index', 'templates/index.html', $markup('index')));
         if ( array() !== $pages ) $templates[] = $make('page', 'templates/page.html', $markup('page'));
+        foreach ( $pages as $page ) if ( 'post' === ($page['post_type'] ?? null) ) { $templates[] = $make('single', 'templates/single.html', $markup('single')); break; }
         foreach ( $pages as $page ) if ( ! empty($page['entrypoint']) ) { $templates[] = $make('front-page', 'templates/front-page.html', $markup('front-page')); break; }
         $overrides = array();
         foreach ($bound as $part) foreach ($part['placement']['excluded_template_slugs'] ?? array() as $slug) if (preg_match('/^(?:page|single)-[a-z0-9-]+$/', $slug)) $overrides[$slug] = true;

--- a/php-transformer/tests/integration/wordpress-site-plan.php
+++ b/php-transformer/tests/integration/wordpress-site-plan.php
@@ -291,6 +291,7 @@ $pageTemplate = file_get_contents($themeDir . '/templates/page.html'); if (false
 $post = $about; $setRequest($post, false); $nestedRendered = do_blocks($pageTemplate); wp_reset_postdata();
 $assert(1 === substr_count($nestedRendered, '<header') && 1 === substr_count($nestedRendered, '<footer') && str_contains($nestedRendered, 'About') && str_contains($nestedRendered, 'href="#content"') && str_contains($nestedRendered, '<main id="content"'), 'WordPress renders nested pages through declared shared parts without duplicate chrome.');
 $indexTemplate = file_get_contents($themeDir . '/templates/index.html'); if (false === $indexTemplate) throw new RuntimeException('Could not read index template.');
+$singleTemplate = file_get_contents($themeDir . '/templates/single.html'); if (false === $singleTemplate) throw new RuntimeException('Could not read single template.');
 $queryPostIds = array();
 foreach (array('Query Loop First', 'Query Loop Second') as $title) {
     $queryPostId = wp_insert_post(array('post_type' => 'post', 'post_status' => 'publish', 'post_title' => $title, 'post_content' => '<!-- wp:paragraph --><p>' . $title . ' excerpt.</p><!-- /wp:paragraph -->'), true);
@@ -307,6 +308,8 @@ $indexRendered = do_blocks($indexTemplate);
 wp_reset_postdata();
 $wp_query = $previousQuery;
 $assert('core/query' === ($indexQuery['blockName'] ?? null) && 10 === ($indexQuery['attrs']['query']['perPage'] ?? null) && true === ($indexQuery['attrs']['query']['inherit'] ?? null) && 'core/post-template' === ($indexPostTemplate['blockName'] ?? null) && $indexTemplate === serialize_blocks($indexBlocks) && str_contains($indexRendered, 'Query Loop First') && str_contains($indexRendered, 'Query Loop Second') && 2 === substr_count($indexRendered, 'wp-block-post ') && !str_contains($indexRendered, 'No posts found.'), 'WordPress parses, serializes, and renders the generated index Query Loop once per inherited post without its no-results fallback.');
+$post = $essay; $setRequest($post, false); $singleRendered = do_blocks($singleTemplate); wp_reset_postdata();
+$assert(str_contains($singleTemplate, 'wp:post-content') && str_contains($singleRendered, 'Essay'), 'WordPress renders each imported post through a standard singular template with its post content.');
 fwrite(STDOUT, "wordpress-site-plan WordPress integration passed\n");
 } finally {
     foreach ($pageIds as $id) wp_delete_post((int) $id, true);


### PR DESCRIPTION
## Summary

Generate a standard `single.html` template when an artifact contains posts. The template renders `post-content`, so imported article routes no longer fall through to the archive-only `index.html` query template. Shared shell parts now bind to the singular template; divergent post shells retain their existing per-post override templates.

## Evidence

The Brezzelo review site stored all six article bodies (the representative `marketing-concepts` post contains 962,069 bytes) but generated no `templates/single.html`. WordPress therefore resolved the archive `index.html`, which renders only linked post title, excerpt, and date.

The WordPress integration contract now asserts that a materialized post is rendered through `single.html` with its post content.

## Testing

- `composer run test:canonical`
- `composer run test:packaging`
- `php -l src/WordPressSitePlan/WordPressSitePlan.php`
- `php -l tests/integration/wordpress-site-plan.php`
- `composer run test:wordpress-integration` is environment-gated and skipped because `WP_TESTS_DIR` is unavailable in this checkout.

## AI Assistance

OpenAI GPT-5.6 Terra via OpenCode diagnosed the generated-theme fallback, implemented the minimal compiler template change, added the WordPress integration assertion, and ran the listed checks. Chris Huber remains responsible for the submitted changes.