### PR TITLE
fix(php-transformer): resolve disclosure icon variables

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -2803,10 +2803,6 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             ),
             ARRAY_FILTER_USE_KEY
         );
-        if ( array() === $carried ) {
-            return '';
-        }
-
         // The label the source painted keeps its classes but loses the toggle
         // ancestor those rules were written against. Its type is inheritable, so
         // restating it on the summary reaches the label again, and any rule the
@@ -2814,12 +2810,17 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
         $carried = array_merge($this->disclosureSummaryLabelTypography($summary), $carried);
 
         $css = $this->styleResolver->cssDeclarationString($carried);
-        if ( '' === $css ) {
+        $descendants = $this->disclosureSummaryDescendantPresentation($summary);
+        if ( '' === $css && array() === $descendants ) {
             return '';
         }
 
-        $marker = 'blocks-engine-disclosure-summary-' . substr(hash('sha256', $css), 0, 12);
-        $this->generatedSupportStyles()->registerDisclosureSummaryPresentation($marker, $css);
+        $marker = 'blocks-engine-disclosure-summary-' . substr(hash('sha256', $css . json_encode($descendants)), 0, 12);
+        $this->generatedSupportStyles()->registerDisclosureSummaryPresentation(
+            $marker,
+            $css,
+            $descendants
+        );
 
         return $marker;
     }
@@ -2863,6 +2864,61 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             ),
             ARRAY_FILTER_USE_KEY
         );
+    }
+
+    /**
+     * Source selectors commonly style an icon through the summary's classes.
+     * core/details drops those classes but retains the summary children, so restate
+     * their resolved presentation under the marker-scoped core summary.
+     *
+     * @return array<string, string>
+     */
+    private function disclosureSummaryDescendantPresentation(DOMElement $summary): array
+    {
+        $rules = array();
+        foreach ($summary->getElementsByTagName('*') as $descendant) {
+            if (! $descendant instanceof DOMElement) {
+                continue;
+            }
+
+            $declarations = $this->styleResolver->safeVisualDeclarations(
+                $this->styleResolver->cssDeclarations(
+                    $this->styleResolver->resolveCssVariablesInValue(
+                        $this->styleResolver->specificityResolvedPresentationStyle($descendant)
+                    )
+                )
+            );
+            $css = $this->styleResolver->cssDeclarationString($declarations);
+            if ('' === $css) {
+                continue;
+            }
+
+            $rules[$this->disclosureSummaryDescendantSelector($summary, $descendant)] = $css;
+        }
+
+        return $rules;
+    }
+
+    private function disclosureSummaryDescendantSelector(DOMElement $summary, DOMElement $descendant): string
+    {
+        $parts = array();
+        for ($node = $descendant; $node !== $summary; $node = $node->parentNode) {
+            if (! $node instanceof DOMElement || ! $node->parentNode instanceof DOMElement) {
+                return '';
+            }
+            $position = 0;
+            foreach ($node->parentNode->childNodes as $sibling) {
+                if ($sibling instanceof DOMElement && strtolower($sibling->tagName) === strtolower($node->tagName)) {
+                    ++$position;
+                }
+                if ($sibling === $node) {
+                    break;
+                }
+            }
+            $parts[] = '>' . strtolower($node->tagName) . ':nth-of-type(' . $position . ')';
+        }
+
+        return implode('', array_reverse($parts));
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -2788,7 +2788,8 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
         $declarations = $this->styleResolver->safeVisualDeclarations(
             $this->styleResolver->cssDeclarations(
                 $this->styleResolver->resolveCssVariablesInValue(
-                    $this->styleResolver->specificityResolvedPresentationStyle($summary)
+                    $this->styleResolver->specificityResolvedPresentationStyle($summary),
+                    $summary
                 )
             )
         );
@@ -2851,7 +2852,8 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
         $declarations = $this->styleResolver->safeVisualDeclarations(
             $this->styleResolver->cssDeclarations(
                 $this->styleResolver->resolveCssVariablesInValue(
-                    $this->styleResolver->specificityResolvedPresentationStyle($label)
+                    $this->styleResolver->specificityResolvedPresentationStyle($label),
+                    $label
                 )
             )
         );
@@ -2884,7 +2886,8 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             $declarations = $this->styleResolver->safeVisualDeclarations(
                 $this->styleResolver->cssDeclarations(
                     $this->styleResolver->resolveCssVariablesInValue(
-                        $this->styleResolver->specificityResolvedPresentationStyle($descendant)
+                        $this->styleResolver->specificityResolvedPresentationStyle($descendant),
+                        $descendant
                     )
                 )
             );

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -2811,17 +2811,12 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
         $carried = array_merge($this->disclosureSummaryLabelTypography($summary), $carried);
 
         $css = $this->styleResolver->cssDeclarationString($carried);
-        $descendants = $this->disclosureSummaryDescendantPresentation($summary);
-        if ( '' === $css && array() === $descendants ) {
+        if ( '' === $css ) {
             return '';
         }
 
-        $marker = 'blocks-engine-disclosure-summary-' . substr(hash('sha256', $css . json_encode($descendants)), 0, 12);
-        $this->generatedSupportStyles()->registerDisclosureSummaryPresentation(
-            $marker,
-            $css,
-            $descendants
-        );
+        $marker = 'blocks-engine-disclosure-summary-' . substr(hash('sha256', $css), 0, 12);
+        $this->generatedSupportStyles()->registerDisclosureSummaryPresentation($marker, $css);
 
         return $marker;
     }
@@ -2866,62 +2861,6 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             ),
             ARRAY_FILTER_USE_KEY
         );
-    }
-
-    /**
-     * Source selectors commonly style an icon through the summary's classes.
-     * core/details drops those classes but retains the summary children, so restate
-     * their resolved presentation under the marker-scoped core summary.
-     *
-     * @return array<string, string>
-     */
-    private function disclosureSummaryDescendantPresentation(DOMElement $summary): array
-    {
-        $rules = array();
-        foreach ($summary->getElementsByTagName('*') as $descendant) {
-            if (! $descendant instanceof DOMElement) {
-                continue;
-            }
-
-            $declarations = $this->styleResolver->safeVisualDeclarations(
-                $this->styleResolver->cssDeclarations(
-                    $this->styleResolver->resolveCssVariablesInValue(
-                        $this->styleResolver->specificityResolvedPresentationStyle($descendant),
-                        $descendant
-                    )
-                )
-            );
-            $css = $this->styleResolver->cssDeclarationString($declarations);
-            if ('' === $css) {
-                continue;
-            }
-
-            $rules[$this->disclosureSummaryDescendantSelector($summary, $descendant)] = $css;
-        }
-
-        return $rules;
-    }
-
-    private function disclosureSummaryDescendantSelector(DOMElement $summary, DOMElement $descendant): string
-    {
-        $parts = array();
-        for ($node = $descendant; $node !== $summary; $node = $node->parentNode) {
-            if (! $node instanceof DOMElement || ! $node->parentNode instanceof DOMElement) {
-                return '';
-            }
-            $position = 0;
-            foreach ($node->parentNode->childNodes as $sibling) {
-                if ($sibling instanceof DOMElement && strtolower($sibling->tagName) === strtolower($node->tagName)) {
-                    ++$position;
-                }
-                if ($sibling === $node) {
-                    break;
-                }
-            }
-            $parts[] = '>' . strtolower($node->tagName) . ':nth-of-type(' . $position . ')';
-        }
-
-        return implode('', array_reverse($parts));
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php
@@ -82,8 +82,11 @@ final class DetailsPattern implements PatternRecognizerInterface
                 $label = trim($summary->getAttribute('data-dla-disclosure-label'));
             }
             if ('' !== $label) {
-                $summaryHtml .= '<span class="screen-reader-text">' . htmlspecialchars($label, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</span>';
+                $summaryHtml .= '<span class="screen-reader-text" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0">' . htmlspecialchars($label, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</span>';
             }
+        }
+        if ($summary instanceof DOMElement) {
+            $summaryHtml = $this->summaryContentCarrier($summary, $summaryHtml);
         }
 
         $attrs = array_merge($presentationAttributes($element), array(
@@ -95,6 +98,24 @@ final class DetailsPattern implements PatternRecognizerInterface
         }
 
         return $createBlock('core/details', array_filter($attrs, static fn ($value): bool => '' !== $value), $children, $element);
+    }
+
+    /**
+     * core/details saves a bare summary, but source CSS often addresses the
+     * summary's classes and responsive data attributes. Keep those safe styling
+     * hooks on its content rather than changing core's saved summary shape.
+     */
+    private function summaryContentCarrier(DOMElement $summary, string $html): string
+    {
+        $attributes = array();
+        foreach (SourceDom::htmlAttributes($summary) as $name => $value) {
+            $lowerName = strtolower($name);
+            if ('class' === $lowerName || 'style' === $lowerName || 'title' === $lowerName || str_starts_with($lowerName, 'data-')) {
+                $attributes[$name] = $value;
+            }
+        }
+
+        return array() === $attributes ? $html : '<span' . SourceDom::htmlAttributeString($attributes) . '>' . $html . '</span>';
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php
@@ -75,8 +75,19 @@ final class DetailsPattern implements PatternRecognizerInterface
             return null;
         }
 
+        $summaryHtml = $summary instanceof DOMElement ? $innerHtml($summary) : '';
+        if ($summary instanceof DOMElement && '' === trim(strip_tags($summaryHtml))) {
+            $label = trim($summary->getAttribute('aria-label'));
+            if ('' === $label) {
+                $label = trim($summary->getAttribute('data-dla-disclosure-label'));
+            }
+            if ('' !== $label) {
+                $summaryHtml .= '<span class="screen-reader-text">' . htmlspecialchars($label, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</span>';
+            }
+        }
+
         $attrs = array_merge($presentationAttributes($element), array(
-            'summary'     => $summary instanceof DOMElement ? $innerHtml($summary) : '',
+            'summary'     => $summaryHtml,
             'showContent' => $element->hasAttribute('open') ? true : '',
         ));
         if ( '' !== $summaryMarker ) {

--- a/php-transformer/src/HtmlToBlocks/Style/GeneratedSupportStylesheetState.php
+++ b/php-transformer/src/HtmlToBlocks/Style/GeneratedSupportStylesheetState.php
@@ -15,7 +15,7 @@ final class GeneratedSupportStylesheetState
     /** @var array<string, string> */
     private array $nativeNavigationToggleRules = array();
 
-    /** @var array<string, string> */
+    /** @var array<string, array{summary: string, descendants: array<string, string>}> */
     private array $disclosureSummaryPresentation = array();
 
     /** @var array<string, string> */
@@ -114,9 +114,13 @@ final class GeneratedSupportStylesheetState
         return array_values($this->navigationInheritedPresentation);
     }
 
-    public function registerDisclosureSummaryPresentation(string $className, string $declarations): void
+    /** @param array<string, string> $descendants */
+    public function registerDisclosureSummaryPresentation(string $className, string $declarations, array $descendants = array()): void
     {
-        $this->disclosureSummaryPresentation[$className] = $declarations;
+        $this->disclosureSummaryPresentation[$className] = array(
+            'summary' => $declarations,
+            'descendants' => $descendants,
+        );
     }
 
     public function registerNavigationLinkIcon(string $className, string $declarations): void
@@ -168,11 +172,16 @@ final class GeneratedSupportStylesheetState
                 $parts[] = '.wp-block-navigation-item.' . $className . '>.wp-block-navigation__submenu-container{background-color:' . $color . '}';
             }
         }
-        foreach ($this->disclosureSummaryPresentation as $className => $declarations) {
+        foreach ($this->disclosureSummaryPresentation as $className => $presentation) {
             if (str_contains($serializedBlocks, $className)) {
                 // core/details owns the summary element, so the source toggle's box is
                 // restated on it from here rather than carried as markup.
-                $parts[] = '.wp-block-details.' . $className . '>summary{' . $declarations . '}';
+                if ('' !== $presentation['summary']) {
+                    $parts[] = '.wp-block-details.' . $className . '>summary{' . $presentation['summary'] . '}';
+                }
+                foreach ($presentation['descendants'] as $selector => $declarations) {
+                    $parts[] = '.wp-block-details.' . $className . '>summary' . $selector . '{' . $declarations . '}';
+                }
             }
         }
         foreach ($this->navigationSpacing as $className => $declarations) {

--- a/php-transformer/src/HtmlToBlocks/Style/GeneratedSupportStylesheetState.php
+++ b/php-transformer/src/HtmlToBlocks/Style/GeneratedSupportStylesheetState.php
@@ -15,7 +15,7 @@ final class GeneratedSupportStylesheetState
     /** @var array<string, string> */
     private array $nativeNavigationToggleRules = array();
 
-    /** @var array<string, array{summary: string, descendants: array<string, string>}> */
+    /** @var array<string, string> */
     private array $disclosureSummaryPresentation = array();
 
     /** @var array<string, string> */
@@ -114,13 +114,9 @@ final class GeneratedSupportStylesheetState
         return array_values($this->navigationInheritedPresentation);
     }
 
-    /** @param array<string, string> $descendants */
-    public function registerDisclosureSummaryPresentation(string $className, string $declarations, array $descendants = array()): void
+    public function registerDisclosureSummaryPresentation(string $className, string $declarations): void
     {
-        $this->disclosureSummaryPresentation[$className] = array(
-            'summary' => $declarations,
-            'descendants' => $descendants,
-        );
+        $this->disclosureSummaryPresentation[$className] = $declarations;
     }
 
     public function registerNavigationLinkIcon(string $className, string $declarations): void
@@ -172,16 +168,11 @@ final class GeneratedSupportStylesheetState
                 $parts[] = '.wp-block-navigation-item.' . $className . '>.wp-block-navigation__submenu-container{background-color:' . $color . '}';
             }
         }
-        foreach ($this->disclosureSummaryPresentation as $className => $presentation) {
+        foreach ($this->disclosureSummaryPresentation as $className => $declarations) {
             if (str_contains($serializedBlocks, $className)) {
                 // core/details owns the summary element, so the source toggle's box is
                 // restated on it from here rather than carried as markup.
-                if ('' !== $presentation['summary']) {
-                    $parts[] = '.wp-block-details.' . $className . '>summary{' . $presentation['summary'] . '}';
-                }
-                foreach ($presentation['descendants'] as $selector => $declarations) {
-                    $parts[] = '.wp-block-details.' . $className . '>summary' . $selector . '{' . $declarations . '}';
-                }
+                $parts[] = '.wp-block-details.' . $className . '>summary{' . $declarations . '}';
             }
         }
         foreach ($this->navigationSpacing as $className => $declarations) {

--- a/php-transformer/tests/unit/menu-chrome-presentation-carry.php
+++ b/php-transformer/tests/unit/menu-chrome-presentation-carry.php
@@ -145,6 +145,29 @@ $assert(
     $iconDisclosure['blocks'] . "\n" . $iconDisclosure['frontend']
 );
 
+// -- Captured menus put the icon's size on a toggle ancestor custom property.
+// The summary class is not part of core/details' save shape, so resolve it at the
+// icon's source cascade scope before carrying the rule to the core summary tree.
+$capturedIconDisclosure = $transform(
+    '<style>.menu-toggle{--size:42px}.menu-toggle .animated-icon{width:var(--size);height:var(--size)}'
+    . '.menu-toggle .animated-icon svg{width:var(--size);height:var(--size)}</style>'
+    . '<details class="dla-disclosure"><summary class="menu-toggle" aria-label="Menu">'
+    . '<div class="animated-icon"><div><svg aria-hidden="true" width="200" height="200"><path d="M0 0h1v1"/></svg></div></div>'
+    . '</summary><div class="dla-dialog" role="dialog"><a href="/">Home</a></div></details>'
+);
+
+$assert(
+    (bool) preg_match('/>summary>div:nth-of-type\(1\)\{[^}]*width:42px[^}]*height:42px/', $capturedIconDisclosure['frontend'])
+        && (bool) preg_match('/>summary>div:nth-of-type\(1\)>div:nth-of-type\(1\)>svg:nth-of-type\(1\)\{[^}]*width:42px[^}]*height:42px/', $capturedIconDisclosure['frontend']),
+    'a captured nested disclosure icon resolves its ancestor-scoped size before core summary projection',
+    $capturedIconDisclosure['frontend']
+);
+$assert(
+    str_contains($capturedIconDisclosure['blocks'], '<span class="screen-reader-text">Menu</span>'),
+    'an icon-only disclosure preserves its accessible source label in core summary markup',
+    $capturedIconDisclosure['blocks']
+);
+
 // -- A disclosure with no authored toggle presentation emits no rule.
 $plain = $transform(
     '<details><summary>More</summary><p>Detail.</p></details><p>Body copy.</p>'

--- a/php-transformer/tests/unit/menu-chrome-presentation-carry.php
+++ b/php-transformer/tests/unit/menu-chrome-presentation-carry.php
@@ -131,6 +131,20 @@ $assert(
     'the emitted summary stays attribute-free, matching core\'s save shape'
 );
 
+// -- A source icon styled through the lost summary classes keeps its control size.
+$iconDisclosure = $transform(
+    '<style>#comp-icon .hamburger .icon{--icon-size:24px;width:var(--icon-size);height:var(--icon-size)}</style>'
+    . '<div id="comp-icon"><details class="dla-disclosure"><summary class="hamburger" aria-label="Menu">'
+    . '<span class="icon"><svg aria-hidden="true"><path d="M0 0h1v1"/></svg></span>Menu</summary>'
+    . '<div class="dla-dialog" role="dialog"><a href="/a/">A</a></div></details><p>Body copy.</p></div>'
+);
+
+$assert(
+    (bool) preg_match('/>summary>span:nth-of-type\(1\)\{[^}]*width:24px[^}]*height:24px/', $iconDisclosure['frontend']),
+    'a disclosure icon keeps its source-sized presentation after summary classes are dropped',
+    $iconDisclosure['blocks'] . "\n" . $iconDisclosure['frontend']
+);
+
 // -- A disclosure with no authored toggle presentation emits no rule.
 $plain = $transform(
     '<details><summary>More</summary><p>Detail.</p></details><p>Body copy.</p>'

--- a/php-transformer/tests/unit/menu-chrome-presentation-carry.php
+++ b/php-transformer/tests/unit/menu-chrome-presentation-carry.php
@@ -131,39 +131,27 @@ $assert(
     'the emitted summary stays attribute-free, matching core\'s save shape'
 );
 
-// -- A source icon styled through the lost summary classes keeps its control size.
-$iconDisclosure = $transform(
-    '<style>#comp-icon .hamburger .icon{--icon-size:24px;width:var(--icon-size);height:var(--icon-size)}</style>'
-    . '<div id="comp-icon"><details class="dla-disclosure"><summary class="hamburger" aria-label="Menu">'
-    . '<span class="icon"><svg aria-hidden="true"><path d="M0 0h1v1"/></svg></span>Menu</summary>'
-    . '<div class="dla-dialog" role="dialog"><a href="/a/">A</a></div></details><p>Body copy.</p></div>'
-);
-
-$assert(
-    (bool) preg_match('/>summary>span:nth-of-type\(1\)\{[^}]*width:24px[^}]*height:24px/', $iconDisclosure['frontend']),
-    'a disclosure icon keeps its source-sized presentation after summary classes are dropped',
-    $iconDisclosure['blocks'] . "\n" . $iconDisclosure['frontend']
-);
-
-// -- Captured menus put the icon's size on a toggle ancestor custom property.
-// The summary class is not part of core/details' save shape, so resolve it at the
-// icon's source cascade scope before carrying the rule to the core summary tree.
+// -- Serialized Busy Bears capture: source responsive rules address the button
+// summary itself. Retaining its classes on a content carrier lets the author CSS,
+// rather than generated pixel rules, size the nested animated icon.
 $capturedIconDisclosure = $transform(
-    '<style>.menu-toggle{--size:42px}.menu-toggle .animated-icon{width:var(--size);height:var(--size)}'
-    . '.menu-toggle .animated-icon svg{width:var(--size);height:var(--size)}</style>'
-    . '<details class="dla-disclosure"><summary class="menu-toggle" aria-label="Menu">'
-    . '<div class="animated-icon"><div><svg aria-hidden="true" width="200" height="200"><path d="M0 0h1v1"/></svg></div></div>'
+    '<details class="dla-disclosure"><summary class="_root_1fj1u_1 hamburger-open-button _button_1fj1u_20 button _fallbackDirection_uix1w_1 wixui-button _hasTransitions_1fj1u_52" data-testid="buttonContent" data-semantic-classname="button" aria-label="Menu">'
+    . '<div class="_animatedIcon_jg4gf_2 animatedIcon icon animated-icon _icon_1fj1u_79" id="animated-icon"><div data-dla-geometry-id="mobile-wrapper-6"><svg id="menu-icon" viewBox="0 0 24 24" width="100%" height="100%"><path d="M0 0h1v1"/></svg></div></div>'
     . '</summary><div class="dla-dialog" role="dialog"><a href="/">Home</a></div></details>'
 );
 
 $assert(
-    (bool) preg_match('/>summary>div:nth-of-type\(1\)\{[^}]*width:42px[^}]*height:42px/', $capturedIconDisclosure['frontend'])
-        && (bool) preg_match('/>summary>div:nth-of-type\(1\)>div:nth-of-type\(1\)>svg:nth-of-type\(1\)\{[^}]*width:42px[^}]*height:42px/', $capturedIconDisclosure['frontend']),
-    'a captured nested disclosure icon resolves its ancestor-scoped size before core summary projection',
+    str_contains($capturedIconDisclosure['blocks'], '<span class="_root_1fj1u_1 hamburger-open-button _button_1fj1u_20 button _fallbackDirection_uix1w_1 wixui-button _hasTransitions_1fj1u_52" data-semantic-classname="button" data-testid="buttonContent">'),
+    'a native details summary retains the captured source selector hooks on its content carrier',
+    $capturedIconDisclosure['blocks']
+);
+$assert(
+    ! str_contains($capturedIconDisclosure['frontend'], '>summary>div:nth-of-type'),
+    'the captured icon keeps source styling hooks without generated descendant projection CSS',
     $capturedIconDisclosure['frontend']
 );
 $assert(
-    str_contains($capturedIconDisclosure['blocks'], '<span class="screen-reader-text">Menu</span>'),
+    str_contains($capturedIconDisclosure['blocks'], '<span class="screen-reader-text" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0">Menu</span>'),
     'an icon-only disclosure preserves its accessible source label in core summary markup',
     $capturedIconDisclosure['blocks']
 );


### PR DESCRIPTION
## Summary
The latest revision replaces flattened descendant CSS with a native summary-content span retaining safe source styling hooks. This lets existing responsive author selectors reach the icon while preserving core/details save markup. Unstyled summaries remain unchanged.

## Verification
- Latest revision: canonical HTML/block contracts, 303 parity fixtures, and 12 menu-presentation assertions pass.
- Diagnostic-only browser change on the real imported page restored SVG width from16px to41.984px with the source classes, without additional presentation CSS. This is causal evidence, not final candidate import acceptance.
- Earlier hand-authored fixture measurements are superseded. Fresh WordPress import verification remains required; keep draft.

## AI Assistance
GPT-5.6 Terra via OpenCode drafted revisions. GPT-6 Astra via OpenCode audited the evidence, identified the retained-class approach, fixed unstyled-summary regressions, and ran the latest tests.