### PR TITLE
Reuse normalized conversion-report inputs

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -159,6 +159,7 @@
       "php tests/unit/corpus-detectors.php",
       "php tests/unit/live-wp-parity-runner.php",
       "php tests/unit/deterministic-row-deduplicator.php",
+      "php tests/unit/conversion-report-projection-input-reuse.php",
       "php tests/unit/html-transformer-shared-analysis-cache.php",
       "php tests/unit/html-transformer-session-state.php",
       "php tests/unit/reusable-component-recognition.php",

--- a/php-transformer/src/Contract/ConversionReportProjection.php
+++ b/php-transformer/src/Contract/ConversionReportProjection.php
@@ -21,6 +21,10 @@ final class ConversionReportProjection
      */
     public static function fromResultParts(string $sourceFormat, array $blocks, array $fallbacks, array $sourceReports, array $assets, array $provenance, array $metrics): array
     {
+        $fallbackDiagnostics = self::fallbackDiagnostics($fallbacks);
+        $runtimeIslands = self::runtimeIslands($sourceReports);
+        $runtimeIslandSummaryEntries = self::runtimeIslandSummaryEntries($runtimeIslands);
+
         $report = array(
             'schema'                => self::SCHEMA,
             'finding_schema'        => ConversionFindingContract::SCHEMA,
@@ -28,9 +32,9 @@ final class ConversionReportProjection
             'source'                => self::firstString($provenance, 'source'),
             'scope'                 => self::firstString($provenance, 'scope'),
             'source_summary'        => self::sourceSummary($sourceFormat, $blocks, $fallbacks, $sourceReports, $assets, $metrics),
-            'selector_summary'      => self::selectorSummary($sourceReports, $fallbacks),
-            'conversion_classification_summary' => self::conversionClassificationSummary($sourceReports, $fallbacks),
-            'fallback_diagnostics'  => self::fallbackDiagnostics($fallbacks),
+            'selector_summary'      => self::selectorSummary($sourceReports, $fallbackDiagnostics, $runtimeIslandSummaryEntries),
+            'conversion_classification_summary' => self::conversionClassificationSummary($sourceReports, $fallbackDiagnostics, $runtimeIslandSummaryEntries),
+            'fallback_diagnostics'  => $fallbackDiagnostics,
             'core_html_fallback_evidence' => self::coreHtmlFallbackEvidence($sourceReports),
             'asset_refs'            => self::assetReferences($blocks, $sourceReports),
             'navigation_candidates' => self::navigationCandidates($blocks, $sourceReports),
@@ -38,7 +42,7 @@ final class ConversionReportProjection
             'editability_report'    => is_array($sourceReports['editability_report'] ?? null) ? $sourceReports['editability_report'] : array(),
             'editability_policy'    => is_array($sourceReports['editability_policy'] ?? null) ? $sourceReports['editability_policy'] : array(),
             'runtime_dependency_parity' => self::runtimeDependencyParity($sourceReports),
-            'runtime_islands'      => self::runtimeIslands($sourceReports),
+            'runtime_islands'      => $runtimeIslands,
             'interaction_candidates' => self::interactionCandidates($sourceReports),
             'presentation_gaps'     => self::presentationGaps($sourceReports),
             'native_target_blocks'  => self::stringList($sourceReports, 'native_target_blocks'),
@@ -89,10 +93,11 @@ final class ConversionReportProjection
 
     /**
      * @param array<string, mixed> $sourceReports
-     * @param array<int, array<string, mixed>> $fallbacks
+     * @param array<int, array<string, mixed>> $fallbackDiagnostics
+     * @param array<int, array<string, mixed>> $runtimeIslandSummaryEntries
      * @return array<string, mixed>
      */
-    private static function selectorSummary(array $sourceReports, array $fallbacks): array
+    private static function selectorSummary(array $sourceReports, array $fallbackDiagnostics, array $runtimeIslandSummaryEntries): array
     {
         $selectors = array();
         $sources = array();
@@ -102,12 +107,12 @@ final class ConversionReportProjection
             self::appendSourcePath($sources, $entry);
         }
 
-        foreach ( self::fallbackDiagnostics($fallbacks) as $entry ) {
+        foreach ( $fallbackDiagnostics as $entry ) {
             self::appendSelector($selectors, $entry, 'fallback');
             self::appendSourcePath($sources, $entry);
         }
 
-        foreach ( self::runtimeIslandSummaryEntries($sourceReports) as $entry ) {
+        foreach ( $runtimeIslandSummaryEntries as $entry ) {
             self::appendSelector($selectors, $entry, 'runtime_island');
             self::appendSourcePath($sources, $entry);
         }
@@ -196,15 +201,16 @@ final class ConversionReportProjection
 
     /**
      * @param array<string, mixed> $sourceReports
-     * @param array<int, array<string, mixed>> $fallbacks
+     * @param array<int, array<string, mixed>> $fallbackDiagnostics
+     * @param array<int, array<string, mixed>> $runtimeIslandSummaryEntries
      * @return array<string, mixed>
      */
-    private static function conversionClassificationSummary(array $sourceReports, array $fallbacks): array
+    private static function conversionClassificationSummary(array $sourceReports, array $fallbackDiagnostics, array $runtimeIslandSummaryEntries): array
     {
         $byClassification = array();
         $byStrategy = array();
 
-        foreach ( array_merge(self::sourceProvenance($sourceReports), self::fallbackDiagnostics($fallbacks), self::runtimeIslandSummaryEntries($sourceReports)) as $entry ) {
+        foreach ( array_merge(self::sourceProvenance($sourceReports), $fallbackDiagnostics, $runtimeIslandSummaryEntries) as $entry ) {
             if ( ! is_array($entry) ) {
                 continue;
             }
@@ -370,13 +376,13 @@ final class ConversionReportProjection
     }
 
     /**
-     * @param array<string, mixed> $sourceReports
+     * @param array<int, array<string, mixed>> $runtimeIslands
      * @return array<int, array<string, mixed>>
      */
-    private static function runtimeIslandSummaryEntries(array $sourceReports): array
+    private static function runtimeIslandSummaryEntries(array $runtimeIslands): array
     {
         $entries = array();
-        foreach ( self::runtimeIslands($sourceReports) as $island ) {
+        foreach ( $runtimeIslands as $island ) {
             $entries[] = array_filter(
                 array(
                     'selector'                  => $island['selector'] ?? '',

--- a/php-transformer/tests/unit/conversion-report-projection-input-reuse.php
+++ b/php-transformer/tests/unit/conversion-report-projection-input-reuse.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionReportProjection;
+
+$failures = 0;
+$assert = static function (bool $condition, string $message) use (&$failures): void {
+    if ( ! $condition ) {
+        ++$failures;
+        fwrite(STDERR, "FAIL: {$message}\n");
+    }
+};
+
+$fallbacks = array(
+    array('diagnostic_code' => 'html_script_fallback', 'selector' => '#widget', 'source_path' => 'index.html', 'conversion_classification' => 'runtime_gap', 'preservation_strategy' => 'core_html'),
+    array('diagnostic_code' => 'html_unsafe_inline_svg', 'selector' => '.logo svg', 'source_path' => 'about.html', 'conversion_classification' => 'asset_gap', 'preservation_strategy' => 'materialize_asset'),
+);
+$sharedIsland = array('selector' => '#widget', 'source_path' => 'index.html', 'tag' => 'div', 'preservation_strategy' => 'scoped_runtime_metadata');
+$secondIsland = array('selector' => '.map', 'source_path' => 'about.html', 'tag' => 'section', 'disposition' => 'preserved');
+$report = ConversionReportProjection::fromResultParts('html', array(), $fallbacks, array(
+    'html' => array(
+        'source_provenance' => array(array('selector' => 'main', 'source_path' => 'index.html', 'conversion_classification' => 'native', 'preservation_strategy' => 'native_block')),
+        'runtime_islands' => array($sharedIsland, $secondIsland),
+    ),
+    'runtime_islands' => array($sharedIsland),
+), array(), array(), array());
+
+$assert(
+    array($sharedIsland, $secondIsland) === ($report['runtime_islands'] ?? null),
+    'runtime islands retain first-occurrence ordering while overlapping declarations are deduplicated'
+);
+$assert(
+    array('main', '#widget', '.logo svg', '#widget', '.map') === array_column($report['selector_summary']['selectors'] ?? array(), 'selector'),
+    'selector summary retains source, fallback, and deduplicated runtime-island order'
+);
+$assert(
+    array('index.html', 'about.html') === ($report['selector_summary']['source_paths'] ?? null),
+    'selector summary source paths retain their first occurrence order'
+);
+$assert(
+    array('native' => 1, 'runtime_gap' => 1, 'asset_gap' => 1, 'runtime_island_preserved' => 2) === ($report['conversion_classification_summary']['by_classification'] ?? null),
+    'classification summary counts each normalized fallback and runtime island exactly once'
+);
+$assert(
+    array('native_block' => 1, 'core_html' => 1, 'materialize_asset' => 1, 'scoped_runtime_metadata' => 2) === ($report['conversion_classification_summary']['by_preservation_strategy'] ?? null),
+    'preservation strategy summary preserves normalized row counts and omission behavior'
+);
+$assert(
+    array('html_script_fallback', 'html_unsafe_inline_svg') === array_column($report['fallback_diagnostics'] ?? array(), 'diagnostic_code'),
+    'fallback diagnostics retain normalized final rows in input order'
+);
+
+if ( 0 < $failures ) {
+    exit(1);
+}
+
+echo "conversion-report-projection-input-reuse ok\n";


### PR DESCRIPTION
## Summary

Reporting-maintainability slice under #242: reuse normalized inputs inside `ConversionReportProjection::fromResultParts()`.

- Project fallback diagnostics once instead of three times.
- Normalize/deduplicate runtime islands once instead of three times.
- Build runtime-island summary entries once instead of twice.
- Feed those local arrays to selector/classification summaries and the final report. Preserve the separate summary-row deduplication.

No new class, cache, persistent state, option or public signature. Report keys, ordering, omissions, classifications and deduplication behavior remain unchanged. No unmeasured speed claim.

## Verification

Baseline: `a57b5f2dd09eaa4a9d81d622a9b4672677516c56`.
Candidate: `2d345985af6126ccd4d7a47edf84b3932511a247`.

All ten final CI checks passed: [PHP 8.2-8.5 package and WordPress integration suites, plus generic visual parity tools](https://github.com/Automattic/blocks-engine/actions/runs/34421474912), and [solved-site promotion](https://github.com/Automattic/blocks-engine/actions/runs/34421475315).

- New behavioral test checks overlapping runtime declarations, first-occurrence ordering, selector/source order, fallback order, and exact classification/preservation counts.
- Full PHP 8.4 / 512 MB Composer gate passed: canonical, unit, 305 parity fixtures, dist shape and install proof.
- Coordinator independently reran the full 385-file HTML corpus and nine targeted HTML/artifact cases. Complete envelope/block comparison records match byte-for-byte, excluding only recursive duration; final record SHA-256 `520a6c71343bab56933991a5cd51cc85483207c03f0204d37998b8e35f1bc6f4`.
- The full/compact invariant tool passed on 385 fixtures, including 365 warning documents, with identical operational outputs and only declared detail differences.
- WordPress integration and solved-site promotion passed separately in final CI as linked above; they are not claimed from standalone lab tests.

## Reproduce

From `php-transformer`, with dependencies and child PHP memory configured:

```sh
composer test
php tests/unit/conversion-report-projection-input-reuse.php
php -d memory_limit=512M tools/benchmarks/validation-evidence-compare.php ../fixtures
REQUIRE_WP_TESTS=1 WP_TESTS_DIR=/path/to/wordpress-tests composer test:wordpress-integration
```

The corpus comparison command from #1627 applies unchanged to the baseline/candidate revisions above with matching dependencies.

## AI Assistance

OpenAI GPT-5.6 Terra via direct OpenCode implemented the local reuse and behavioral test, then ran lab gates. GPT-6 Astra via OpenCode coordinated and reviewed ordering/count/deduplication semantics, independently reran the final corpus/artifact comparison and prepared this PR under Chris Huber's direction. No release or deployment was performed.
