### PR TITLE
fix(php-transformer): honor explicit block flow before inferring columns

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
@@ -157,6 +157,12 @@ final class ColumnsPattern implements PatternRecognizerInterface
             return false;
         }
 
+        // Semantic sidebar/content names can suggest a split layout only when
+        // author CSS does not explicitly retain normal document flow.
+        if ( preg_match('/(?:^|;)\s*display\s*:\s*(?:block|inline|flow-root|contents)\b/', $style) ) {
+            return false;
+        }
+
         // core/columns is a flex layout. Preserve resolved grid containers as
         // groups so their source classes continue to control track geometry.
         if ( preg_match('/(?:^|;)\s*display\s*:\s*(?:inline-)?grid\b/', $style) ) {

--- a/php-transformer/tests/unit/block-style-support-conversion.php
+++ b/php-transformer/tests/unit/block-style-support-conversion.php
@@ -295,6 +295,14 @@ $nativeColumnsResult = ( new HtmlTransformer() )->transform($nativeColumnsHtml, 
 $nativeColumnsBlock = $nativeColumnsResult['blocks'][0] ?? array();
 $assert('core/columns' === ($nativeColumnsBlock['blockName'] ?? ''), '29: explicit native Columns markup remains core Columns', (string) ($nativeColumnsBlock['blockName'] ?? '(none)'));
 
+$blockFlowSidebarHtml = '<div class="plain-wrapper"><aside>Sidebar</aside><main>Content</main></div>';
+$blockFlowSidebarResult = ( new HtmlTransformer() )->transform($blockFlowSidebarHtml, array('static_css' => '.plain-wrapper{display:block}.lightbox{display:none}'))->toArray();
+$blockFlowSidebarBlock = $blockFlowSidebarResult['blocks'][0] ?? array();
+$blockFlowSidebarMarkup = (string) ($blockFlowSidebarResult['serialized_blocks'] ?? '');
+
+$assert('core/group' === ($blockFlowSidebarBlock['blockName'] ?? ''), '29a: explicit block flow overrides semantic sidebar/content column inference', (string) ($blockFlowSidebarBlock['blockName'] ?? '(none)'));
+$assert(! str_contains($blockFlowSidebarMarkup, '<!-- wp:columns'), '29b: explicit block flow never serializes core Columns', $blockFlowSidebarMarkup);
+
 $labelHtml = '<section class="pricing"><div class="section-head"><div class="tag" style="padding:4px 12px;border:1px solid #6b4f2d;border-radius:100px;background:#f2e3c6;width:137px;height:28px">Pricing</div><h2>Simple plans</h2></div><article class="pricing-card"><div class="tier-name">Team</div><div class="tier-price"><span class="amount">$29</span>/mo</div><div class="use-case-result">Launch faster</div></article></section>';
 $labelCss = '.tag{display:inline-flex;align-items:center;gap:6px;padding:4px 12px;border-radius:100px}.pricing-card{padding:2rem}.tier-name{font-family:monospace;font-size:11px;letter-spacing:.12em;text-transform:uppercase}.tier-price{display:flex;align-items:flex-end;gap:6px}.use-case-result{display:flex;align-items:center;gap:8px;padding:10px 14px;border-radius:6px}';
 $labelResult = ( new HtmlTransformer() )->transform($labelHtml, array('static_css' => $labelCss))->toArray();


### PR DESCRIPTION
## Summary

Fixes #1628.

Honor explicit normal-flow display evidence before inferring native Columns from semantic sidebar/content children. A wrapper with authored `display:block` must remain a Group rather than acquiring an equal-width flex row and a Gutenberg column gap.

The reduced fixture uses ordinary classes and semantic children. The fix adds no source-platform marker or site-specific exception.

## Verification

- `php php-transformer/tests/unit/block-style-support-conversion.php`: 138 assertions passed.
- `composer test` from `php-transformer/`: canonical, unit, 303 parity fixtures, distribution-shape and package-install checks passed.
- Shared static-style geometry comparison of the reduced normal-flow fixture reports geometry, property parity and coverage of 1.
- PHP syntax and diff checks passed.

This fixes one proven layout inference defect. Full Potted site parity remains an independent acceptance gate after refreshing the paired importer package and reimporting.

## AI Assistance

GPT-5.6 Terra via OpenCode traced the source and generated geometry, corrected the initial ownership diagnosis, implemented the generic inference guard and verified it. GPT-6 Astra via OpenCode reviewed the scope and diff and prepared publication. Chris directed the work and authorized direct execution while the orchestration control plane was blocked.
