### PR TITLE
fix(php-transformer): collect direct inline styles

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -2517,7 +2517,7 @@ final class ArtifactCompiler
      *
      * @param list<array{path: string, content: string, source_hash: string}> $stylesheets
      * @param array<int, array<string, mixed>> $files
-     * @return list<array{content: string, source_hash: string}>
+     * @return list<array{content: string, source_hash: string, media: string}>
      */
     private function linkedStylesheetPayloads(array $stylesheets, string $sourcePath, array $files): array
     {
@@ -2528,6 +2528,7 @@ final class ArtifactCompiler
                 $payloads[] = array(
                     'content' => $this->artifactRelativeStylesheetContent($content, (string) ($stylesheet['source_path'] ?? $sourcePath), $files),
                     'source_hash' => (string) ($stylesheet['source_hash'] ?? hash('sha256', $content)),
+                    'media' => (string) ($stylesheet['media'] ?? ''),
                 );
             }
         }

--- a/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
@@ -406,7 +406,7 @@ final class ArtifactNormalizer
             foreach ( StyleTagScanner::scan($content) as $style ) {
                 $attributes = $style['attributes'];
                 $css = trim($style['content']);
-                if ( '' === $css || ! $this->isCssType($this->htmlAttribute($attributes, 'type')) ) {
+                if ( '' === $css || ! StyleTagScanner::isCssType($this->htmlAttribute($attributes, 'type')) ) {
                     continue;
                 }
                 $styles[] = array( 'content' => $css, 'media' => $this->htmlAttribute($attributes, 'media'), 'type' => $this->htmlAttribute($attributes, 'type') );
@@ -544,12 +544,6 @@ final class ArtifactNormalizer
         }
         $reservedPaths[$path] = true;
         return $path;
-    }
-
-    private function isCssType(string $type): bool
-    {
-        $type = strtolower(trim($type));
-        return '' === $type || 1 === preg_match("/^text\\/css(?:\\s*;\\s*[!#$%&'*+\\-.^_`|~0-9a-z]+(?:\\s*=\\s*(?:[!#$%&'*+\\-.^_`|~0-9a-z]+|\"(?:[^\"\\\\]|\\\\.)*\"))?)*\\s*$/i", $type);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -17,6 +17,7 @@ use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionReportProjection;
 use Automattic\BlocksEngine\PhpTransformer\Contract\BlockCompilationOutput;
 use Automattic\BlocksEngine\PhpTransformer\Contract\EditabilityReport;
 use Automattic\BlocksEngine\PhpTransformer\Support\ShellLandmarkPolicy;
+use Automattic\BlocksEngine\PhpTransformer\Support\StyleTagScanner;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\CoreBlockCapabilityMatrix;
 use Automattic\BlocksEngine\PhpTransformer\Contract\CoreHtmlFallbackEvidence;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformationOptions;
@@ -1669,12 +1670,7 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
      */
     private function authoredCssText(string $html, string $staticCss): string
     {
-        $embedded = array();
-        if ( 0 < preg_match_all('/<style\b[^>]*>(.*?)<\/style>/is', $html, $matches) ) {
-            $embedded = $matches[1];
-        }
-
-        return trim($staticCss . "\n" . implode("\n", $embedded));
+        return $this->stylesheetAnalysisComposer->combinedAuthorStylesheet($html, $staticCss);
     }
 
     /**
@@ -1861,10 +1857,12 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
         if ( $includeAuthorStyles && '' !== $this->authorStyles()->combinedCss() ) {
             $authorCss = $this->rewriteAuthorStylesheet($this->authorStyles()->combinedCss());
             $split = ( new CssStylesheetTransformer() )->splitLeadingAtRulePreamble($authorCss);
-            if ( '' !== trim($split['preamble']) ) {
-                $authorCssParts[] = $split['preamble'];
+            if ( array() === $this->authorStyles()->stylesheetAssets() ) {
+                if ( '' !== trim($split['preamble']) ) {
+                    $authorCssParts[] = $split['preamble'];
+                }
+                $authorCssParts[] = $split['stylesheet'];
             }
-            $authorCss = $split['stylesheet'];
         }
         $geometryCss = $this->styleResolver->generatedGeometryCss($serializedBlocks);
         if ( '' !== $geometryCss ) {
@@ -2107,8 +2105,47 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             : implode("\n\n", array_column($authorStylesheetProjections, 'content'));
         array_push($afterAuthorCssParts, ...( new RevealAnimationSettler() )->settleRules($settleableAuthorCss));
         $this->materializeStylesheetAsset($beforeAuthorCssParts, 'engine-support', 'before-author', 'engine-support-before-author');
-        $this->materializeStylesheetAsset($authorCssParts, 'author-css', 'author', 'source-author');
+        if ( $includeAuthorStyles && array() !== $this->authorStyles()->stylesheetAssets() ) {
+            foreach ( $authorStylesheetProjections as $projection ) {
+                $this->materializeAuthorStylesheetProjection($projection);
+            }
+        } else {
+            $this->materializeStylesheetAsset($authorCssParts, 'author-css', 'author', 'source-author');
+        }
         $this->materializeStylesheetAsset($afterAuthorCssParts, 'engine-support', 'after-author', 'engine-support-after-author');
+    }
+
+    /** @param array<string, mixed> $projection */
+    private function materializeAuthorStylesheetProjection(array $projection): void
+    {
+        $path = trim((string) ($projection['path'] ?? ''), '/');
+        $css = trim((string) ($projection['content'] ?? ''));
+        if ( '' === $path || '' === $css ) {
+            return;
+        }
+
+        $content = $css . "\n";
+        $hash = hash('sha256', $content);
+        $this->materializedAssets()->register($path, array(
+            'source' => 'author-css',
+            'source_path' => (string) ($projection['source_path'] ?? ''),
+            'path' => $path,
+            'target_path' => $path,
+            'kind' => 'css',
+            'role' => 'stylesheet',
+            'stylesheet_placement' => 'author',
+            'stylesheet_target' => 'both',
+            'mime_type' => 'text/css',
+            'media_type' => 'text/css',
+            'media' => (string) ($projection['media'] ?? ''),
+            'type' => (string) ($projection['type'] ?? ''),
+            'content' => $content,
+            'bytes' => strlen($content),
+            'encoding' => 'utf-8',
+            'binary' => false,
+            'hash' => $hash,
+            'source_hash' => (string) ($projection['source_hash'] ?? $hash),
+        ));
     }
 
     private function richTextMarkerResetCss(): string
@@ -2139,6 +2176,9 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
                 'bytes'       => strlen($content),
                 'hash'        => $hash,
                 'source_hash' => $asset['source_hash'],
+                'source_path' => $asset['source_path'],
+                'media'       => $asset['media'],
+                'type'        => $asset['type'] ?? '',
                 'attribute_state_markers' => $this->authorSelectorProjections()->attributeNegationMarkers(),
             );
         }
@@ -3146,6 +3186,13 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
         // Stylesheet and document-resource links are collected by the artifact
         // compiler. They are metadata, not page-content blocks.
         if ( 'link' === $tagName ) {
+            return null;
+        }
+
+        // Source styles are collected before DOM conversion and materialized as
+        // author stylesheet assets. A collected CSS style is therefore not an
+        // unsupported content element.
+        if ( 'style' === $tagName && StyleTagScanner::isCssType($this->attr($element, 'type')) ) {
             return null;
         }
 

--- a/php-transformer/src/HtmlToBlocks/Style/AuthorSelectorSemanticPreparer.php
+++ b/php-transformer/src/HtmlToBlocks/Style/AuthorSelectorSemanticPreparer.php
@@ -28,6 +28,22 @@ final class AuthorSelectorSemanticPreparer
         HtmlTransformerSession $session
     ): void {
         $stylesheetAssets = $this->stylesheetAnalysisComposer->authorStylesheetAssetsFromOptions($options);
+        if ( array() === $stylesheetAssets ) {
+            $stylesheetAssets = $this->stylesheetAnalysisComposer->inlineAuthorStylesheetAssets($html);
+            $staticCss = trim($staticCss);
+            if ( '' !== $staticCss ) {
+                $stylesheetAssets[] = array(
+                    'path' => 'static-style.css',
+                    // static_css predates explicit source assets and reports as
+                    // inline-style in the public fallback provenance contract.
+                    'source_path' => 'inline-style',
+                    'content' => $staticCss,
+                    'source_hash' => hash('sha256', $staticCss),
+                    'media' => '',
+                    'type' => '',
+                );
+            }
+        }
         $combinedAuthorCss = array() === $stylesheetAssets
             ? $this->stylesheetAnalysisComposer->combinedAuthorStylesheet($html, $staticCss)
             : implode("\n\n", array_column($stylesheetAssets, 'content'));

--- a/php-transformer/src/HtmlToBlocks/Style/StylesheetAnalysisComposer.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StylesheetAnalysisComposer.php
@@ -41,7 +41,11 @@ final class StylesheetAnalysisComposer
     public function stylesheetPayloads(string $html, string $staticCss, array $options): array
     {
         $staticPayloads = $this->staticStylesheetPayloads($staticCss, $options);
-        $inlinePayloads = $this->inlineStylesheetPayloads($html);
+        // Artifact compilation supplies every stylesheet occurrence, including
+        // inline styles, in document order through stylesheet_payloads.
+        $inlinePayloads = is_array($options['stylesheet_payloads'] ?? null)
+            ? array()
+            : $this->inlineStylesheetPayloads($html);
         $payloads = array_merge($staticPayloads, $inlinePayloads);
         if ( ! $this->hasSafeStylesheetBoundaries($payloads) ) {
             // Preserve the legacy parser's recovery across a concatenated stream.
@@ -208,7 +212,12 @@ final class StylesheetAnalysisComposer
         $payloads = array();
         foreach ( $options['stylesheet_payloads'] as $payload ) {
             if ( is_array($payload) && is_string($payload['content'] ?? null) ) {
-                $payloads[] = $payload['content'];
+                $content = $payload['content'];
+                $media = is_string($payload['media'] ?? null) ? trim($payload['media']) : '';
+                // A link/style media attribute scopes the entire stylesheet.
+                // Preserve that scope for presentation analysis just as emitted
+                // stylesheet assets preserve it for browser rendering.
+                $payloads[] = '' === $media ? $content : '@media ' . $media . '{' . $content . '}';
             }
         }
 

--- a/php-transformer/src/HtmlToBlocks/Style/StylesheetAnalysisComposer.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StylesheetAnalysisComposer.php
@@ -22,6 +22,9 @@ final class StylesheetAnalysisComposer
     {
         $cssParts = array();
         foreach ( StyleTagScanner::scan($html) as $style ) {
+            if ( ! StyleTagScanner::isCssType(StyleTagScanner::attribute($style['attributes'], 'type')) ) {
+                continue;
+            }
             $styleBlock = trim(html_entity_decode($style['content'], ENT_QUOTES | ENT_HTML5, 'UTF-8'));
             if ( '' !== $styleBlock ) {
                 $cssParts[] = $styleBlock;
@@ -173,6 +176,29 @@ final class StylesheetAnalysisComposer
         return $assets;
     }
 
+    /** @return list<array{path: string, source_path: string, content: string, source_hash: string, media: string, type: string}> */
+    public function inlineAuthorStylesheetAssets(string $html): array
+    {
+        $assets = array();
+        foreach ( StyleTagScanner::scan($html) as $index => $style ) {
+            $type = StyleTagScanner::attribute($style['attributes'], 'type');
+            $content = trim(html_entity_decode($style['content'], ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+            if ( '' === $content || ! StyleTagScanner::isCssType($type) ) {
+                continue;
+            }
+            $assets[] = array(
+                'path' => 'inline-style-' . ($index + 1) . '.css',
+                'source_path' => 'inline-style',
+                'content' => $content,
+                'source_hash' => hash('sha256', $content),
+                'media' => StyleTagScanner::attribute($style['attributes'], 'media'),
+                'type' => $type,
+            );
+        }
+
+        return $assets;
+    }
+
     /** @param array<string, mixed> $options @return list<string> */
     private function staticStylesheetPayloads(string $staticCss, array $options): array
     {
@@ -192,7 +218,13 @@ final class StylesheetAnalysisComposer
     /** @return list<string> */
     private function inlineStylesheetPayloads(string $html): array
     {
-        return array_map(static fn (array $style): string => trim($style['content']), StyleTagScanner::scan($html));
+        return array_values(array_map(
+            static fn (array $style): string => trim($style['content']),
+            array_filter(
+                StyleTagScanner::scan($html),
+                static fn (array $style): bool => StyleTagScanner::isCssType(StyleTagScanner::attribute($style['attributes'], 'type'))
+            )
+        ));
     }
 
     /** @param list<string> $payloads */

--- a/php-transformer/src/Support/StyleTagScanner.php
+++ b/php-transformer/src/Support/StyleTagScanner.php
@@ -5,6 +5,21 @@ namespace Automattic\BlocksEngine\PhpTransformer\Support;
 
 final class StyleTagScanner
 {
+    public static function isCssType(string $type): bool
+    {
+        $type = strtolower(trim($type));
+        return '' === $type || 1 === preg_match("/^text\\/css(?:\\s*;\\s*[!#$%&'*+\\-.^_`|~0-9a-z]+(?:\\s*=\\s*(?:[!#$%&'*+\\-.^_`|~0-9a-z]+|\"(?:[^\"\\\\]|\\\\.)*\"))?)*\\s*$/i", $type);
+    }
+
+    public static function attribute(string $attributes, string $name): string
+    {
+        if ( 1 !== preg_match('/(?:^|\\s)' . preg_quote($name, '/') . '\\s*=\\s*(?:"([^"]*)"|\\\'([^\\\']*)\\\'|([^\\s>]+))/i', $attributes, $matches) ) {
+            return '';
+        }
+
+        return html_entity_decode((string) ($matches[1] ?? $matches[2] ?? $matches[3] ?? ''), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    }
+
     /**
      * @return list<array{attributes:string,content:string,offset:int,end_offset:int}>
      */

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -5573,6 +5573,16 @@ $htmlAssetResult = $bridge->convertResult('<style>.logo{display:inline-flex}</st
 $htmlAssetCss = implode("\n", array_map(static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '', $htmlAssetResult['assets'] ?? array()));
 assertSame('core/paragraph', $htmlAssetResult['blocks'][0]['blockName'] ?? '', 'HTML format conversion should keep a classed-span text logo on the paragraph path.');
 assertStringContains('.logo{display:inline-flex}', $htmlAssetCss, 'HTML format conversion should preserve generated author stylesheet assets.');
+$inlineStyleFixture = '<section class="card"><style>.card{color:rebeccapurple}</style><style type="text/css" media="(min-width:40rem)">.card{padding:1rem}</style><h1>Card</h1></section>';
+$directInlineStyleResult = (new HtmlTransformer())->transform($inlineStyleFixture)->toArray();
+$artifactInlineStyleResult = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => $inlineStyleFixture)))->toArray();
+$directInlineStyleAssets = array_values(array_filter($directInlineStyleResult['assets'], static fn (array $asset): bool => 'author-css' === ($asset['source'] ?? '') && 'css' === ($asset['kind'] ?? '')));
+$directInlineStyleCss = implode("\n", array_column($directInlineStyleAssets, 'content'));
+assertSame(array(), array_values(array_filter($directInlineStyleResult['fallbacks'], static fn (array $fallback): bool => 'style' === ($fallback['tag'] ?? ''))), 'Direct HTML conversion collects nested CSS style elements instead of emitting unsupported fallbacks.');
+assertSame(array(), array_values(array_filter($artifactInlineStyleResult['fallbacks'], static fn (array $fallback): bool => 'style' === ($fallback['tag'] ?? ''))), 'Artifact compilation keeps collected nested CSS style elements out of fallbacks.');
+assertSame(true, str_contains($directInlineStyleCss, '.card{color:rebeccapurple}') && str_contains($directInlineStyleCss, '.card{padding:1rem}') && strpos($directInlineStyleCss, '.card{color:rebeccapurple}') < strpos($directInlineStyleCss, '.card{padding:1rem}'), 'Direct HTML stylesheet assets retain nested style source order.');
+assertSame(true, array('both', 'both') === array_column($directInlineStyleAssets, 'stylesheet_target') && array('', '(min-width:40rem)') === array_column($directInlineStyleAssets, 'media') && array('', 'text/css') === array_column($directInlineStyleAssets, 'type'), 'Direct HTML stylesheet assets preserve media/type scope and remain applicable in frontend and editor contexts.');
+assertSame(true, str_contains(implode("\n", array_column($artifactInlineStyleResult['assets'], 'content')), '.card{color:rebeccapurple}') && str_contains(implode("\n", array_column($artifactInlineStyleResult['assets'], 'content')), '.card{padding:1rem}'), 'Artifact compilation retains the same nested stylesheet content.');
 assertSame('blocks-engine/php-transformer/wp-block-validity-report/v1', $htmlAssetResult['source_reports']['wp_block_validity']['schema'] ?? '', 'HTML format conversion should preserve source transformer reports.');
 $strictHtmlResult = $bridge->convertResult(
     '<main><applet code="clock.class"></applet></main>',

--- a/php-transformer/tests/fixtures/parity/html-source-attribute-selector-projection.json
+++ b/php-transformer/tests/fixtures/parity/html-source-attribute-selector-projection.json
@@ -20,9 +20,7 @@
     { "path": "blocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "Label" } },
     { "path": "blocks.1", "name": "core/paragraph", "attrs": { "content": "Visible" } }
   ],
-  "expected_fallbacks": [
-    { "type": "unsupported_element", "tag": "style", "severity": "info" }
-  ],
+  "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "serialized_blocks", "assert": "contains", "value": "blocks-engine-attribute-" },

--- a/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
+++ b/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
@@ -292,6 +292,25 @@ $assert('(min-width: 48rem)' === (($embeddedStyleAssets[2]['media'] ?? '')), 'em
 $assert(str_contains($embeddedStyleContents, '.hero{background:url("images/banner.svg")}'), 'embedded CSS URL references retain canonical artifact-relative resolution');
 $assert(array() === $styleFallbacks && 1 === count($unsupportedBodyFallbacks), 'materialized style elements avoid unsupported-element fallbacks while genuine unsupported body elements remain reported');
 
+// Stylesheet occurrences must keep source order for analysis, but a media
+// attribute must remain a condition rather than becoming unconditional input.
+$mediaScopedCascade = ( new ArtifactCompiler() )->compile(array(
+    'entrypoint' => 'index.html',
+    'files' => array(
+        array( 'path' => 'index.html', 'kind' => 'html', 'content' => '<style>.card{display:grid}</style><link rel="stylesheet" href="screen.css"><link rel="stylesheet" href="print.css" media="print"><main><div class="card"><p>One</p><p>Two</p></div></main>' ),
+        array( 'path' => 'screen.css', 'kind' => 'css', 'content' => '.card{display:block}' ),
+        array( 'path' => 'print.css', 'kind' => 'css', 'content' => '.card{display:grid}' ),
+    ),
+) )->toArray();
+$mediaScopedAssets = array_column($mediaScopedCascade['assets'] ?? array(), null, 'path');
+$mediaScopedMarkup = (string) ($mediaScopedCascade['serialized_blocks'] ?? '');
+$assert(
+    ! str_contains($mediaScopedMarkup, 'blocks-engine-css-owned-grid')
+        && 'print' === ($mediaScopedAssets['print.css']['media'] ?? null)
+        && 1 === substr_count((string) ($mediaScopedAssets['print.css']['content'] ?? ''), '.card{display:grid}'),
+    'source-ordered inline and linked styles resolve the screen layout without treating print-only CSS as unconditional, while the print stylesheet is emitted once with its media scope'
+);
+
 $image = ( new ArtifactCompiler() )->compile(array(
     'files' => array(
         array( 'path' => 'index.html', 'kind' => 'html', 'content' => '<link rel="stylesheet" href="image.css"><img class="root-photo" src="photo.jpg" alt="Root photo"><main><img class="photo relative-photo" src="photo.jpg" alt="Photo"></main>' ),


### PR DESCRIPTION
## Summary

Fixes #1623.

Collect direct HTML inline styles through the existing author-stylesheet pipeline rather than converting already-collected CSS nodes into unsupported blocks. Preserve occurrence order, media, and type metadata. Keep media constraints in presentation analysis as well as emitted assets, and avoid re-adding inline styles when artifact compilation supplied the ordered stylesheet list.

## Verification

From `php-transformer/`:

- `composer test:canonical`: passed.
- `composer test:parity`: 303 fixtures passed.
- `composer test:packaging`: passed.
- `php tests/unit/artifact-author-stylesheet-projection.php`: passed, including mixed inline/external order and print-only layout negative coverage.
- `composer validate --strict`: passed.

Real Studio URL import using Studio draft #3952 at `0920bd364`, SSI `cda5b2d3`, and this candidate `a854528b7` completed all six routes of the public Potted Plant Design source with **zero fallbacks**, compared with 114 on the original producer. Build the paired SSI development ZIP against this branch, then use Studio's `create --from https://www.pottedplantdesign.com/ --static-site-importer-path <paired-zip>` to reproduce.

This is a scoped conversion repair, not a claim of full site parity. The follow-up existing-runtime review still reports desktop/mobile layout differences despite valid blocks. The standalone WordPress integration suite was unavailable because `WP_TESTS_DIR` was not configured; the Studio import supplied the real materialization check.

## AI Assistance

GPT-5.6 Terra via OpenCode implemented and self-reviewed the repair, added regressions, and ran producer gates. GPT-6 Astra via OpenCode reviewed the candidate, requested media/order corrections, and ran the paired Studio URL import and existing-runtime review. Chris directed the work and authorized direct execution while the orchestration control plane was blocked.
