### PR TITLE
Bound generated form runtime declarations

### DIFF
--- a/docs/contracts/wordpress-site-plan-v2.md
+++ b/docs/contracts/wordpress-site-plan-v2.md
@@ -40,7 +40,14 @@ and `WordPressSitePlanResolver::resolve()`.
   keys. Duplicate identities, unsafe paths, unresolved requirements, contradictory
   kinds, and non-serializable or overlarge payloads fail validation before plan
    emission. Declarations are carried unchanged after canonical normalization by
-   compilation, resolution, reports, and package serialization.
+    compilation, resolution, reports, and package serialization.
+- Oversized entity collections use the additive
+  `runtime_entity_records` content-addressed store. The declaration keeps an
+  ordered bounded `blocks-engine/runtime-entity-manifest/v1` reference payload;
+  each unique record has a SHA-256 content hash and remains individually bounded
+  to 5 MiB. Resolution exposes complete records in
+  `runtime_entity_resolution`, so materializers consume every entity without
+  expanding or changing the canonical declaration.
 - Provider entity block bindings use `generic/block-binding/v1`. In addition to
   materializer-compatible `search_block_markup` and `occurrence`, each binding
   carries a `blocks-engine/runtime-binding-position/v1` emitted-block identity:

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -654,7 +654,8 @@ final class ArtifactCompiler
         }
         $allGutenbergGaps = $this->dedupeRows($allGutenbergGaps);
         $runtimeDeclarationDiagnostics = array();
-        $normalized['runtime_declarations'] = $this->runtimeDeclarationsFromFallbacks($normalized['runtime_declarations'], $allFallbacks, $entryPath, $normalized['files'], $runtimeDeclarationDiagnostics);
+        $runtimeEntityRecords = array();
+        $normalized['runtime_declarations'] = $this->runtimeDeclarationsFromFallbacks($normalized['runtime_declarations'], $allFallbacks, $entryPath, $normalized['files'], $runtimeDeclarationDiagnostics, $runtimeEntityRecords);
         $normalized['files'] = $this->applyAuthorStylesheetProjections($normalized['files'], $authorStylesheetProjections, $entryBlocks['author_stylesheet_projections']);
         $normalized['files'] = $this->chunkProjectedStylesheets($normalized['files']);
         foreach ($normalized['files'] as $file) {
@@ -743,6 +744,7 @@ final class ArtifactCompiler
             );
         }
         $sourceReports['compiled_site'] = $this->compiledSiteReport($normalized, $entryPath, $documents['documents'], $assets, $blockTypes, $serializedBlocks, $entryBlocks['shell_artifacts'], $compiledHtmlDocuments, $inlineShellCompilation['artifacts']);
+        $sourceReports['compiled_site']['runtime_entity_records'] = $runtimeEntityRecords;
         $identityFailures = WordPressSitePlan::compiledSiteIdentityFailures($sourceReports['compiled_site']);
         foreach ( WordPressSitePlan::documentIdentityDiagnostics($identityFailures) as $identityDiagnostic ) {
             $diagnostics[] = array_merge($identityDiagnostic, array('source' => self::class));
@@ -1905,7 +1907,7 @@ final class ArtifactCompiler
      * @param array<int,array<string,mixed>> $fallbacks
      * @return array<int,array<string,mixed>>
      */
-    private function runtimeDeclarationsFromFallbacks(array $declarations, array $fallbacks, string $entryPath, array $files, array &$diagnostics = array()): array
+    private function runtimeDeclarationsFromFallbacks(array $declarations, array $fallbacks, string $entryPath, array $files, array &$diagnostics = array(), array &$runtimeEntityRecords = array()): array
     {
         if ( '' === $entryPath ) return $declarations;
         foreach ( $declarations as $declaration ) foreach ( $declaration['payload']['entities'] ?? array() as $entity ) if ( is_array($entity) && array_key_exists('superseded_scripts', $entity) ) throw new \InvalidArgumentException('Caller runtime declarations cannot provide compiler-reserved script supersession proofs.');
@@ -2010,10 +2012,12 @@ final class ArtifactCompiler
                 if ( 'forms' === $collection['type'] ) {
                     $budget = $this->budgetGeneratedForms($declarations, $collection['entities'], $entryPath, $entityKey, isset($keys['dependency:' . $capability]));
                     $collection['entities'] = $budget['entities'];
+                    if (isset($budget['records'])) $runtimeEntityRecords = array_merge($runtimeEntityRecords, $budget['records']);
+                    if (isset($budget['payload'])) $collection['payload'] = $budget['payload'];
                     if ( null !== $budget['diagnostic'] ) $diagnostics[] = $budget['diagnostic'];
                 }
                 if ( array() === $collection['entities'] ) continue;
-                $declarations[] = array('kind' => 'entity_collection', 'type' => $collection['type'], 'source_path' => $entryPath, 'payload' => array('schema' => $collection['schema'], 'entities' => $collection['entities']));
+                $declarations[] = array('kind' => 'entity_collection', 'type' => $collection['type'], 'source_path' => $entryPath, 'payload' => $collection['payload'] ?? array('schema' => $collection['schema'], 'entities' => $collection['entities']));
                 $keys[$entityKey] = true;
             }
             $dependencyKey = 'dependency:' . $capability;
@@ -2031,7 +2035,7 @@ final class ArtifactCompiler
      *
      * @param array<int,array<string,mixed>> $declarations
      * @param array<int,array<string,mixed>> $forms
-     * @return array{entities:array<int,array<string,mixed>>,diagnostic:array<string,mixed>|null}
+     * @return array{entities:array<int,array<string,mixed>>,payload?:array<string,mixed>,records?:array<int,array<string,mixed>>,diagnostic:array<string,mixed>|null}
      */
     private function budgetGeneratedForms(array $declarations, array $forms, string $entryPath, string $entityKey, bool $hasDependency): array
     {
@@ -2048,42 +2052,11 @@ final class ArtifactCompiler
         };
         if ( $fits($forms) ) return array('entities' => $forms, 'diagnostic' => null);
 
-        $presentationGraphsDropped = 0;
-        foreach ( $forms as &$form ) {
-            if ( isset($form['presentation_graph']) ) {
-                unset($form['presentation_graph']);
-                ++$presentationGraphsDropped;
-                if ( $fits($forms) ) return array('entities' => $forms, 'diagnostic' => $this->formsBudgetDiagnostic($forms, array(), $presentationGraphsDropped));
-            }
-        }
-        unset($form);
-
-        $retained = array();
-        $omitted = array();
-        foreach ( $forms as $form ) {
-            $candidate = array_merge($retained, array($form));
-            if ( ! $fits($candidate) ) {
-                $omitted = array_slice($forms, count($retained));
-                break;
-            }
-            $retained[] = $form;
-        }
-        return array('entities' => $retained, 'diagnostic' => $this->formsBudgetDiagnostic($retained, $omitted, $presentationGraphsDropped));
-    }
-
-    /** @param array<int,array<string,mixed>> $retained @param array<int,array<string,mixed>> $omitted @return array<string,mixed> */
-    private function formsBudgetDiagnostic(array $retained, array $omitted, int $presentationGraphsDropped): array
-    {
-        $sample = static function (array $forms): array {
-            return array_slice(array_map(static fn(array $form): array => array('source_path' => (string) ($form['source_path'] ?? ''), 'selector' => (string) ($form['selector'] ?? '')), $forms), 0, 8);
-        };
-        return $this->diagnostic('runtime_declarations_forms_budgeted', 'warning', 'Compiler-generated form declarations exceeded the canonical runtime declaration budget; source fallback markup remains in place for omitted forms.', array(
-            'retained_count' => count($retained),
-            'omitted_count' => count($omitted),
-            'presentation_graphs_dropped' => $presentationGraphsDropped,
-            'retained_samples' => $sample($retained),
-            'omitted_samples' => $sample($omitted),
-        ));
+        $manifest = RuntimeEntityManifest::fromEntities('generic/forms/v1', $forms);
+        $candidate = array_merge($declarations, array(array('kind' => 'entity_collection', 'type' => 'forms', 'source_path' => $entryPath, 'payload' => $manifest['payload'])));
+        if (!$hasDependency) $candidate[] = array('kind' => 'dependency', 'capability' => 'form', 'source_path' => $entryPath, 'required_for' => array($entityKey));
+        RuntimeDeclarations::normalizeList($candidate);
+        return array('entities' => $forms, 'payload' => $manifest['payload'], 'records' => $manifest['records'], 'diagnostic' => null);
     }
 
     /** @param array<string,mixed> $fallback @param array<int,array<string,mixed>> $files @return array<int,array<string,string>> */

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -653,7 +653,8 @@ final class ArtifactCompiler
             $coreHtmlFallbackEvidence[] = $compiledHtmlDocument['core_html_fallback_evidence'] ?? array();
         }
         $allGutenbergGaps = $this->dedupeRows($allGutenbergGaps);
-        $normalized['runtime_declarations'] = $this->runtimeDeclarationsFromFallbacks($normalized['runtime_declarations'], $allFallbacks, $entryPath, $normalized['files']);
+        $runtimeDeclarationDiagnostics = array();
+        $normalized['runtime_declarations'] = $this->runtimeDeclarationsFromFallbacks($normalized['runtime_declarations'], $allFallbacks, $entryPath, $normalized['files'], $runtimeDeclarationDiagnostics);
         $normalized['files'] = $this->applyAuthorStylesheetProjections($normalized['files'], $authorStylesheetProjections, $entryBlocks['author_stylesheet_projections']);
         $normalized['files'] = $this->chunkProjectedStylesheets($normalized['files']);
         foreach ($normalized['files'] as $file) {
@@ -695,7 +696,7 @@ final class ArtifactCompiler
         }
         $assets = $this->deduplicateVisualAssets($assets);
         $assets = $this->coalesceStylesheetAssets($assets);
-        $diagnostics = array_merge($diagnostics, $allDiagnostics);
+        $diagnostics = array_merge($diagnostics, $allDiagnostics, $runtimeDeclarationDiagnostics);
         $serializedBlocks = $entryBlocks['serialized_blocks'];
         if ( '' === $serializedBlocks && ! empty($documents['documents'][0]['block_markup']) ) {
             $serializedBlocks = (string) $documents['documents'][0]['block_markup'];
@@ -1904,7 +1905,7 @@ final class ArtifactCompiler
      * @param array<int,array<string,mixed>> $fallbacks
      * @return array<int,array<string,mixed>>
      */
-    private function runtimeDeclarationsFromFallbacks(array $declarations, array $fallbacks, string $entryPath, array $files): array
+    private function runtimeDeclarationsFromFallbacks(array $declarations, array $fallbacks, string $entryPath, array $files, array &$diagnostics = array()): array
     {
         if ( '' === $entryPath ) return $declarations;
         foreach ( $declarations as $declaration ) foreach ( $declaration['payload']['entities'] ?? array() as $entity ) if ( is_array($entity) && array_key_exists('superseded_scripts', $entity) ) throw new \InvalidArgumentException('Caller runtime declarations cannot provide compiler-reserved script supersession proofs.');
@@ -2006,6 +2007,12 @@ final class ArtifactCompiler
             $entityKey = 'entity_collection:' . $collection['type'];
             foreach ( $collection['aliases'] as $alias ) if ( isset($keys['entity_collection:' . $alias]) ) { $entityKey = 'entity_collection:' . $alias; break; }
             if ( array() !== $collection['entities'] && ! isset($keys[$entityKey]) ) {
+                if ( 'forms' === $collection['type'] ) {
+                    $budget = $this->budgetGeneratedForms($declarations, $collection['entities'], $entryPath, $entityKey, isset($keys['dependency:' . $capability]));
+                    $collection['entities'] = $budget['entities'];
+                    if ( null !== $budget['diagnostic'] ) $diagnostics[] = $budget['diagnostic'];
+                }
+                if ( array() === $collection['entities'] ) continue;
                 $declarations[] = array('kind' => 'entity_collection', 'type' => $collection['type'], 'source_path' => $entryPath, 'payload' => array('schema' => $collection['schema'], 'entities' => $collection['entities']));
                 $keys[$entityKey] = true;
             }
@@ -2016,6 +2023,67 @@ final class ArtifactCompiler
             }
         }
         return RuntimeDeclarations::normalizeList($declarations);
+    }
+
+    /**
+     * Keep generated form declarations within the same canonical limit enforced
+     * for caller declarations, without ever trimming a JSON entity in place.
+     *
+     * @param array<int,array<string,mixed>> $declarations
+     * @param array<int,array<string,mixed>> $forms
+     * @return array{entities:array<int,array<string,mixed>>,diagnostic:array<string,mixed>|null}
+     */
+    private function budgetGeneratedForms(array $declarations, array $forms, string $entryPath, string $entityKey, bool $hasDependency): array
+    {
+        $fits = static function (array $entities) use ($declarations, $entryPath, $entityKey, $hasDependency): bool {
+            $candidate = array_merge($declarations, array(array('kind' => 'entity_collection', 'type' => 'forms', 'source_path' => $entryPath, 'payload' => array('schema' => 'generic/forms/v1', 'entities' => $entities))));
+            if ( ! $hasDependency ) $candidate[] = array('kind' => 'dependency', 'capability' => 'form', 'source_path' => $entryPath, 'required_for' => array($entityKey));
+            try {
+                RuntimeDeclarations::normalizeList($candidate);
+                return true;
+            } catch (\InvalidArgumentException $error) {
+                if (str_contains($error->getMessage(), 'payload exceeds the byte limit') || str_contains($error->getMessage(), 'aggregate canonical byte limit')) return false;
+                throw $error;
+            }
+        };
+        if ( $fits($forms) ) return array('entities' => $forms, 'diagnostic' => null);
+
+        $presentationGraphsDropped = 0;
+        foreach ( $forms as &$form ) {
+            if ( isset($form['presentation_graph']) ) {
+                unset($form['presentation_graph']);
+                ++$presentationGraphsDropped;
+                if ( $fits($forms) ) return array('entities' => $forms, 'diagnostic' => $this->formsBudgetDiagnostic($forms, array(), $presentationGraphsDropped));
+            }
+        }
+        unset($form);
+
+        $retained = array();
+        $omitted = array();
+        foreach ( $forms as $form ) {
+            $candidate = array_merge($retained, array($form));
+            if ( ! $fits($candidate) ) {
+                $omitted = array_slice($forms, count($retained));
+                break;
+            }
+            $retained[] = $form;
+        }
+        return array('entities' => $retained, 'diagnostic' => $this->formsBudgetDiagnostic($retained, $omitted, $presentationGraphsDropped));
+    }
+
+    /** @param array<int,array<string,mixed>> $retained @param array<int,array<string,mixed>> $omitted @return array<string,mixed> */
+    private function formsBudgetDiagnostic(array $retained, array $omitted, int $presentationGraphsDropped): array
+    {
+        $sample = static function (array $forms): array {
+            return array_slice(array_map(static fn(array $form): array => array('source_path' => (string) ($form['source_path'] ?? ''), 'selector' => (string) ($form['selector'] ?? '')), $forms), 0, 8);
+        };
+        return $this->diagnostic('runtime_declarations_forms_budgeted', 'warning', 'Compiler-generated form declarations exceeded the canonical runtime declaration budget; source fallback markup remains in place for omitted forms.', array(
+            'retained_count' => count($retained),
+            'omitted_count' => count($omitted),
+            'presentation_graphs_dropped' => $presentationGraphsDropped,
+            'retained_samples' => $sample($retained),
+            'omitted_samples' => $sample($omitted),
+        ));
     }
 
     /** @param array<string,mixed> $fallback @param array<int,array<string,mixed>> $files @return array<int,array<string,string>> */

--- a/php-transformer/src/ArtifactCompiler/RuntimeDeclarations.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeDeclarations.php
@@ -19,8 +19,10 @@ final class RuntimeDeclarations
     public const MAX_PROVENANCE_DEPTH = 32;
     // Declarations are metadata, so keep their aggregate below one artifact file.
     public const MAX_TOTAL_DECLARATION_BYTES = ArtifactNormalizer::DEFAULT_MAX_FILE_BYTES;
-    private const MAX_PAYLOAD_BYTES = self::MAX_TOTAL_DECLARATION_BYTES;
+    public const MAX_PAYLOAD_BYTES = self::MAX_TOTAL_DECLARATION_BYTES;
     private const MAX_CANONICAL_DEPTH = self::MAX_PROVENANCE_DEPTH + 1;
+    public const RECORD_MANIFEST_SCHEMA = 'blocks-engine/runtime-record-references/v1';
+    public const RECORD_SCHEMA = 'blocks-engine/runtime-record/v1';
 
     /** @param array<string,mixed> $artifact @return array<int,array<string,mixed>> */
     public static function normalize(array $artifact): array
@@ -67,10 +69,15 @@ final class RuntimeDeclarations
                 try { $encoded = self::canonicalJson($payload); } catch (InvalidArgumentException) { throw new InvalidArgumentException("Runtime declaration {$index} payload is not serializable."); }
                 if (strlen($encoded) > self::MAX_PAYLOAD_BYTES) throw new InvalidArgumentException("Runtime declaration {$index} payload exceeds the byte limit.");
                 $normalized['payload'] = $payload;
+                $manifest = RuntimeEntityManifest::SCHEMA === ($payload['schema'] ?? null);
+                if ($manifest && (!is_string($payload['entity_schema'] ?? null) || !is_array($payload['entities'] ?? null) || !array_is_list($payload['entities']))) throw new InvalidArgumentException("Runtime declaration {$index} entity manifest is invalid.");
                 if ('entity_collection' === $kind && 'forms' === $name && 'generic/forms/v1' === ($payload['schema'] ?? null)) foreach ($payload['entities'] ?? array() as $entity) if (is_array($entity) && isset($entity['layout_graph'])) { if (!is_array($entity['layout_graph'])) throw new InvalidArgumentException("Runtime declaration {$index} form layout graph must be an object."); FormLayoutGraphBuilder::assertValid($entity['layout_graph']); }
                 if ('entity_collection' === $kind && 'forms' === $name && 'generic/forms/v1' === ($payload['schema'] ?? null)) foreach ($payload['entities'] ?? array() as $entity) if (is_array($entity) && isset($entity['presentation_graph'])) { if (!is_array($entity['presentation_graph'])) throw new InvalidArgumentException("Runtime declaration {$index} form presentation graph must be an object."); FormPresentationGraphBuilder::assertValid($entity['presentation_graph']); }
             }
-            if ('entity_collection' === $kind && (!isset($normalized['type'], $normalized['payload']['entities']) || !array_is_list($normalized['payload']['entities']))) throw new InvalidArgumentException("Runtime declaration {$index} entity collections require a typed entities payload.");
+            if ('entity_collection' === $kind && !isset($normalized['type'])) throw new InvalidArgumentException("Runtime declaration {$index} entity collections require a typed entities payload.");
+            if ('entity_collection' === $kind && !isset($normalized['payload']['entities']) && self::RECORD_MANIFEST_SCHEMA !== ($normalized['payload']['schema'] ?? null)) throw new InvalidArgumentException("Runtime declaration {$index} entity collections require a typed entities payload.");
+            if ('entity_collection' === $kind && isset($normalized['payload']['entities']) && !array_is_list($normalized['payload']['entities'])) throw new InvalidArgumentException("Runtime declaration {$index} entity collections require a typed entities payload.");
+            if (self::RECORD_MANIFEST_SCHEMA === ($normalized['payload']['schema'] ?? null)) self::assertRecordManifest($normalized['payload'], $index);
             if (isset($declaration['required_for'])) {
                 if (!is_array($declaration['required_for']) || !array_is_list($declaration['required_for']) || array_filter($declaration['required_for'], static fn(mixed $value): bool => !is_string($value) || '' === $value)) throw new InvalidArgumentException("Runtime declaration {$index} required_for must be a list of declaration keys.");
                 if (count($declaration['required_for']) !== count(array_unique($declaration['required_for']))) throw new InvalidArgumentException("Runtime declaration {$index} required_for must not contain duplicates.");
@@ -149,6 +156,45 @@ final class RuntimeDeclarations
         if ($declarations !== self::normalizeList($declarations)) throw new InvalidArgumentException('Runtime declarations are not canonically normalized or have stale hashes.');
     }
 
+    /** @param array<int,array<string,mixed>> $declarations @return array{declarations:array<int,array<string,mixed>>,records:array<int,array<string,mixed>>} */
+    public static function factor(array $declarations): array
+    {
+        try { return array('declarations' => self::normalizeList($declarations), 'records' => array()); }
+        catch (InvalidArgumentException $error) { if (!str_contains($error->getMessage(), 'payload exceeds the byte limit') && !str_contains($error->getMessage(), 'aggregate canonical byte limit')) throw $error; }
+        $records = array();
+        foreach ($declarations as $index => &$declaration) {
+            $payload = $declaration['payload'] ?? null;
+            if (!is_array($payload) || !is_array($payload['entities'] ?? null) || !array_is_list($payload['entities'])) continue;
+            $chunks = array(); $chunk = array();
+            foreach ($payload['entities'] as $entity) { $candidate = array_merge($chunk, array($entity)); if (strlen(self::canonicalJson(array('schema' => $payload['schema'], 'entities' => $candidate))) > self::MAX_PAYLOAD_BYTES) { if (array() === $chunk) throw new InvalidArgumentException("Runtime declaration {$index} contains an entity that exceeds the byte limit."); $chunks[] = $chunk; $chunk = array($entity); } else $chunk = $candidate; }
+            if (array() !== $chunk) $chunks[] = $chunk;
+            $references = array(); foreach ($chunks as $chunk) { $recordPayload = array('schema' => $payload['schema'], 'entities' => $chunk); $encoded = self::canonicalJson($recordPayload); $hash = self::hash($recordPayload); $id = 'runtime-record-' . $hash; $records[$id] = array('schema' => self::RECORD_SCHEMA, 'id' => $id, 'content_hash' => $hash, 'bytes' => strlen($encoded), 'payload' => $recordPayload); $references[] = array('id' => $id, 'content_hash' => $hash, 'bytes' => strlen($encoded)); }
+            $declaration['payload'] = array('schema' => self::RECORD_MANIFEST_SCHEMA, 'record_schema' => $payload['schema'], 'records' => $references); unset($declaration['reconciliation_identity'], $declaration['payload_hash'], $declaration['content_hash']);
+        }
+        unset($declaration); ksort($records, SORT_STRING); return array('declarations' => self::normalizeList($declarations), 'records' => array_values($records));
+    }
+
+    /** @param array<int,array<string,mixed>> $records @return array<int,array<string,mixed>> */
+    public static function normalizeRecords(array $records): array
+    {
+        if (!array_is_list($records) || count($records) > self::MAX_DECLARATIONS) throw new InvalidArgumentException('Runtime records must be a bounded ordered collection.');
+        $normalized = array(); foreach ($records as $index => $record) { if (!is_array($record) || self::RECORD_SCHEMA !== ($record['schema'] ?? null) || !is_string($record['id'] ?? null) || !preg_match('/^runtime-record-[a-f0-9]{64}$/', $record['id']) || !self::isHash($record['content_hash'] ?? null) || !is_int($record['bytes'] ?? null) || $record['bytes'] < 1 || $record['bytes'] > self::MAX_PAYLOAD_BYTES || !is_array($record['payload'] ?? null) || !is_string($record['payload']['schema'] ?? null) || !is_array($record['payload']['entities'] ?? null) || !array_is_list($record['payload']['entities'])) throw new InvalidArgumentException("Runtime record {$index} is invalid."); $payload = self::canonical($record['payload']); $encoded = self::canonicalJson($payload); $hash = self::hash($payload); if ($record['id'] !== 'runtime-record-' . $hash || $record['content_hash'] !== $hash || $record['bytes'] !== strlen($encoded)) throw new InvalidArgumentException("Runtime record {$index} has a stale identity or content hash."); $normalized[] = array('schema' => self::RECORD_SCHEMA, 'id' => $record['id'], 'content_hash' => $hash, 'bytes' => strlen($encoded), 'payload' => $payload); }
+        usort($normalized, static fn(array $left, array $right): int => strcmp($left['id'], $right['id'])); if (count(array_unique(array_column($normalized, 'id'))) !== count($normalized)) throw new InvalidArgumentException('Runtime records must have unique content-addressed ids.'); return $normalized;
+    }
+
+    /** @param array<int,array<string,mixed>> $declarations @param array<int,array<string,mixed>> $records @return array<int,array<string,mixed>> */
+    public static function materialize(array $declarations, array $records): array
+    {
+        $recordsById = array_column(self::normalizeRecords($records), null, 'id'); foreach ($declarations as &$declaration) { $payload = $declaration['payload'] ?? array(); if (self::RECORD_MANIFEST_SCHEMA !== ($payload['schema'] ?? null)) continue; $entities = array(); foreach ($payload['records'] as $reference) { $record = $recordsById[$reference['id']] ?? null; if (!is_array($record) || $record['content_hash'] !== $reference['content_hash'] || $record['bytes'] !== $reference['bytes'] || $record['payload']['schema'] !== $payload['record_schema']) throw new InvalidArgumentException('Runtime declaration record reference is unresolved or stale.'); array_push($entities, ...$record['payload']['entities']); } $declaration['payload'] = array('schema' => $payload['record_schema'], 'entities' => $entities); } unset($declaration); return $declarations;
+    }
+
+    /** @param array<string,mixed> $payload */
+    private static function assertRecordManifest(array $payload, int $index): void
+    {
+        if (!is_string($payload['record_schema'] ?? null) || !is_array($payload['records'] ?? null) || !array_is_list($payload['records']) || array() === $payload['records'] || count($payload['records']) > self::MAX_DECLARATIONS) throw new InvalidArgumentException("Runtime declaration {$index} record manifest is invalid.");
+        $seen = array(); foreach ($payload['records'] as $reference) { if (!is_array($reference) || !is_string($reference['id'] ?? null) || !preg_match('/^runtime-record-[a-f0-9]{64}$/', $reference['id']) || !self::isHash($reference['content_hash'] ?? null) || !is_int($reference['bytes'] ?? null) || $reference['bytes'] < 1 || $reference['bytes'] > self::MAX_PAYLOAD_BYTES || $reference['id'] !== 'runtime-record-' . $reference['content_hash'] || isset($seen[$reference['id']])) throw new InvalidArgumentException("Runtime declaration {$index} record manifest has an invalid reference."); $seen[$reference['id']] = true; }
+    }
+
     public static function canonicalJson(mixed $value): string
     {
         try { return json_encode(self::canonical($value), JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE); } catch (JsonException) { throw new InvalidArgumentException('Runtime declaration payload is not serializable.'); }
@@ -217,7 +263,7 @@ final class RuntimeDeclarations
         hash_update($context, '"');
     }
 
-    private static function canonical(mixed $value, int $depth = 0): mixed
+    public static function canonical(mixed $value, int $depth = 0): mixed
     {
         if ($depth > self::MAX_CANONICAL_DEPTH || is_resource($value) || is_object($value)) throw new InvalidArgumentException('Runtime declaration payload contains an unsupported value.');
         if (!is_array($value)) return $value;

--- a/php-transformer/src/ArtifactCompiler/RuntimeEntityManifest.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeEntityManifest.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
+
+use InvalidArgumentException;
+
+/** Bounded, content-addressed records for declaration entities. */
+final class RuntimeEntityManifest
+{
+    public const SCHEMA = 'blocks-engine/runtime-entity-manifest/v1';
+
+    /** @param array<int,array<string,mixed>> $entities @return array{payload:array<string,mixed>,records:array<int,array<string,mixed>>} */
+    public static function fromEntities(string $entitySchema, array $entities): array
+    {
+        $records = array(); $references = array();
+        foreach ($entities as $entity) {
+            if (!is_array($entity)) throw new InvalidArgumentException('Runtime entity manifest records must be objects.');
+            $entity = RuntimeDeclarations::canonical($entity);
+            $hash = RuntimeDeclarations::hash($entity);
+            $record = array('content_hash' => $hash, 'entity' => $entity);
+            if (strlen(RuntimeDeclarations::canonicalJson($record)) > RuntimeDeclarations::MAX_PAYLOAD_BYTES) throw new InvalidArgumentException('Runtime entity manifest record exceeds the 5 MiB payload limit.');
+            $records[$hash] = $record;
+            $references[] = array('content_hash' => $hash);
+        }
+        ksort($records, SORT_STRING);
+        $payload = array('schema' => self::SCHEMA, 'entity_schema' => $entitySchema, 'entities' => $references);
+        if (strlen(RuntimeDeclarations::canonicalJson($payload)) > RuntimeDeclarations::MAX_PAYLOAD_BYTES) throw new InvalidArgumentException('Runtime entity manifest references exceed the 5 MiB payload limit.');
+        return array('payload' => $payload, 'records' => array_values($records));
+    }
+
+    /** @param array<int,mixed> $records @return array<int,array<string,mixed>> */
+    public static function normalizeRecords(array $records): array
+    {
+        $normalized = array();
+        foreach ($records as $record) {
+            if (!is_array($record) || array('content_hash', 'entity') !== array_keys($record) || !is_string($record['content_hash'] ?? null) || !preg_match('/^[a-f0-9]{64}$/', $record['content_hash']) || !is_array($record['entity'] ?? null) || $record['content_hash'] !== RuntimeDeclarations::hash($record['entity']) || strlen(RuntimeDeclarations::canonicalJson($record)) > RuntimeDeclarations::MAX_PAYLOAD_BYTES) throw new InvalidArgumentException('Runtime entity manifest record is invalid or exceeds the 5 MiB payload limit.');
+            if (isset($normalized[$record['content_hash']])) throw new InvalidArgumentException('Runtime entity manifest record hashes must be unique.');
+            $normalized[$record['content_hash']] = array('content_hash' => $record['content_hash'], 'entity' => RuntimeDeclarations::canonical($record['entity']));
+        }
+        ksort($normalized, SORT_STRING);
+        return array_values($normalized);
+    }
+
+    /** @param array<string,mixed> $payload @param array<int,mixed> $records @return array<int,array<string,mixed>> */
+    public static function resolve(array $payload, array $records): array
+    {
+        if (array('entities', 'entity_schema', 'schema') !== array_keys($payload) || self::SCHEMA !== ($payload['schema'] ?? null) || !is_string($payload['entity_schema'] ?? null) || !is_array($payload['entities'] ?? null) || !array_is_list($payload['entities'])) throw new InvalidArgumentException('Runtime entity manifest payload is invalid.');
+        $byHash = array_column(self::normalizeRecords($records), 'entity', 'content_hash');
+        $entities = array();
+        foreach ($payload['entities'] as $reference) {
+            $hash = is_array($reference) ? ($reference['content_hash'] ?? null) : null;
+            if (!is_array($reference) || array('content_hash') !== array_keys($reference) || !is_string($hash) || !isset($byHash[$hash])) throw new InvalidArgumentException('Runtime entity manifest references an undeclared record.');
+            $entities[] = $byHash[$hash];
+        }
+        return $entities;
+    }
+}

--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
@@ -7,6 +7,7 @@ use Automattic\BlocksEngine\PhpTransformer\Support\ShellLandmarkPolicy;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
 use Automattic\BlocksEngine\PhpTransformer\Contract\EditabilityPolicy;
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\RuntimeDeclarations;
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\RuntimeEntityManifest;
 use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\SrcsetParser;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
 use InvalidArgumentException;
@@ -39,7 +40,7 @@ final class WordPressSitePlan
     public static function planIdentity(array $plan): array
     {
         $canonical = $plan;
-        unset($canonical['resolution']);
+        unset($canonical['resolution'], $canonical['runtime_entity_resolution']);
         // The identity describes the plan; including it would make its hash recursive.
         unset($canonical['plan_identity']);
         return array('schema' => self::IDENTITY_SCHEMA, 'hash' => RuntimeDeclarations::hash($canonical));
@@ -76,6 +77,8 @@ final class WordPressSitePlan
         }
 
         $runtimeDeclarations = $compiled['runtime_declarations'] ?? array();
+        $runtimeRecords = RuntimeDeclarations::normalizeRecords($compiled['runtime_records'] ?? array());
+        $runtimeDeclarations = RuntimeDeclarations::materialize($runtimeDeclarations, $runtimeRecords);
         $runtimeScriptOwnership = $this->runtimeScriptOwnership($data['source_reports'], $runtimeDeclarations);
         $documents = $this->withoutOwnedRuntimeScripts($this->decideDocuments($compiled['pages'] ?? null), $runtimeScriptOwnership['documents']);
         $documentScriptAssets = $this->documentScriptAssets($documents);
@@ -114,6 +117,9 @@ final class WordPressSitePlan
         // extraction. Asset and route projection can make source anchors equal,
         // so assign occurrences only after that shared projection is complete.
         $runtimeDeclarations = $this->canonicalEntityBindings($runtimeDeclarations, $references, $routeMap, $pages);
+        $factoredRuntimeDeclarations = RuntimeDeclarations::factor($runtimeDeclarations);
+        $runtimeDeclarations = $factoredRuntimeDeclarations['declarations'];
+        $runtimeRecords = $factoredRuntimeDeclarations['records'];
         $pages = $this->pageHierarchy($pages, $routeMap);
         $assets = $this->scopeAssets($assets, $pages);
         $projector = new ThemeJsonProjection();
@@ -159,6 +165,8 @@ final class WordPressSitePlan
             'theme' => array('stylesheet' => 'style.css', 'theme_json' => 'theme.json', 'bootstrap' => self::needsBootstrap($assets, $scriptLoading['scripts'], $parts, $templates) ? 'functions.php' : null, 'design_token_provenance' => $themeProjection['provenance']),
             'visual_repair' => $compiled['visual_repair'] ?? array(),
             'runtime_declarations' => $runtimeDeclarations,
+            'runtime_records' => $runtimeRecords,
+            'runtime_entity_records' => $compiled['runtime_entity_records'] ?? array(),
             'diagnostics' => array_merge($data['diagnostics'], $inlineShells['diagnostics'], $shells['diagnostics'], $scriptLoading['diagnostics']),
             'quality' => array('status' => $data['status'], 'pass' => 'failed' !== $data['status'], 'metrics' => array_diff_key($data['metrics'], array('transform_duration_ms' => true)), 'fallbacks' => $data['fallbacks'], 'core_html_fallback_evidence' => $data['source_reports']['conversion_report']['core_html_fallback_evidence'] ?? array(), 'editability_policy' => $editabilityPolicy ?? array()),
             'reporting' => $this->reporting($pages, $data, array_merge($inlineShells['diagnostics'], $shells['diagnostics'], $scriptLoading['diagnostics']), $surfaces),
@@ -205,7 +213,7 @@ final class WordPressSitePlan
         if ( self::SCHEMA !== ($plan['schema'] ?? null) ) {
             throw new InvalidArgumentException('WordPress site plan has an unsupported schema.');
         }
-        foreach ( array('plan_identity', 'source', 'pages', 'templates', 'template_parts', 'assets', 'reference_tokens', 'reference_semantics', 'writes', 'operations', 'routes', 'navigation_links', 'menus', 'theme', 'visual_repair', 'runtime_declarations', 'diagnostics', 'quality', 'reporting') as $key ) {
+        foreach ( array('plan_identity', 'source', 'pages', 'templates', 'template_parts', 'assets', 'reference_tokens', 'reference_semantics', 'writes', 'operations', 'routes', 'navigation_links', 'menus', 'theme', 'visual_repair', 'runtime_declarations', 'runtime_entity_records', 'diagnostics', 'quality', 'reporting') as $key ) {
             if ( ! is_array($plan[$key] ?? null) ) {
                 throw new InvalidArgumentException(sprintf('WordPress site plan %s must be an array.', $key));
             }
@@ -216,6 +224,9 @@ final class WordPressSitePlan
         self::assertSource($plan['source']);
         $sourceCatalog = self::sourceDocumentCatalogFromSource($plan['source']);
         RuntimeDeclarations::assertNormalized($plan['runtime_declarations']);
+        $records = RuntimeEntityManifest::normalizeRecords($plan['runtime_entity_records']);
+        if ($records !== $plan['runtime_entity_records']) throw new InvalidArgumentException('WordPress site plan runtime entity records are not canonically normalized.');
+        foreach ($plan['runtime_declarations'] as $declaration) if (RuntimeEntityManifest::SCHEMA === ($declaration['payload']['schema'] ?? null)) RuntimeEntityManifest::resolve($declaration['payload'], $records);
         self::assertEntityBindingsRemainPageOwned($plan['runtime_declarations'], $plan['pages'], $plan['assets']);
         if ('declared_tokens_only' !== ($plan['reference_semantics']['static_browser_references'] ?? null) || !in_array($plan['reference_semantics']['dynamic_script_references'] ?? null, array('proven', 'not_proven'), true) || !is_array($plan['reference_semantics']['dynamic_client_assets'] ?? null) || !in_array($plan['reference_semantics']['dynamic_client_assets']['status'] ?? null, array('proven', 'not_proven'), true) || !is_bool($plan['reference_semantics']['dynamic_client_assets']['materializer_may_reject'] ?? null) || ($plan['reference_semantics']['dynamic_script_references'] ?? null) !== ($plan['reference_semantics']['dynamic_client_assets']['status'] ?? null) || ('proven' === $plan['reference_semantics']['dynamic_client_assets']['status'] && true === $plan['reference_semantics']['dynamic_client_assets']['materializer_may_reject'])) throw new InvalidArgumentException('WordPress site plan reference capability semantics are invalid.');
         self::assertRows($plan['routes'], 'route', array('kind', 'source_path', 'target_path', 'target_slug', 'source_relation', 'order'));

--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlanResolver.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlanResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan;
 
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\RuntimeDeclarations;
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\RuntimeEntityManifest;
 use InvalidArgumentException;
 
 /** Resolves declared asset tokens using explicit runtime destination context. */
@@ -33,6 +34,7 @@ final class WordPressSitePlanResolver
         // Provider bindings replace page markup, so their anchors must use the
         // same destination projection as the page materialized by consumers.
         $plan['runtime_declarations'] = self::resolveEntityBindings($plan['runtime_declarations'], $plan['pages'], $references);
+        $plan['runtime_entity_resolution'] = self::resolveManifestEntities($plan['runtime_declarations'], $plan['runtime_entity_records'], $plan['pages'], $references);
         foreach ($plan['writes'] as &$write) if ('utf8' === $write['payload']['encoding']) { $write['canonical_payload'] = $write['payload']['data']; $write['canonical_payload_hash'] = WordPressSitePlan::contentHash($write['canonical_payload']); $write['payload']['data'] = self::resolveWritePayload($write['canonical_payload'], $plan['reference_tokens'], $themeUri, $write['target_path']); $write['payload_hash'] = WordPressSitePlan::contentHash($write['payload']['data']); }
         unset($write);
         foreach (array('pages', 'template_parts') as $documents) foreach ($plan[$documents] as &$document) foreach (array('links', 'scripts') as $kind) { if (!is_array($document['document_metadata'][$kind] ?? null)) continue; foreach ($document['document_metadata'][$kind] as &$declaration) if (is_string($declaration['asset_reference'] ?? null)) $declaration['resolved_url'] = self::resolvePayload($declaration['asset_reference'], $references); }
@@ -56,7 +58,7 @@ final class WordPressSitePlanResolver
         return self::resolvePayload($content, self::referencesForWrite($tokens, $themeUri, $targetPath));
     }
     /** @param array<int,array<string,mixed>> $declarations @param array<int,array<string,mixed>> $pages @param array<string,string> $references @return array<int,array<string,mixed>> */
-    private static function resolveEntityBindings(array $declarations, array $pages, array $references): array
+    private static function resolveEntityBindings(array $declarations, array $pages, array $references, bool $normalize = true): array
     {
         $pagesBySource = array_column($pages, null, 'source_path');
         foreach ($declarations as $declarationIndex => $declaration) {
@@ -89,7 +91,20 @@ final class WordPressSitePlanResolver
         }
         foreach ($declarations as &$declaration) unset($declaration['payload_hash'], $declaration['content_hash']);
         unset($declaration);
-        return RuntimeDeclarations::normalizeList($declarations);
+        return $normalize ? RuntimeDeclarations::normalizeList($declarations) : $declarations;
+    }
+    /** @param array<int,array<string,mixed>> $declarations @param array<int,array<string,mixed>> $records @param array<int,array<string,mixed>> $pages @param array<string,string> $references @return array<int,array<string,mixed>> */
+    private static function resolveManifestEntities(array $declarations, array $records, array $pages, array $references): array
+    {
+        $resolved = array();
+        foreach ($declarations as $declaration) {
+            $payload = $declaration['payload'] ?? null;
+            if (!is_array($payload) || RuntimeEntityManifest::SCHEMA !== ($payload['schema'] ?? null)) continue;
+            $entities = RuntimeEntityManifest::resolve($payload, $records);
+            $expanded = self::resolveEntityBindings(array(array('payload' => array('entities' => $entities))), $pages, $references, false);
+            $resolved[] = array('reconciliation_identity' => $declaration['reconciliation_identity'], 'kind' => $declaration['kind'], 'type' => $declaration['type'] ?? null, 'entity_schema' => $payload['entity_schema'], 'entities' => $expanded[0]['payload']['entities']);
+        }
+        return $resolved;
     }
     /** @return array<int,array{offset:int,length:int}> */
     private static function blockRanges(string $markup): array

--- a/php-transformer/tests/contract/staged-artifact-compilation.php
+++ b/php-transformer/tests/contract/staged-artifact-compilation.php
@@ -7,7 +7,9 @@ use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactNormalizer;
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\PayloadReader;
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\RuntimeDeclarations;
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\RuntimeEntityManifest;
 use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlan;
+use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanResolver;
 
 $assert = static function (bool $condition, string $message): void { if (!$condition) throw new RuntimeException($message); };
 $throws = static function (callable $callback, string $message) use ($assert): void { try { $callback(); } catch (InvalidArgumentException) { return; } $assert(false, $message); };
@@ -123,11 +125,15 @@ $unbudgetedFormsBytes = strlen(RuntimeDeclarations::canonicalJson(array('schema'
 $assert($unbudgetedFormsBytes > RuntimeDeclarations::MAX_TOTAL_DECLARATION_BYTES, sprintf('Generated form metadata exceeds the 5 MiB runtime declaration ceiling before compiler budgeting (%d bytes across %d forms).', $unbudgetedFormsBytes, count($unbudgetedForms)));
 $largeFormsPlan = $largeFormsStaged['source_reports']['wordpress_site_plan'] ?? array();
 $largeFormsDeclarations = array_values(array_filter($largeFormsPlan['runtime_declarations'] ?? array(), static fn(array $declaration): bool => 'forms' === ($declaration['type'] ?? null)));
-$largeFormsDiagnostic = current(array_filter($largeFormsStaged['diagnostics'] ?? array(), static fn(array $diagnostic): bool => 'runtime_declarations_forms_budgeted' === ($diagnostic['code'] ?? null)));
-$assert(1 === count($largeFormsDeclarations) && strlen(RuntimeDeclarations::canonicalJson($largeFormsDeclarations[0]['payload'] ?? null)) <= RuntimeDeclarations::MAX_TOTAL_DECLARATION_BYTES && ($largeFormsWhole['source_reports']['wordpress_site_plan']['runtime_declarations'] ?? array()) === ($largeFormsPlan['runtime_declarations'] ?? array()), 'JSON shared, page, and receipt checkpoints compose one bounded forms declaration identical to whole compilation.');
-$assert(2 === ($largeFormsDiagnostic['context']['presentation_graphs_dropped'] ?? 0) && 1 === ($largeFormsDiagnostic['context']['retained_count'] ?? 0) && 1 === ($largeFormsDiagnostic['context']['omitted_count'] ?? 0) && 'a.html' === ($largeFormsDiagnostic['context']['retained_samples'][0]['source_path'] ?? '') && 'index.html' === ($largeFormsDiagnostic['context']['omitted_samples'][0]['source_path'] ?? '') && !isset($largeFormsDeclarations[0]['payload']['entities'][0]['presentation_graph']), 'Optional presentation facts are removed before deterministic source-path form omission, while retained entities remain complete.');
-$omittedFallback = current(array_filter($largeFormsStaged['fallbacks'] ?? array(), static fn(array $fallback): bool => 'index.html' === ($fallback['source'] ?? null) && 'html_form_fallback' === ($fallback['diagnostic_code'] ?? null)));
-$assert(str_contains((string) ($omittedFallback['html'] ?? ''), '<select'), 'The omitted form retains its original bounded source fallback markup.');
+$largeFormRecords = $largeFormsPlan['runtime_entity_records'] ?? array();
+$largeFormsResolved = (new WordPressSitePlanResolver())->resolve($largeFormsPlan, array('theme_uri' => 'https://example.test/theme'));
+$resolvedLargeForms = $largeFormsResolved['runtime_entity_resolution'][0]['entities'] ?? array();
+$assert(1 === count($largeFormsDeclarations) && RuntimeEntityManifest::SCHEMA === ($largeFormsDeclarations[0]['payload']['schema'] ?? null) && strlen(RuntimeDeclarations::canonicalJson($largeFormsDeclarations[0]['payload'] ?? null)) <= RuntimeDeclarations::MAX_TOTAL_DECLARATION_BYTES && 2 === count($largeFormRecords) && 2 === count($resolvedLargeForms), 'JSON shared, page, and receipt checkpoints retain a bounded content-addressed forms manifest while the production resolver expands every entity.');
+$assert(6400 === count($resolvedLargeForms[0]['controls'][0]['options'] ?? array()) && isset($resolvedLargeForms[0]['control_topology'], $resolvedLargeForms[0]['layout_graph'], $resolvedLargeForms[0]['presentation_graph'], $resolvedLargeForms[0]['bindings'][0]['search_block_markup']) && 6400 === count($resolvedLargeForms[1]['controls'][0]['options'] ?? array()), 'The manifest resolver materializes every source form with controls, layout and presentation graphs, bindings, and source identity intact.');
+$assert(!array_filter($largeFormsStaged['diagnostics'] ?? array(), static fn(array $diagnostic): bool => 'runtime_declarations_forms_budgeted' === ($diagnostic['code'] ?? null)), 'Oversized generated forms no longer emit a lossy budget omission diagnostic.');
+$tamperedManifestPlan = $largeFormsPlan; $tamperedManifestPlan['runtime_entity_records'][0]['entity']['controls'][0]['options'][0]['label'] = 'forged';
+$throws(static fn() => WordPressSitePlan::assertValid($tamperedManifestPlan), 'Canonical WordPress plan validation rejects a content-addressed runtime record whose entity no longer matches its hash.');
+$throws(static fn() => RuntimeEntityManifest::fromEntities('generic/forms/v1', array(array('value' => str_repeat('x', RuntimeDeclarations::MAX_PAYLOAD_BYTES)))), 'Runtime entity manifests reject a single entity record that exceeds the 5 MiB payload cap.');
 $rootAssetPath = "website/external/Happy Women's Day.jpg";
 $rootAssetUrl = "/external/Happy%20Women's%20Day.jpg";
 $rootAssetArtifact = array('entrypoint' => 'website/index.html', 'files' => array(

--- a/php-transformer/tests/contract/staged-artifact-compilation.php
+++ b/php-transformer/tests/contract/staged-artifact-compilation.php
@@ -95,6 +95,39 @@ $utf8Staged = (new ArtifactCompiler())->compose($utf8Shared, $utf8Receipts)->toA
 $utf8MetadataDiagnostic = current(array_filter($utf8Staged['diagnostics'] ?? array(), static fn (array $diagnostic): bool => 'html_head_metadata_not_carried' === ($diagnostic['code'] ?? null)));
 $utf8Content = $utf8MetadataDiagnostic['entries'][0]['content'] ?? null;
 $assert(str_repeat('a', 499) === $utf8Content && 499 === strlen($utf8Content) && 1 === preg_match('//u', $utf8Content), 'Serialized shared, page, and compiled checkpoints retain the 500-byte metadata diagnostic bound at a UTF-8 character boundary without replacement or conversion.');
+$largeOptions = '';
+$largeOptionValue = str_repeat('choice-', 16);
+for ($index = 0; $index < 6400; ++$index) $largeOptions .= '<option value="' . $largeOptionValue . '">' . $largeOptionValue . '</option>';
+$largeFormsArtifact = array('entrypoint' => 'index.html', 'compiler_limits' => array('max_total_bytes' => 10485760), 'files' => array(
+    'a.html' => '<main><form id="first"><select name="first">' . $largeOptions . '</select><button type="submit">Submit</button></form></main>',
+    'index.html' => '<main><form id="second"><select name="second">' . $largeOptions . '</select><button type="submit">Submit</button></form></main>',
+));
+$largeFormsWhole = $compiler->compile($largeFormsArtifact)->toArray();
+$largeFormsShared = json_decode(json_encode($compiler->prepareShared($largeFormsArtifact), JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
+$largeFormsPages = json_decode(json_encode($compiler->preparePages($largeFormsArtifact, $largeFormsShared), JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
+$largeFormsReceipts = json_decode(json_encode($compiler->compilePreparedPages($largeFormsShared, $largeFormsPages), JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
+$largeFormsStaged = $compiler->compose($largeFormsShared, array_reverse($largeFormsReceipts))->toArray();
+$unbudgetedForms = array();
+foreach ($largeFormsWhole['fallbacks'] ?? array() as $fallback) {
+    if ('html_form_fallback' !== ($fallback['diagnostic_code'] ?? null) || !is_array($fallback['controls'] ?? null)) continue;
+    $sourcePath = is_string($fallback['source'] ?? null) ? $fallback['source'] : 'index.html';
+    $selector = is_string($fallback['selector'] ?? null) ? $fallback['selector'] : '';
+    $form = array('selector' => $selector, 'source_path' => $sourcePath, 'form' => is_array($fallback['form'] ?? null) ? $fallback['form'] : array(), 'controls' => array_values(array_filter($fallback['controls'], 'is_array')));
+    foreach (array('fallback_identity', 'reconciliation_identity') as $identityKey) if (is_string($fallback[$identityKey] ?? null)) $form[$identityKey] = $fallback[$identityKey];
+    foreach (array('control_topology', 'layout_graph', 'presentation_graph') as $graph) if (is_array($fallback[$graph] ?? null) && true !== ($fallback[$graph]['truncated'] ?? false)) $form[$graph] = $fallback[$graph];
+    if (is_array($fallback['binding'] ?? null) && 'generic/block-binding/v1' === ($fallback['binding']['schema'] ?? null)) $form['bindings'] = array(array_merge($fallback['binding'], array('source_path' => $sourcePath)));
+    if (isset($form['bindings'])) $unbudgetedForms[$sourcePath . "\n" . $selector] = $form;
+}
+ksort($unbudgetedForms, SORT_STRING);
+$unbudgetedFormsBytes = strlen(RuntimeDeclarations::canonicalJson(array('schema' => 'generic/forms/v1', 'entities' => array_values($unbudgetedForms))));
+$assert($unbudgetedFormsBytes > RuntimeDeclarations::MAX_TOTAL_DECLARATION_BYTES, sprintf('Generated form metadata exceeds the 5 MiB runtime declaration ceiling before compiler budgeting (%d bytes across %d forms).', $unbudgetedFormsBytes, count($unbudgetedForms)));
+$largeFormsPlan = $largeFormsStaged['source_reports']['wordpress_site_plan'] ?? array();
+$largeFormsDeclarations = array_values(array_filter($largeFormsPlan['runtime_declarations'] ?? array(), static fn(array $declaration): bool => 'forms' === ($declaration['type'] ?? null)));
+$largeFormsDiagnostic = current(array_filter($largeFormsStaged['diagnostics'] ?? array(), static fn(array $diagnostic): bool => 'runtime_declarations_forms_budgeted' === ($diagnostic['code'] ?? null)));
+$assert(1 === count($largeFormsDeclarations) && strlen(RuntimeDeclarations::canonicalJson($largeFormsDeclarations[0]['payload'] ?? null)) <= RuntimeDeclarations::MAX_TOTAL_DECLARATION_BYTES && ($largeFormsWhole['source_reports']['wordpress_site_plan']['runtime_declarations'] ?? array()) === ($largeFormsPlan['runtime_declarations'] ?? array()), 'JSON shared, page, and receipt checkpoints compose one bounded forms declaration identical to whole compilation.');
+$assert(2 === ($largeFormsDiagnostic['context']['presentation_graphs_dropped'] ?? 0) && 1 === ($largeFormsDiagnostic['context']['retained_count'] ?? 0) && 1 === ($largeFormsDiagnostic['context']['omitted_count'] ?? 0) && 'a.html' === ($largeFormsDiagnostic['context']['retained_samples'][0]['source_path'] ?? '') && 'index.html' === ($largeFormsDiagnostic['context']['omitted_samples'][0]['source_path'] ?? '') && !isset($largeFormsDeclarations[0]['payload']['entities'][0]['presentation_graph']), 'Optional presentation facts are removed before deterministic source-path form omission, while retained entities remain complete.');
+$omittedFallback = current(array_filter($largeFormsStaged['fallbacks'] ?? array(), static fn(array $fallback): bool => 'index.html' === ($fallback['source'] ?? null) && 'html_form_fallback' === ($fallback['diagnostic_code'] ?? null)));
+$assert(str_contains((string) ($omittedFallback['html'] ?? ''), '<select'), 'The omitted form retains its original bounded source fallback markup.');
 $rootAssetPath = "website/external/Happy Women's Day.jpg";
 $rootAssetUrl = "/external/Happy%20Women's%20Day.jpg";
 $rootAssetArtifact = array('entrypoint' => 'website/index.html', 'files' => array(


### PR DESCRIPTION
Closes #1651.

This branch now preserves oversized generated form declarations losslessly. It keeps the single bounded `entity_collection:forms` declaration as an ordered content-addressed manifest and stores complete, individually bounded form records in the canonical WordPress site plan. The resolver validates record hashes and expands complete entities for consumers; it does not strip graphs or omit forms.

The branch contains the original bounded policy commit plus `d0c7daab`, which replaces that policy. Remaining consumer support is in static-site-importer PR #1585.

Checks: Blocks Engine staged artifact compilation, WordPress site plan, and runtime declaration hash contracts.

AI assistance disclosure: OpenCode using openai/gpt-5.6-terra implemented and self-reviewed the lossless bounded-manifest contract under Chris Hubers direction.