### PR TITLE
Capture explicit required label markers as form metadata

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Elements/FormControlMetadataBuilder.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FormControlMetadataBuilder.php
@@ -109,6 +109,15 @@ final class FormControlMetadataBuilder
 
         if ( $control->hasAttribute('required') || 'true' === strtolower(trim(SourceDom::attr($control, 'aria-required'))) ) {
             $metadata['required'] = true;
+            if ( $labelElement instanceof DOMElement ) {
+                foreach ( $labelElement->getElementsByTagName('span') as $marker ) {
+                    $text = trim($marker->textContent ?? '');
+                    if ( 'true' === strtolower(SourceDom::attr($marker, 'aria-hidden')) && preg_match('/^\*{1,4}$/D', $text) ) {
+                        $metadata['required_text'] = $text;
+                        break;
+                    }
+                }
+            }
         }
         foreach ( array( 'disabled', 'readonly', 'checked', 'multiple' ) as $attribute ) {
             if ( $control->hasAttribute($attribute) ) {

--- a/php-transformer/tests/unit/form-associated-label-submit.php
+++ b/php-transformer/tests/unit/form-associated-label-submit.php
@@ -41,6 +41,12 @@ $form = '<main><form aria-label="Contact">'
 $serialized = $serialize($form);
 $formResult = $transformer->transform($form)->toArray();
 $runtimeSubmit = $formResult['fallbacks'][0]['controls'][3] ?? array();
+$assert(
+    '*' === ($formResult['fallbacks'][0]['controls'][0]['required_text'] ?? null)
+        && 'First name' === ($formResult['fallbacks'][0]['controls'][0]['label'] ?? null)
+        && ! isset($formResult['fallbacks'][0]['controls'][1]['required_text']),
+    'required marker text is captured separately from the accessible label only when present'
+);
 
 $assert(
     str_contains($serialized, 'Claim My Spot') && ! str_contains($serialized, '>Button<'),


### PR DESCRIPTION
## Summary
Preserve an explicit aria-hidden asterisk marker on a required field as required_text, separately from its accessible label. Leave the metadata absent when the source has no marker. The destination adapter can use its existing required-label API rather than hardcoding a glyph or overriding every form globally.

## Verification
The associated-label/submit regression passes, including separate label/marker capture and absent-marker behavior. Fresh combined WordPress verification follows with the SSI adapter mapping to jetpack/label requiredText.

## AI Assistance
GPT-6 Astra via OpenCode inspected the public source DOM and Jetpack source APIs, implemented the metadata capture, and ran the regression. No Jetpack changes.