### PR TITLE
Share block traversal for conversion-report references

### DIFF
--- a/php-transformer/src/Contract/ConversionReportProjection.php
+++ b/php-transformer/src/Contract/ConversionReportProjection.php
@@ -24,6 +24,15 @@ final class ConversionReportProjection
         $fallbackDiagnostics = self::fallbackDiagnostics($fallbacks);
         $runtimeIslands = self::runtimeIslands($sourceReports);
         $runtimeIslandSummaryEntries = self::runtimeIslandSummaryEntries($runtimeIslands);
+        $blockAssetReferences = array();
+        $blockNavigationCandidates = array();
+        self::collectBlockReportRows(
+            $blocks,
+            'blocks',
+            $blockAssetReferences,
+            $blockNavigationCandidates,
+            array() === self::artifactAssetReferences($sourceReports)
+        );
 
         $report = array(
             'schema'                => self::SCHEMA,
@@ -36,8 +45,8 @@ final class ConversionReportProjection
             'conversion_classification_summary' => self::conversionClassificationSummary($sourceReports, $fallbackDiagnostics, $runtimeIslandSummaryEntries),
             'fallback_diagnostics'  => $fallbackDiagnostics,
             'core_html_fallback_evidence' => self::coreHtmlFallbackEvidence($sourceReports),
-            'asset_refs'            => self::assetReferences($blocks, $sourceReports),
-            'navigation_candidates' => self::navigationCandidates($blocks, $sourceReports),
+            'asset_refs'            => self::assetReferences($blockAssetReferences, $sourceReports),
+            'navigation_candidates' => self::navigationCandidates($blockNavigationCandidates, $sourceReports),
             'semantic_parity'       => self::semanticParity($sourceReports),
             'editability_report'    => is_array($sourceReports['editability_report'] ?? null) ? $sourceReports['editability_report'] : array(),
             'editability_policy'    => is_array($sourceReports['editability_policy'] ?? null) ? $sourceReports['editability_policy'] : array(),
@@ -236,28 +245,26 @@ final class ConversionReportProjection
     }
 
     /**
-     * @param array<int, array<string, mixed>> $blocks
+     * @param array<int, array<string, mixed>> $blockReferences
      * @param array<string, mixed> $sourceReports
      * @return array<int, array<string, mixed>>
      */
-    private static function assetReferences(array $blocks, array $sourceReports): array
+    private static function assetReferences(array $blockReferences, array $sourceReports): array
     {
         $references = self::artifactAssetReferences($sourceReports);
         if ( array() !== $references ) {
             return self::dedupeRows($references);
         }
 
-        self::collectBlockAssetReferences($blocks, 'blocks', $references);
-
-        return self::dedupeRows($references);
+        return self::dedupeRows($blockReferences);
     }
 
     /**
-     * @param array<int, array<string, mixed>> $blocks
+     * @param array<int, array<string, mixed>> $blockCandidates
      * @param array<string, mixed> $sourceReports
      * @return array<int, array<string, mixed>>
      */
-    private static function navigationCandidates(array $blocks, array $sourceReports): array
+    private static function navigationCandidates(array $blockCandidates, array $sourceReports): array
     {
         $candidates = array();
         foreach ( self::artifactInternalLinks($sourceReports) as $link ) {
@@ -273,7 +280,7 @@ final class ConversionReportProjection
             );
         }
 
-        self::collectBlockNavigationCandidates($blocks, 'blocks', $candidates);
+        $candidates = array_merge($candidates, $blockCandidates);
 
         return self::dedupeRows($candidates);
     }
@@ -565,8 +572,9 @@ final class ConversionReportProjection
     /**
      * @param array<int, array<string, mixed>> $blocks
      * @param array<int, array<string, mixed>> $references
+     * @param array<int, array<string, mixed>> $candidates
      */
-    private static function collectBlockAssetReferences(array $blocks, string $path, array &$references): void
+    private static function collectBlockReportRows(array $blocks, string $path, array &$references, array &$candidates, bool $collectAssetReferences): void
     {
         foreach ( $blocks as $index => $block ) {
             if ( ! is_array($block) ) {
@@ -576,38 +584,20 @@ final class ConversionReportProjection
             $blockPath = $path . '.' . $index;
             $blockName = (string) ($block['blockName'] ?? '');
             $attrs = is_array($block['attrs'] ?? null) ? $block['attrs'] : array();
-            foreach ( array('url', 'src', 'href', 'poster') as $attribute ) {
-                if ( is_string($attrs[$attribute] ?? null) && '' !== $attrs[$attribute] ) {
-                    $references[] = array(
-                        'source'     => 'block_attribute',
-                        'block_path' => $blockPath,
-                        'block_name' => $blockName,
-                        'attribute'  => $attribute,
-                        'url'        => $attrs[$attribute],
-                    );
+            if ( $collectAssetReferences ) {
+                foreach ( array('url', 'src', 'href', 'poster') as $attribute ) {
+                    if ( is_string($attrs[$attribute] ?? null) && '' !== $attrs[$attribute] ) {
+                        $references[] = array(
+                            'source'     => 'block_attribute',
+                            'block_path' => $blockPath,
+                            'block_name' => $blockName,
+                            'attribute'  => $attribute,
+                            'url'        => $attrs[$attribute],
+                        );
+                    }
                 }
             }
 
-            if ( ! empty($block['innerBlocks']) && is_array($block['innerBlocks']) ) {
-                self::collectBlockAssetReferences($block['innerBlocks'], $blockPath . '.innerBlocks', $references);
-            }
-        }
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $blocks
-     * @param array<int, array<string, mixed>> $candidates
-     */
-    private static function collectBlockNavigationCandidates(array $blocks, string $path, array &$candidates): void
-    {
-        foreach ( $blocks as $index => $block ) {
-            if ( ! is_array($block) ) {
-                continue;
-            }
-
-            $blockPath = $path . '.' . $index;
-            $blockName = (string) ($block['blockName'] ?? '');
-            $attrs = is_array($block['attrs'] ?? null) ? $block['attrs'] : array();
             if ( 'core/navigation-link' === $blockName ) {
                 $candidates[] = array_filter(
                     array(
@@ -623,7 +613,7 @@ final class ConversionReportProjection
             }
 
             if ( ! empty($block['innerBlocks']) && is_array($block['innerBlocks']) ) {
-                self::collectBlockNavigationCandidates($block['innerBlocks'], $blockPath . '.innerBlocks', $candidates);
+                self::collectBlockReportRows($block['innerBlocks'], $blockPath . '.innerBlocks', $references, $candidates, $collectAssetReferences);
             }
         }
     }

--- a/php-transformer/tests/unit/conversion-report-projection-input-reuse.php
+++ b/php-transformer/tests/unit/conversion-report-projection-input-reuse.php
@@ -52,6 +52,51 @@ $assert(
     'fallback diagnostics retain normalized final rows in input order'
 );
 
+$blocks = array(
+    2 => array('blockName' => 'core/image', 'attrs' => array('url' => 'https://example.test/image', 'src' => 'https://example.test/image.jpg', 'href' => 'https://example.test/image-link', 'poster' => 'https://example.test/image.mp4')),
+    4 => 'malformed block',
+    6 => array('blockName' => 'core/navigation-link', 'attrs' => array('label' => 'Top', 'url' => '/top', 'kind' => 'custom')),
+    9 => array('blockName' => 'core/group', 'attrs' => array('src' => 'https://example.test/group.jpg'), 'innerBlocks' => array(
+        1 => array('blockName' => 'core/navigation-link', 'attrs' => array('label' => 'Child', 'url' => '/child', 'kind' => 'post-type')),
+        3 => false,
+        7 => array('blockName' => 'core/navigation-link', 'attrs' => array('label' => 'Child', 'url' => '/child', 'kind' => 'post-type')),
+        8 => array('blockName' => 'core/video', 'attrs' => array('poster' => 'https://example.test/video.jpg', 'href' => array('invalid'))),
+    )),
+);
+$blockReport = ConversionReportProjection::fromResultParts('html', $blocks, array(), array(), array(), array(), array());
+$expectedBlockAssets = array(
+    array('source' => 'block_attribute', 'block_path' => 'blocks.2', 'block_name' => 'core/image', 'attribute' => 'url', 'url' => 'https://example.test/image'),
+    array('source' => 'block_attribute', 'block_path' => 'blocks.2', 'block_name' => 'core/image', 'attribute' => 'src', 'url' => 'https://example.test/image.jpg'),
+    array('source' => 'block_attribute', 'block_path' => 'blocks.2', 'block_name' => 'core/image', 'attribute' => 'href', 'url' => 'https://example.test/image-link'),
+    array('source' => 'block_attribute', 'block_path' => 'blocks.2', 'block_name' => 'core/image', 'attribute' => 'poster', 'url' => 'https://example.test/image.mp4'),
+    array('source' => 'block_attribute', 'block_path' => 'blocks.6', 'block_name' => 'core/navigation-link', 'attribute' => 'url', 'url' => '/top'),
+    array('source' => 'block_attribute', 'block_path' => 'blocks.9', 'block_name' => 'core/group', 'attribute' => 'src', 'url' => 'https://example.test/group.jpg'),
+    array('source' => 'block_attribute', 'block_path' => 'blocks.9.innerBlocks.1', 'block_name' => 'core/navigation-link', 'attribute' => 'url', 'url' => '/child'),
+    array('source' => 'block_attribute', 'block_path' => 'blocks.9.innerBlocks.7', 'block_name' => 'core/navigation-link', 'attribute' => 'url', 'url' => '/child'),
+    array('source' => 'block_attribute', 'block_path' => 'blocks.9.innerBlocks.8', 'block_name' => 'core/video', 'attribute' => 'poster', 'url' => 'https://example.test/video.jpg'),
+);
+$expectedBlockNavigation = array(
+    array('source' => 'block', 'block_path' => 'blocks.6', 'block_name' => 'core/navigation-link', 'label' => 'Top', 'url' => '/top', 'kind' => 'custom'),
+    array('source' => 'block', 'block_path' => 'blocks.9.innerBlocks.1', 'block_name' => 'core/navigation-link', 'label' => 'Child', 'url' => '/child', 'kind' => 'post-type'),
+    array('source' => 'block', 'block_path' => 'blocks.9.innerBlocks.7', 'block_name' => 'core/navigation-link', 'label' => 'Child', 'url' => '/child', 'kind' => 'post-type'),
+);
+$assert($expectedBlockAssets === ($blockReport['asset_refs'] ?? null), 'block assets retain depth-first sparse paths and attribute order');
+$assert($expectedBlockNavigation === ($blockReport['navigation_candidates'] ?? null), 'block navigation retains depth-first sparse paths and malformed-entry skipping');
+
+$artifactAsset = array('source_path' => 'index.html', 'selector' => 'img.hero', 'url' => '/hero.jpg');
+$artifactLink = array('source_path' => 'index.html', 'selector' => 'a.home', 'url' => '/home', 'target_path' => 'home/index.html');
+$artifactReport = ConversionReportProjection::fromResultParts('artifact', $blocks, array(), array(
+    'artifact' => array(
+        'asset_references' => array($artifactAsset, $artifactAsset),
+        'internal_links' => array($artifactLink, $artifactLink),
+    ),
+), array(), array(), array());
+$assert(array($artifactAsset) === ($artifactReport['asset_refs'] ?? null), 'nonempty artifact assets suppress block attribute collection and retain first-occurrence deduplication');
+$assert(
+    array_merge(array(array('source' => 'artifact_reference', 'source_path' => 'index.html', 'selector' => 'a.home', 'url' => '/home', 'target_path' => 'home/index.html')), $expectedBlockNavigation) === ($artifactReport['navigation_candidates'] ?? null),
+    'artifact links precede block navigation candidates while duplicate artifact rows are deduplicated'
+);
+
 if ( 0 < $failures ) {
     exit(1);
 }


### PR DESCRIPTION
## Summary

Continue reporting simplification under #242 after #1640: replace the separate asset-reference and navigation-candidate block traversals with one private depth-first walk.

- Preserve artifact asset-reference precedence: block asset rows are not collected when artifact references are present.
- Preserve asset attribute order (`url`, `src`, `href`, `poster`), sparse block indexes, nested paths and malformed-entry handling.
- Keep artifact navigation rows before block navigation rows, with existing independent deduplication.
- Keep public signatures, report shapes and the previous shared fallback/runtime normalization unchanged. No new classes, persistent caches or public options.

## Verification

Baseline: `48edda6e398112245e42ca8459f0a7fbeb0472aa`.
Candidate: `153e3d7b6ed5c5ceb4455655fcdfcb75c0c4c317`.

All ten final checks passed: [PHP 8.2-8.5 package and WordPress integration suites, plus generic visual parity tools](https://github.com/Automattic/blocks-engine/actions/runs/34475405597), and [solved-site promotion](https://github.com/Automattic/blocks-engine/actions/runs/34475406551).

- Extended the existing report test with exact expected asset/navigation arrays for nested and sparse blocks, invalid entries, multiple asset attributes, repeated navigation data, artifact precedence and artifact-first ordering.
- Full PHP 8.4 Composer suite passed, including packaging/install proof.
- Coordinator independently reran the 385-file HTML corpus and nine targeted HTML/artifact cases: serialized blocks and full envelopes match baseline, excluding only recursive `transform_duration_ms`.
- Final verifier-file SHA-256: `520a6c71343bab56933991a5cd51cc85483207c03f0204d37998b8e35f1bc6f4`.
- Full/compact invariant tool passed: 385 fixtures, 365 warning documents, operational outputs equal and only declared detail/duration differences.
- WordPress integration was unavailable locally; the separate final CI integration matrix and solved-site promotion passed as linked above.

## Reproduce

From `php-transformer` with dependencies installed and child PHP memory configured:

```sh
composer test
php tests/unit/conversion-report-projection-input-reuse.php
php -d memory_limit=512M tools/benchmarks/validation-evidence-compare.php ../fixtures
REQUIRE_WP_TESTS=1 WP_TESTS_DIR=/path/to/wordpress-tests composer test:wordpress-integration
```

The corpus comparison command in #1627 applies unchanged to the baseline/candidate above with matching dependencies. This removes duplicate traversal work; no unmeasured speed or memory claim is made.

## AI Assistance

OpenAI GPT-5.6 Terra via direct OpenCode implemented and lab-tested the shared traversal. GPT-6 Astra via OpenCode coordinated and reviewed precedence, ordering and deduplication semantics, independently reran the final corpus/artifact comparison, and prepared this PR under Chris Huber's direction. No release or deployment was performed.
