### PR TITLE
Produce semantic validation outcomes before report projection

### DIFF
--- a/php-transformer/docs/html-validation-outcome-consumer-inventory.md
+++ b/php-transformer/docs/html-validation-outcome-consumer-inventory.md
@@ -1,12 +1,12 @@
 # HTML Validation Outcome Consumer Inventory
 
-`HtmlCompilation` evaluates block validity, semantic parity, and content round-trip once. It constructs `Contract\HtmlValidationOutcome` at that producer boundary and carries it in `BlockCompilationOutput`.
+`HtmlCompilation` evaluates block validity, semantic parity, and content round-trip once. `SemanticParityReporter::evaluate()` owns the semantic status, detailed enriched findings, landmark counts, and menu pairing/folding facts. Its `report()` facade projects the unchanged detailed report, while `HtmlCompilation` passes the evaluation's status and findings directly to `Contract\HtmlValidationOutcome`, which it carries in `BlockCompilationOutput`.
 
 | Consumer | Required facts | Source |
 | --- | --- | --- |
 | `DiagnosticsCollector` | validator finding code, summary, severity, and the diagnostic-specific location field | `HtmlValidationOutcome` |
 | `HtmlCompilation` result status | fallback/strict-context acceptance only | unchanged; validator outcomes do not alter existing status policy |
 | `ArtifactCompiler`, staged plans, and `WordPressSitePlan` | flattened diagnostics and their severities for artifact acceptance | existing `TransformerResult::diagnostics`, populated from `HtmlValidationOutcome` |
-| `HtmlResultComposer` and `ConversionReportProjection` | full detailed validator evidence | unchanged `source_reports.wp_block_validity`, `semantic_parity`, and `content_round_trip`; semantic parity remains projected into `conversion_report` |
+| `HtmlResultComposer` and `ConversionReportProjection` | full detailed validator evidence | unchanged `source_reports.wp_block_validity`, `semantic_parity`, and `content_round_trip`; `SemanticParityEvaluation::report()` supplies semantic parity and it remains projected into `conversion_report` |
 
-The required outcome stores each validator status plus only the original finding keys used to emit diagnostics. Values remain mixed because the existing collector preserves any non-null severity and location value; it owns the existing defaults for missing or null `summary` and `severity`. Detailed report-only evidence remains outside the outcome and is serialized only through the existing report projections. Empty and parse-failure HTML results carry `BlockCompilationOutput::empty()` with explicit empty, `not_evaluated` validation outcomes.
+The required outcome stores each validator status plus only the original finding keys used to emit diagnostics. Semantic facts come from the evaluation, not from a report map. Values remain mixed because the existing collector preserves any non-null severity and location value; it owns the existing defaults for missing or null `summary` and `severity`. Detailed report-only evidence remains outside the outcome and is serialized only through the existing report projections. Empty and parse-failure HTML results carry `BlockCompilationOutput::empty()` with explicit empty, `not_evaluated` validation outcomes.

--- a/php-transformer/src/Contract/HtmlValidationOutcome.php
+++ b/php-transformer/src/Contract/HtmlValidationOutcome.php
@@ -40,6 +40,30 @@ final class HtmlValidationOutcome
         );
     }
 
+    /**
+     * Semantic parity is evaluated by its producer; its detailed report remains
+     * a projection rather than the source of required diagnostic facts.
+     *
+     * @param array<string, mixed> $blockValidityReport
+     * @param array<int, array<string, mixed>> $semanticParityFindings
+     * @param array<string, mixed> $contentRoundTripReport
+     */
+    public static function fromBlockValidityAndContentRoundTripReports(
+        array $blockValidityReport,
+        string $semanticParityStatus,
+        array $semanticParityFindings,
+        array $contentRoundTripReport
+    ): self {
+        return new self(
+            blockValidityStatus: self::status($blockValidityReport),
+            blockValidityFindings: self::findings($blockValidityReport, array('block_name', 'path')),
+            semanticParityStatus: $semanticParityStatus,
+            semanticParityFindings: self::findings(array('findings' => $semanticParityFindings), array('selector')),
+            contentRoundTripStatus: self::status($contentRoundTripReport),
+            contentRoundTripFindings: self::findings($contentRoundTripReport, array('text'))
+        );
+    }
+
     /** @param array<string, mixed> $report */
     private static function status(array $report): string
     {

--- a/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityEvaluation.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityEvaluation.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics;
+
+use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionFindingContract;
+
+/**
+ * The single semantic-parity evaluation, projected as a detailed report or
+ * consumed directly by required validation diagnostics.
+ */
+final class SemanticParityEvaluation
+{
+    /**
+     * @param array<string, int> $sourceLandmarks
+     * @param array<string, int> $blockLandmarks
+     * @param array<int, array<string, mixed>> $sourceMenus
+     * @param array<int, array<string, mixed>> $blockMenus
+     * @param array<int, array<string, mixed>> $findings
+     */
+    public function __construct(
+        public readonly array $sourceLandmarks,
+        public readonly array $blockLandmarks,
+        public readonly array $sourceMenus,
+        public readonly array $blockMenus,
+        public readonly array $findings
+    ) {
+    }
+
+    public function status(): string
+    {
+        return array() === $this->findings ? 'pass' : 'warning';
+    }
+
+    /** @return array<string, mixed> */
+    public function report(): array
+    {
+        return array(
+            'schema' => 'blocks-engine/php-transformer/semantic-parity/v1',
+            'finding_schema' => ConversionFindingContract::SCHEMA,
+            'status' => $this->status(),
+            'landmarks' => array(
+                'source' => $this->sourceLandmarks,
+                'blocks' => $this->blockLandmarks,
+            ),
+            'navigation_menus' => array(
+                'source' => $this->sourceMenus,
+                'blocks' => $this->blockMenus,
+            ),
+            'findings' => $this->findings,
+        );
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
@@ -44,7 +44,6 @@ final class SemanticParityReporter
     /**
      * @param array<int, array<string, mixed>> $blocks
      * @param array<int, array<string, mixed>> $sourceProvenance
-     * @return array<string, mixed>
      */
     public function evaluate(DOMElement $body, array $blocks, array $sourceProvenance, string $html = '', string $staticCss = ''): SemanticParityEvaluation
     {

--- a/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
@@ -46,7 +46,7 @@ final class SemanticParityReporter
      * @param array<int, array<string, mixed>> $sourceProvenance
      * @return array<string, mixed>
      */
-    public function report(DOMElement $body, array $blocks, array $sourceProvenance, string $html = '', string $staticCss = ''): array
+    public function evaluate(DOMElement $body, array $blocks, array $sourceProvenance, string $html = '', string $staticCss = ''): SemanticParityEvaluation
     {
         $sourceLandmarks = $this->sourceLandmarkReport($body);
         $blockLandmarks = $this->blockLandmarkReport($blocks, $sourceProvenance, $sourceLandmarks);
@@ -76,20 +76,23 @@ final class SemanticParityReporter
             $findings
         );
 
-        return array(
-            'schema' => 'blocks-engine/php-transformer/semantic-parity/v1',
-            'finding_schema' => ConversionFindingContract::SCHEMA,
-            'status' => array() === $findings ? 'pass' : 'warning',
-            'landmarks' => array(
-                'source' => $sourceLandmarks['counts'],
-                'blocks' => $blockLandmarks['counts'],
-            ),
-            'navigation_menus' => array(
-                'source' => $sourceMenus,
-                'blocks' => $blockMenus,
-            ),
-            'findings' => $findings,
+        return new SemanticParityEvaluation(
+            sourceLandmarks: $sourceLandmarks['counts'],
+            blockLandmarks: $blockLandmarks['counts'],
+            sourceMenus: $sourceMenus,
+            blockMenus: $blockMenus,
+            findings: $findings
         );
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks
+     * @param array<int, array<string, mixed>> $sourceProvenance
+     * @return array<string, mixed>
+     */
+    public function report(DOMElement $body, array $blocks, array $sourceProvenance, string $html = '', string $staticCss = ''): array
+    {
+        return $this->evaluate($body, $blocks, $sourceProvenance, $html, $staticCss)->report();
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -1292,9 +1292,15 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
         );
         $this->navigationStyleProjector->materializeEditorStaticStateStylesheet();
         $blockValidityReport = $this->runtime->validateBlockSerialization($blocks);
-        $semanticParityReport = $this->semanticParityReporter->report($body, $blocks, $sourceProvenance, $html, (string) ($options['static_css'] ?? ''));
+        $semanticParityEvaluation = $this->semanticParityReporter->evaluate($body, $blocks, $sourceProvenance, $html, (string) ($options['static_css'] ?? ''));
+        $semanticParityReport = $semanticParityEvaluation->report();
         $contentRoundTripReport = $this->contentRoundTripReporter->report($serializedBlocks, $html, $this->transformationEvidence()->formControlEchoTexts());
-        $validationOutcome = \Automattic\BlocksEngine\PhpTransformer\Contract\HtmlValidationOutcome::fromReports($blockValidityReport, $semanticParityReport, $contentRoundTripReport);
+        $validationOutcome = \Automattic\BlocksEngine\PhpTransformer\Contract\HtmlValidationOutcome::fromBlockValidityAndContentRoundTripReports(
+            $blockValidityReport,
+            $semanticParityEvaluation->status(),
+            $semanticParityEvaluation->findings,
+            $contentRoundTripReport
+        );
         $diagnostics = $this->diagnosticsCollector->collect(
             HtmlTransformer::class,
             $this->runtimeBehavior()->scriptMetadata(),

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -134,12 +134,17 @@ $assert(
         && $validationOutcome->contentRoundTripStatus === ($validationOutcomeReports['content_round_trip']['status'] ?? null)
         && array_map(static fn (array $finding): string => $finding['code'], $validationOutcome->blockValidityFindings) === array_map(static fn (array $finding): string => (string) ($finding['code'] ?? ''), $validationOutcomeReports['wp_block_validity']['findings'] ?? array())
         && array_map(static fn (array $finding): string => $finding['code'], $validationOutcome->semanticParityFindings) === array_map(static fn (array $finding): string => (string) ($finding['code'] ?? ''), $validationOutcomeReports['semantic_parity']['findings'] ?? array())
+        && $validationOutcome->semanticParityFindings === array_map(
+            static fn (array $finding): array => array_intersect_key($finding, array_flip(array('code', 'summary', 'severity', 'selector'))),
+            $validationOutcomeReports['semantic_parity']['findings'] ?? array()
+        )
         && array_map(static fn (array $finding): string => $finding['code'], $validationOutcome->contentRoundTripFindings) === array_map(static fn (array $finding): string => (string) ($finding['code'] ?? ''), $validationOutcomeReports['content_round_trip']['findings'] ?? array()),
-    'producer-owned required validation outcomes retain each detailed report status and every diagnostic finding while reports remain projections'
+    'semantic evaluation directly supplies required diagnostic facts while its full report remains an identical projection'
 );
-$validationFailureOutcome = HtmlValidationOutcome::fromReports(
+$validationFailureOutcome = HtmlValidationOutcome::fromBlockValidityAndContentRoundTripReports(
     array('status' => 'fail', 'findings' => array(array('code' => 'invalid_save', 'summary' => null, 'severity' => 0, 'block_name' => false, 'path' => 12, 'verbose_evidence' => array('not-needed')))),
-    array('status' => 'fail', 'findings' => array(array('code' => 'missing_landmark', 'severity' => null, 'selector' => 0, 'verbose_evidence' => array('not-needed')))),
+    'fail',
+    array(array('code' => 'missing_landmark', 'severity' => null, 'selector' => 0, 'verbose_evidence' => array('not-needed'))),
     array('status' => 'fail', 'findings' => array(array('code' => 'invented_text', 'summary' => null, 'severity' => false, 'text' => array('unexpected'), 'verbose_evidence' => array('not-needed'))))
 );
 $validationFailureDiagnostics = (new DiagnosticsCollector())->collect('Example\\Transformer', array(), array(), array(), array(), array(), $validationFailureOutcome);


### PR DESCRIPTION
## Summary

Continue #1360 by completing the semantic-parity producer boundary introduced on the consumer side in #1627.

- `SemanticParityReporter::evaluate()` performs the existing analysis once and returns authoritative findings and comparison facts.
- `SemanticParityEvaluation` supplies status directly and projects the unchanged full semantic report.
- `HtmlCompilation` consumes semantic status/findings from the evaluation, not from the full report map.
- Preserve the shipped `report()` API as a projection facade over evaluation.
- Keep block-validity/content-round-trip paths, uncomputed outcomes, default full reporting, diagnostics and acceptance behavior unchanged.

Landmark/nav counting, menu pairing and carrier folding, typography and finding enrichment retain their existing sequencing. There is no reduced-evidence mode, skipped validation, or performance claim in this change.

## Verification

Baseline: `6a50fba0d8874778b92f2d5b22ec9ff2d57a65eb`.
Candidate: `091f5dcd3ee14b4c36bc5cd1fb699c868cbec426` (implementation plus return-documentation correction).

- Full Composer suites passed for baseline and candidate in PHP 8.4 lab containers with 512 MB PHP configuration inherited by child commands, including canonical/unit/parity/packaging/install proof.
- Agent comparison: 231 HTML parity inputs retain identical blocks and complete envelopes, excluding only recursive `transform_duration_ms`.
- Coordinator additionally ran the full 385-document HTML corpus and targeted HTML/artifact comparison, including nonzero companion/runtime/style/shared-shell/responsive outputs. Complete comparison records are byte-identical, SHA-256 `bf7a12f997cd6c8d47d9483bf50e6e3c215fe481f75b505cf405d5ad175446a2`.
- Existing semantic failure/pass, navigation pairing, carrier folding and typography coverage passed; direct semantic required-fact tests retain mixed/null value behavior.
- Stable comparisons use PHP serialization for binary bytes and array ordering, not lossy JSON replacement.
- WordPress integration was unavailable locally because `WP_TESTS_DIR` was unset; actual CI and solved-site promotion remain required.

## Reproduce

From `php-transformer`, after dependency installation and configuring child PHP memory:

```sh
composer test
REQUIRE_WP_TESTS=1 WP_TESTS_DIR=/path/to/wordpress-tests composer test:wordpress-integration
```

The full-corpus command in [#1627](https://github.com/Automattic/blocks-engine/pull/1627) applies unchanged: run it in separate checkouts of the baseline and candidate above with matching dependencies and compare outputs. The updated consumer inventory is `php-transformer/docs/html-validation-outcome-consumer-inventory.md`.

## AI Assistance

OpenAI GPT-5.6 Terra via direct OpenCode implemented and lab-tested the producer boundary. GPT-6 Astra via OpenCode coordinated and reviewed the data flow, corrected the evaluation return documentation, independently expanded verification to the full corpus and targeted artifacts, and prepared this PR under Chris Huber's direction. No release or deployment was performed.
