### PR TITLE
Retain empty hosts painted by conditional pseudo-element CSS

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
@@ -2450,10 +2450,10 @@ final class StyleResolver implements ElementPresentationResolver
                     if ($supportedRestingSelector && array() === $conditions && array() !== $cascadedValueDeclarations) {
                         $analysis['cascaded_values'][] = array('selector' => $selector, 'declarations' => $cascadedValueDeclarations);
                     }
-                    if (array() !== $conditions || array() === $declarations) {
+                    if (array() === $declarations) {
                         continue;
                     }
-                    if (1 === preg_match_all('/:(hover|focus-visible|focus|active)\b/i', $selector, $stateMatches, PREG_OFFSET_CAPTURE)) {
+                    if (array() === $conditions && 1 === preg_match_all('/:(hover|focus-visible|focus|active)\b/i', $selector, $stateMatches, PREG_OFFSET_CAPTURE)) {
                         $state = strtolower((string) $stateMatches[1][0][0]);
                         $offset = (int) $stateMatches[0][0][1];
                         $baseSelector = trim(substr_replace($selector, '', $offset, strlen((string) $stateMatches[0][0][0])));
@@ -2465,7 +2465,7 @@ final class StyleResolver implements ElementPresentationResolver
                     if (preg_match('/::?(before|after)\b/i', $selector, $pseudoMatch)) {
                         $baseSelector = trim((string) preg_replace('/::?(?:before|after)\b/i', '', $selector));
                         if ('' !== $baseSelector && ! $this->selectorCarriesPseudoState($baseSelector) && $this->isSupportedCssSelector($baseSelector)) {
-                            $analysis['pseudo'][] = array('selector' => $baseSelector, 'pseudo' => strtolower($pseudoMatch[1]), 'declarations' => $declarations);
+                            $analysis['pseudo'][] = array('selector' => $baseSelector, 'pseudo' => strtolower($pseudoMatch[1]), 'declarations' => $declarations, 'conditions' => $conditions);
                         }
                     }
                 }

--- a/php-transformer/tests/contract/empty-visual-figure.php
+++ b/php-transformer/tests/contract/empty-visual-figure.php
@@ -23,6 +23,24 @@ $assert(1 === substr_count($transformMarkup, 'wp-block-group border-figure') && 
 $assert(str_contains($transformMarkup, 'border-figure') && str_contains($transformMarkup, 'gradient-figure') && str_contains($transformMarkup, 'pseudo-figure'), 'Transformer retains each visual figure identity for projected CSS.');
 $assert(! str_contains($transformMarkup, 'empty-figure') && ! str_contains($transformMarkup, '<!-- wp:html'), 'Transformer prunes nonvisual empty figures without HTML fallback.');
 
+// A pseudo-painted divider has no host geometry. Its only paint is scoped to
+// nested responsive media rules, which must still retain the host for CSS projection.
+$responsivePseudoCss = '@media screen{@media (min-width:768px){.responsive-pseudo-divider::before{content:"";display:block;height:1px;background:#345}}}';
+$responsivePseudoHtml = '<main><div class="responsive-pseudo-divider"></div><div class="responsive-empty-divider"></div></main>';
+$responsivePseudo = ( new HtmlTransformer() )->transform('<style>' . $responsivePseudoCss . '</style>' . $responsivePseudoHtml)->toArray();
+$responsivePseudoMarkup = (string) ($responsivePseudo['serialized_blocks'] ?? '');
+$assert(str_contains($responsivePseudoMarkup, 'wp-block-group responsive-pseudo-divider') && ! str_contains($responsivePseudoMarkup, 'responsive-empty-divider'), 'Nested responsive pseudo-element paint retains only its otherwise-empty host.');
+
+$responsivePseudoArtifact = ( new ArtifactCompiler() )->compile(array(
+    'entrypoint' => 'index.html',
+    'files'      => array(
+        'index.html' => '<link rel="stylesheet" href="assets/divider.css">' . $responsivePseudoHtml,
+        'assets/divider.css' => $responsivePseudoCss,
+    ),
+))->toArray();
+$responsivePseudoArtifactMarkup = (string) ($responsivePseudoArtifact['serialized_blocks'] ?? '');
+$assert(str_contains($responsivePseudoArtifactMarkup, 'wp-block-group responsive-pseudo-divider') && ! str_contains($responsivePseudoArtifactMarkup, 'responsive-empty-divider'), 'Artifact compilation retains a host painted only by nested responsive pseudo-element CSS.');
+
 foreach (array(1, 11) as $count) {
     $geometryGroups = ( new HtmlTransformer() )->transform(str_repeat('<div style="height:12px;overflow:hidden;width:100%"></div>', $count))->toArray();
     $geometryMetrics = $geometryGroups['source_reports']['editability_report']['metrics'] ?? array();


### PR DESCRIPTION
## Summary
Preserve pseudo-element analysis inside conditional CSS so responsive decorative elements survive HTML-to-block conversion. Retain the enclosing conditions and leave state analysis behavior unchanged.

## Verification
- Added a nested-media regression that fails before the fix and passes after it, covering direct HTML and artifact compilation.
- Full composer test suite passes, including 305 parity fixtures and package-install proof.
- Fresh Studio URL import of https://www.busybearscleaning.com/ using this commit: six mobile dividers match source at 342 by 1 pixels and rgb(58,95,125). Desktop divider widths and the vertical footer divider also match.
- All four routes at 390/1440 load without browser errors or horizontal overflow; all editor blocks valid, no missing blocks. Whole-site visual parity remains open.

## Reproduction
Run `php tests/contract/empty-visual-figure.php` and `composer test` from php-transformer. For the end-to-end path, build a paired SSI development ZIP from this branch and use Studio PR #3952 `create --from https://www.busybearscleaning.com/ --keep-source --static-site-importer-path <zip>`. Compare service-divider dimensions and computed pseudo-element paint at 390 and 1440 pixels.

AI assistance: OpenAI gpt-6-astra via OpenCode orchestrated source-stage diagnosis, review, and fresh WordPress/browser verification; OpenAI gpt-5.6-terra via OpenCode investigated and implemented the scoped analyzer fix and regression tests.