### PR TITLE
fix: preserve captured menu disclosures

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -3714,10 +3714,8 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
     }
 
     /**
-     * An empty native details summary is sometimes capture scaffolding for an
-     * adjacent dialog. A core/details block gives that otherwise invisible
-     * trigger WordPress's default summary geometry, so preserve the bounded
-     * dialog as a closed native dialog instead.
+     * A details disclosure can only lower to a captured dialog when the source
+     * provides the trigger linkage that makes the dialog operable at runtime.
      */
     private function capturedDisclosureDialog(DOMElement $element): ?DOMElement
     {
@@ -3751,6 +3749,10 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
         }
 
         if ( ! $summary instanceof DOMElement || ! $dialog instanceof DOMElement ) {
+            return null;
+        }
+
+        if ( '' === trim($this->attr($dialog, 'data-blocks-engine-triggers')) ) {
             return null;
         }
 

--- a/php-transformer/src/HtmlToBlocks/NavigationBlockNormalizer.php
+++ b/php-transformer/src/HtmlToBlocks/NavigationBlockNormalizer.php
@@ -84,7 +84,7 @@ final class NavigationBlockNormalizer
     public function normalize(array $blocks, array $sourceProvenance, array $sourceBaseHiddenStates): array
     {
         $seen = array();
-        return $this->normalizeRecursive($blocks, $seen, $sourceProvenance, $sourceBaseHiddenStates);
+        return $this->normalizeRecursive($blocks, $seen, $sourceProvenance, $sourceBaseHiddenStates, false);
     }
 
     private function directItemAnchor(DOMElement $item): ?DOMElement
@@ -123,7 +123,7 @@ final class NavigationBlockNormalizer
      * @param array<int, bool> $sourceBaseHiddenStates
      * @return array<int, array<string, mixed>>
      */
-    private function normalizeRecursive(array $blocks, array &$seen, array $sourceProvenance, array $sourceBaseHiddenStates): array
+    private function normalizeRecursive(array $blocks, array &$seen, array $sourceProvenance, array $sourceBaseHiddenStates, bool $preserveDisclosureNavigation): array
     {
         $blocks = $this->preferVisibleSiblings($blocks, $sourceBaseHiddenStates);
         $deduplicated = array();
@@ -133,13 +133,19 @@ final class NavigationBlockNormalizer
             }
 
             if ( ! empty($block['innerBlocks']) && is_array($block['innerBlocks']) ) {
-                $block['innerBlocks'] = $this->normalizeRecursive($block['innerBlocks'], $seen, $sourceProvenance, $sourceBaseHiddenStates);
+                $block['innerBlocks'] = $this->normalizeRecursive(
+                    $block['innerBlocks'],
+                    $seen,
+                    $sourceProvenance,
+                    $sourceBaseHiddenStates,
+                    $preserveDisclosureNavigation || $this->isNativeDisclosure($block)
+                );
                 $block = $this->reconcileInnerContentChildPlaceholders($block);
             }
 
             if ( 'core/navigation' === ($block['blockName'] ?? '') ) {
                 $signature = $this->signature($block);
-                if ( '' !== $signature && isset($seen[$signature]) && $this->isMobileDuplicate($block, $sourceProvenance) ) {
+                if ( ! $preserveDisclosureNavigation && '' !== $signature && isset($seen[$signature]) && $this->isMobileDuplicate($block, $sourceProvenance) ) {
                     continue;
                 }
                 if ( '' !== $signature ) {
@@ -151,6 +157,13 @@ final class NavigationBlockNormalizer
         }
 
         return $deduplicated;
+    }
+
+    /** Native DLA disclosures retain independent desktop and mobile panels. */
+    private function isNativeDisclosure(array $block): bool
+    {
+        return 'core/details' === ($block['blockName'] ?? '')
+            && (bool) preg_match('/(?:^|\s)dla-disclosure(?:\s|$)/', (string) ($block['attrs']['className'] ?? ''));
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -234,6 +234,33 @@ final class NavigationPattern implements PatternRecognizerInterface
         );
     }
 
+    private function overlayMenu(DOMElement $element, ?NavigationPatternContext $context): string
+    {
+        if ( $this->isInsideCapturedDisclosurePanel($element) ) {
+            return 'never';
+        }
+
+        return $context?->overlayMenu($element) ?? 'never';
+    }
+
+    /** A native disclosure already supplies the only mobile open/close control. */
+    private function isInsideCapturedDisclosurePanel(DOMElement $element): bool
+    {
+        $hasDialogPanel = false;
+        for ( $ancestor = $element->parentNode; $ancestor instanceof DOMElement; $ancestor = $ancestor->parentNode ) {
+            $classes = ' ' . trim(SourceDom::attr($ancestor, 'class')) . ' ';
+            if ( str_contains($classes, ' dla-dialog ') ) {
+                $hasDialogPanel = true;
+                continue;
+            }
+            if ( $hasDialogPanel && 'details' === strtolower($ancestor->tagName) && str_contains($classes, ' dla-disclosure ') ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private function isNavigationSectionHeading(DOMElement $element): bool
     {
         if ( preg_match('/^h[1-6]$/i', $element->tagName) ) {

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -95,7 +95,7 @@ final class NavigationPattern implements PatternRecognizerInterface
         $navigationAttrs = $label instanceof DOMElement
             ? $this->nestedLabeledNavigationAttributes($element, $presentationAttributes)
             : $this->navigationContainerAttributes($element, $presentationAttributes);
-        $navigationAttrs['overlayMenu'] = $navigationContext?->overlayMenu($element) ?? 'never';
+        $navigationAttrs['overlayMenu'] = $this->overlayMenu($element, $navigationContext);
         if ( 'mobile' === $navigationAttrs['overlayMenu'] ) {
             $navigationAttrs = $this->withClassName($navigationAttrs, 'blocks-engine-native-responsive-navigation');
             $navigationAttrs = $this->withClassName($navigationAttrs, $navigationContext?->responsiveToggleMarker($element) ?? '');
@@ -222,7 +222,7 @@ final class NavigationPattern implements PatternRecognizerInterface
                 'kind' => 'custom',
             ), static fn ($value): bool => '' !== $value), array(), $anchor);
         }
-        $overlayMenu = $context->navigationContext()?->overlayMenu($element) ?? 'never';
+        $overlayMenu = $this->overlayMenu($element, $context->navigationContext());
         $navigationAttrs = array('overlayMenu' => $overlayMenu);
         if ( 'mobile' === $overlayMenu ) {
             $navigationAttrs['className'] = 'blocks-engine-native-responsive-navigation';
@@ -470,7 +470,7 @@ final class NavigationPattern implements PatternRecognizerInterface
                 }
             }
         }
-        $navigationAttrs['overlayMenu'] = $navigationContext?->overlayMenu($cluster) ?? 'never';
+        $navigationAttrs['overlayMenu'] = $this->overlayMenu($cluster, $navigationContext);
         if ( 'mobile' === $navigationAttrs['overlayMenu'] ) {
             $navigationAttrs = $this->withClassName($navigationAttrs, 'blocks-engine-native-responsive-navigation');
             $navigationAttrs = $this->withClassName($navigationAttrs, $navigationContext?->responsiveToggleMarker($cluster) ?? '');

--- a/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressor.php
+++ b/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressor.php
@@ -43,7 +43,7 @@ final class NavigationToggleSuppressor
         }
 
         foreach ( $root->getElementsByTagName('*') as $control ) {
-            if ( ! $control instanceof DOMElement || ! $this->isHamburgerMenuToggleControl($control) ) {
+            if ( ! $control instanceof DOMElement || $this->isCapturedDialogControl($control) || ! $this->isHamburgerMenuToggleControl($control) ) {
                 continue;
             }
 
@@ -212,11 +212,42 @@ final class NavigationToggleSuppressor
      */
     public function isRedundantMenuToggleControl(DOMElement $element): bool
     {
+        if ( $this->isCapturedDialogControl($element) ) {
+            return false;
+        }
+
         if ( ! $this->isHamburgerMenuToggleControl($element) ) {
             return false;
         }
 
         return $this->hasAssociatedNavigationMenu($element);
+    }
+
+    /** A native disclosure with a captured dialog has its own preservation path. */
+    private function isCapturedDialogControl(DOMElement $element): bool
+    {
+        if ( 'summary' === strtolower($element->tagName) && $element->parentNode instanceof DOMElement ) {
+            $element = $element->parentNode;
+        }
+        if ( 'details' !== strtolower($element->tagName) ) {
+            return false;
+        }
+
+        $hasSummary = false;
+        foreach ( $element->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+            if ( 'summary' === strtolower($child->tagName) ) {
+                $hasSummary = true;
+                continue;
+            }
+            if ( $hasSummary && 'dialog' === strtolower(SourceDom::attr($child, 'role')) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -641,6 +672,7 @@ final class NavigationToggleSuppressor
 
         foreach ( $document->getElementsByTagName('*') as $toggle ) {
             if ( ! $toggle instanceof DOMElement
+                || $this->isCapturedDialogControl($toggle)
                 || ! $this->isHamburgerMenuToggleControl($toggle)
                 || ! $this->hasAssociatedNavigationMenu($toggle)
             ) {

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -858,23 +858,26 @@ $assert(str_contains($closedDetailsMarkup, '<details class="wp-block-details"><s
 $assert(strpos($closedDetailsMarkup, '<summary>Closed summary</summary>') < strpos($closedDetailsMarkup, '<p>Closed content.</p>'), 'closed native details preserves summary before content through final serialization');
 $assert('pass' === ($closedDetailsResult['source_reports']['wp_block_validity']['status'] ?? ''), 'closed native details serialization remains Gutenberg-valid');
 
-// A visually empty native summary is capture scaffolding, not an editor-visible
-// disclosure trigger. Keep adjacent prose editable while lowering the bounded
-// dialog separately so core/details cannot add its default closed-state height.
+// Native DLA disclosures without explicit dialog trigger linkage retain their
+// browser-native summary behavior through core/details.
 $capturedDisclosureResult = ( new HtmlTransformer() )->transform('<div class="rich-text"><p>Copyright text</p><details class="dla-disclosure"><summary>&nbsp;</summary><div class="dla-dialog" role="dialog"><nav><a href="/about">About</a><a href="/contact">Contact</a></nav></div></details></div>')->toArray();
 $capturedDisclosureRoot = $capturedDisclosureResult['blocks'][0] ?? array();
 $capturedDisclosureChildren = $capturedDisclosureRoot['innerBlocks'] ?? array();
 $capturedDisclosureDialog = $capturedDisclosureChildren[1] ?? array();
 $capturedDisclosureMarkup = (string) ($capturedDisclosureResult['serialized_blocks'] ?? '');
 $assert('core/group' === ($capturedDisclosureRoot['blockName'] ?? null) && 'core/paragraph' === (($capturedDisclosureChildren[0] ?? array())['blockName'] ?? null) && 'Copyright text' === (($capturedDisclosureChildren[0]['attrs']['content'] ?? null)), 'mixed rich text keeps ordinary sibling prose editable when an empty-summary disclosure is present');
-$assert(str_ends_with((string) ($capturedDisclosureDialog['blockName'] ?? ''), '/captured-dialog') && 'core/navigation' === (($capturedDisclosureDialog['innerBlocks'][0] ?? array())['blockName'] ?? null), 'bounded empty-summary dialog disclosures lower to the typed dialog block with native navigation children');
-$assert(! str_contains($capturedDisclosureMarkup, '<!-- wp:details') && ! str_contains($capturedDisclosureMarkup, '/collection') && str_contains($capturedDisclosureMarkup, '<dialog class="dla-dialog">'), 'empty-summary dialog disclosures avoid both details trigger geometry and collection fallback');
+$assert('core/details' === ($capturedDisclosureDialog['blockName'] ?? null) && 'core/navigation' === (($capturedDisclosureDialog['innerBlocks'][0]['innerBlocks'][0] ?? array())['blockName'] ?? null), 'bounded empty-summary dialog disclosures retain a native details trigger with navigation children');
+$assert(str_contains($capturedDisclosureMarkup, '<!-- wp:details') && ! str_contains($capturedDisclosureMarkup, '/collection') && str_contains($capturedDisclosureMarkup, '<summary>'), 'empty-summary dialog disclosures preserve their source disclosure instead of lowering to a triggerless dialog');
 
 $capturedMenuDisclosure = ( new HtmlTransformer() )->transform('<details class="dla-disclosure"><summary aria-label="Menu"><svg aria-hidden="true"><path d="M0 0h1v1"></path></svg></summary><div class="dla-dialog" role="dialog" aria-label="Site"><nav aria-label="Site"><a href="/">Home</a><a href="/contact">Contact</a></nav></div></details>')->toArray();
 $capturedMenuDisclosureMarkup = (string) ($capturedMenuDisclosure['serialized_blocks'] ?? '');
 $capturedMenuDisclosureBlock = $capturedMenuDisclosure['blocks'][0] ?? array();
-$assert(str_ends_with((string) ($capturedMenuDisclosureBlock['blockName'] ?? ''), '/captured-dialog') && 'core/navigation' === (($capturedMenuDisclosureBlock['innerBlocks'][0] ?? array())['blockName'] ?? null), 'icon-only menu disclosures preserve the captured dialog instead of suppressing its native trigger');
-$assert(str_contains($capturedMenuDisclosureMarkup, '<dialog class="dla-dialog" aria-label="Site">') && str_contains($capturedMenuDisclosureMarkup, '<!-- wp:navigation'), 'icon-only menu disclosures retain a native dialog with editable navigation content');
+$assert('core/details' === ($capturedMenuDisclosureBlock['blockName'] ?? null) && 'core/navigation' === (($capturedMenuDisclosureBlock['innerBlocks'][0]['innerBlocks'][0] ?? array())['blockName'] ?? null), 'icon-only menu disclosures preserve their native trigger and navigation content');
+$assert(str_contains($capturedMenuDisclosureMarkup, '<summary><svg aria-hidden="true">') && str_contains($capturedMenuDisclosureMarkup, '<!-- wp:navigation'), 'icon-only menu disclosures retain an operable summary with editable navigation content');
+
+$linkedCapturedDisclosure = ( new HtmlTransformer() )->transform('<details><summary>&nbsp;</summary><div role="dialog" data-blocks-engine-triggers="menu-trigger"><nav><a href="/about">About</a></nav></div></details>')->toArray();
+$linkedCapturedDisclosureBlock = $linkedCapturedDisclosure['blocks'][0] ?? array();
+$assert(str_ends_with((string) ($linkedCapturedDisclosureBlock['blockName'] ?? ''), '/captured-dialog') && array('menu-trigger') === ($linkedCapturedDisclosureBlock['attrs']['triggerIds'] ?? null), 'explicitly linked captured disclosures lower to the typed dialog block');
 
 $unsafeCapturedDisclosureResult = ( new HtmlTransformer() )->transform('<div class="rich-text"><p>Copyright text</p><details><summary>&nbsp;</summary><div role="dialog"><script>window.open()</script><nav><a href="/about">About</a></nav></div></details></div>')->toArray();
 $unsafeCapturedDisclosureMarkup = (string) ($unsafeCapturedDisclosureResult['serialized_blocks'] ?? '');

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -875,6 +875,17 @@ $capturedMenuDisclosureBlock = $capturedMenuDisclosure['blocks'][0] ?? array();
 $assert('core/details' === ($capturedMenuDisclosureBlock['blockName'] ?? null) && 'core/navigation' === (($capturedMenuDisclosureBlock['innerBlocks'][0]['innerBlocks'][0] ?? array())['blockName'] ?? null), 'icon-only menu disclosures preserve their native trigger and navigation content');
 $assert(str_contains($capturedMenuDisclosureMarkup, '<summary><svg aria-hidden="true">') && str_contains($capturedMenuDisclosureMarkup, '<!-- wp:navigation'), 'icon-only menu disclosures retain an operable summary with editable navigation content');
 
+$capturedMobileMenuDisclosure = ( new ArtifactCompiler() )->compile(
+    array(
+        'entry' => 'index.html',
+        'files' => array(
+            'index.html' => '<header><details class="dla-disclosure"><summary aria-label="Menu"><svg aria-hidden="true"></svg></summary><div class="dla-dialog" role="dialog"><nav class="mobile-nav"><ul><li><a href="/">Home</a></li><li><a href="/about">About</a></li></ul></nav></div></details></header>',
+        ),
+    )
+)->toArray();
+$capturedMobileMenuDisclosureMarkup = (string) ($capturedMobileMenuDisclosure['serialized_blocks'] ?? '');
+$assert(str_contains($capturedMobileMenuDisclosureMarkup, '"overlayMenu":"never"') && ! str_contains($capturedMobileMenuDisclosureMarkup, 'blocks-engine-native-responsive-navigation'), 'navigation inside a captured native disclosure does not create a nested mobile overlay', $capturedMobileMenuDisclosureMarkup);
+
 $linkedCapturedDisclosure = ( new HtmlTransformer() )->transform('<details><summary>&nbsp;</summary><div role="dialog" data-blocks-engine-triggers="menu-trigger"><nav><a href="/about">About</a></nav></div></details>')->toArray();
 $linkedCapturedDisclosureBlock = $linkedCapturedDisclosure['blocks'][0] ?? array();
 $assert(str_ends_with((string) ($linkedCapturedDisclosureBlock['blockName'] ?? ''), '/captured-dialog') && array('menu-trigger') === ($linkedCapturedDisclosureBlock['attrs']['triggerIds'] ?? null), 'explicitly linked captured disclosures lower to the typed dialog block');

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -870,6 +870,12 @@ $assert('core/group' === ($capturedDisclosureRoot['blockName'] ?? null) && 'core
 $assert(str_ends_with((string) ($capturedDisclosureDialog['blockName'] ?? ''), '/captured-dialog') && 'core/navigation' === (($capturedDisclosureDialog['innerBlocks'][0] ?? array())['blockName'] ?? null), 'bounded empty-summary dialog disclosures lower to the typed dialog block with native navigation children');
 $assert(! str_contains($capturedDisclosureMarkup, '<!-- wp:details') && ! str_contains($capturedDisclosureMarkup, '/collection') && str_contains($capturedDisclosureMarkup, '<dialog class="dla-dialog">'), 'empty-summary dialog disclosures avoid both details trigger geometry and collection fallback');
 
+$capturedMenuDisclosure = ( new HtmlTransformer() )->transform('<details class="dla-disclosure"><summary aria-label="Menu"><svg aria-hidden="true"><path d="M0 0h1v1"></path></svg></summary><div class="dla-dialog" role="dialog" aria-label="Site"><nav aria-label="Site"><a href="/">Home</a><a href="/contact">Contact</a></nav></div></details>')->toArray();
+$capturedMenuDisclosureMarkup = (string) ($capturedMenuDisclosure['serialized_blocks'] ?? '');
+$capturedMenuDisclosureBlock = $capturedMenuDisclosure['blocks'][0] ?? array();
+$assert(str_ends_with((string) ($capturedMenuDisclosureBlock['blockName'] ?? ''), '/captured-dialog') && 'core/navigation' === (($capturedMenuDisclosureBlock['innerBlocks'][0] ?? array())['blockName'] ?? null), 'icon-only menu disclosures preserve the captured dialog instead of suppressing its native trigger');
+$assert(str_contains($capturedMenuDisclosureMarkup, '<dialog class="dla-dialog" aria-label="Site">') && str_contains($capturedMenuDisclosureMarkup, '<!-- wp:navigation'), 'icon-only menu disclosures retain a native dialog with editable navigation content');
+
 $unsafeCapturedDisclosureResult = ( new HtmlTransformer() )->transform('<div class="rich-text"><p>Copyright text</p><details><summary>&nbsp;</summary><div role="dialog"><script>window.open()</script><nav><a href="/about">About</a></nav></div></details></div>')->toArray();
 $unsafeCapturedDisclosureMarkup = (string) ($unsafeCapturedDisclosureResult['serialized_blocks'] ?? '');
 $assert(! str_contains($unsafeCapturedDisclosureMarkup, '/captured-dialog') && str_contains($unsafeCapturedDisclosureMarkup, 'Copyright text'), 'runtime-heavy empty-summary dialogs fail closed without swallowing adjacent editable prose');

--- a/php-transformer/tests/unit/navigation-block-normalizer.php
+++ b/php-transformer/tests/unit/navigation-block-normalizer.php
@@ -52,6 +52,16 @@ $assert(1 === count($normalized) && 1 === ($normalized[0]['_source_provenance_id
 $normalized = $normalizer->normalize(array($navigation(1), $navigation(2)), $sourceProvenance, array());
 $assert(1 === count($normalized) && 1 === ($normalized[0]['_source_provenance_id'] ?? null), 'removes a mobile duplicate after preserving the first canonical navigation');
 
+$disclosure = static fn (array $children): array => array(
+    'blockName' => 'core/details',
+    'attrs' => array('className' => 'dla-disclosure'),
+    'innerBlocks' => $children,
+    'innerContent' => array('<details>', null, '</details>'),
+    'innerHTML' => '<details></details>',
+);
+$normalized = $normalizer->normalize(array($disclosure(array($navigation(1))), $disclosure(array($navigation(2))),), $sourceProvenance, array());
+$assert(2 === count($normalized) && 1 === ($normalized[0]['innerBlocks'][0]['_source_provenance_id'] ?? null) && 2 === ($normalized[1]['innerBlocks'][0]['_source_provenance_id'] ?? null), 'keeps responsive navigation variants inside independent native disclosures');
+
 $sourceProvenance[2] = array('source_attributes' => array('class' => 'wsite-menu-default'), 'context' => array('class_names' => array('wsite-menu-default'), 'ancestor_class_names' => array('mobile-nav', 'menu')));
 $normalized = $normalizer->normalize(array($navigation(1), $navigation(2)), $sourceProvenance, array());
 $assert(1 === count($normalized) && 1 === ($normalized[0]['_source_provenance_id'] ?? null), 'recognizes a responsive duplicate from its source ancestor identity');


### PR DESCRIPTION
## Summary
- Preserve native details disclosures that carry a direct captured dialog from hamburger-toggle suppression.
- Keep the icon-only summary and captured navigation available to the existing typed dialog lowering path.
- Add regression coverage for an icon-only menu disclosure.

## Evidence
- `composer test`
- Recompiled the retained Busy Bears run `d490ab2b65a3d10ebe56ffbde52c8c86efa0d8700a930c9040329e2d59f2f0cb` from its staged `website/index.html` payload: the result now contains four captured-dialog block occurrences and native dialog output.
- Follow-up to merged #1584; this fixes the preserved DLA disclosure path rather than changing source capture or SSI materialization.

## Acceptance status
The package-backed Studio `create --from` flow is not exposed by the installed CLI, so fresh WordPress browser click/open/close validation remains pending that runtime contract.

AI assistance: OpenAI gpt-5.6-terra via OpenCode traced the retained staged artifact, identified the Blocks Engine suppression boundary, implemented the scoped fix, and ran the test suite.