### PR TITLE
Fix JSON encoding of Figma archive reports

### DIFF
--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -139,9 +139,9 @@ final class FigmaTransformer
         $sourceReports = array(
             'figma' => array(
                 'input'   => $archive['input'],
-                'archive' => $archive['archive'],
+                'archive' => $this->jsonSafeArchiveReport($archive['archive']),
                 'meta'    => $archive['meta'],
-                'assets'  => $archive['assets'],
+                'assets'  => $this->archiveAssetReport($archive['assets']),
             ),
         );
 
@@ -221,6 +221,67 @@ final class FigmaTransformer
             $parity,
             $metrics
         );
+    }
+
+    /**
+     * Archive assets are input material for export, not report payloads. Keep
+     * their metadata for provenance without duplicating arbitrary binary bytes.
+     *
+     * @param array<int, array<string, mixed>> $assets
+     * @return array<int, array<string, mixed>>
+     */
+    private function archiveAssetReport(array $assets): array
+    {
+        return array_map(
+            static function (array $asset): array {
+                unset($asset['content']);
+                return $asset;
+            },
+            $assets
+        );
+    }
+
+    /**
+     * Decoded Kiwi archive metadata can contain raw byte strings such as image
+     * hashes and font digests. They are not needed by report consumers, so omit
+     * them instead of corrupting them with a lossy UTF-8 replacement.
+     *
+     * @param array<string, mixed> $archive
+     * @return array<string, mixed>
+     */
+    private function jsonSafeArchiveReport(array $archive): array
+    {
+        return $this->omitInvalidUtf8ArchiveValues($archive);
+    }
+
+    /**
+     * @param array<string|int, mixed> $value
+     * @return array<string|int, mixed>
+     */
+    private function omitInvalidUtf8ArchiveValues(array $value): array
+    {
+        $report = array();
+        $isList = array_is_list($value);
+
+        foreach ( $value as $key => $child ) {
+            if ( is_string($key) && ! $this->isValidUtf8($key) ) {
+                continue;
+            }
+            if ( is_string($child) && ! $this->isValidUtf8($child) ) {
+                continue;
+            }
+
+            $report[$key] = is_array($child)
+                ? $this->omitInvalidUtf8ArchiveValues($child)
+                : $child;
+        }
+
+        return $isList ? array_values($report) : $report;
+    }
+
+    private function isValidUtf8(string $value): bool
+    {
+        return 1 === preg_match('//u', $value);
     }
 
     /**

--- a/figma-transformer/tests/contract/KiwiParserContract.php
+++ b/figma-transformer/tests/contract/KiwiParserContract.php
@@ -103,8 +103,48 @@ function blocks_engine_figma_transformer_run_kiwi_parser_contract(callable $asse
     $assert('blocks-engine/figma-transformer/compiled-site/v1' === ($fileResult['source_reports']['compiled_site']['schema'] ?? null), 'file-transform-compiled-site-source-report');
     $assert('synthetic' === ($fileResult['source_reports']['figma']['assets'][0]['id'] ?? null), 'archive-asset-id');
     $assert('images/synthetic' === ($fileResult['source_reports']['figma']['assets'][0]['path'] ?? null), 'archive-asset-path');
-    $assert('asset' === ($fileResult['source_reports']['figma']['assets'][0]['content'] ?? null), 'archive-asset-content');
+    $assert(! array_key_exists('content', $fileResult['source_reports']['figma']['assets'][0] ?? array()), 'archive-asset-content-omitted-from-report');
     $assert('assets/synthetic.bin' === ($fileResult['assets'][0]['path'] ?? null), 'archive-asset-emitted-from-decoded-scenegraph');
+
+    $binaryAssetId = 'binary-report-fixture';
+    $binaryAssetContent = "\x89PNG\r\n\x1a\n\xff\x00binary";
+    $binaryReportPayload = SyntheticFigKiwiFixtureBuilder::nodeChangesPayload('Binary Report');
+    $binaryReportPayload['NODE_CHANGES']['4:1']['node']['children'][2]['asset_id'] = $binaryAssetId;
+    $binaryFontDigest = "\xff\x00\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89";
+    $binaryKiwiMessage = str_replace(
+        'inter-digest',
+        $binaryFontDigest,
+        blocks_engine_figma_transformer_kiwi_derived_text_message_fixture()
+    );
+    $binaryReportFixture = SyntheticFigKiwiFixtureBuilder::figArchive(
+        SyntheticFigKiwiFixtureBuilder::canvas(array(
+            SyntheticFigKiwiFixtureBuilder::jsonZlibChunk($binaryReportPayload),
+            SyntheticFigKiwiFixtureBuilder::zlibChunk(blocks_engine_figma_transformer_kiwi_derived_text_schema_fixture()),
+            SyntheticFigKiwiFixtureBuilder::zlibChunk($binaryKiwiMessage),
+        )),
+        array('images/' . $binaryAssetId => $binaryAssetContent)
+    );
+    $binaryReportResult = blocks_engine_figma_transformer_transform_file($binaryReportFixture);
+    @unlink($binaryReportFixture);
+    $binaryExported = false;
+    foreach ( $binaryReportResult['files'] ?? array() as $file ) {
+        if ( $binaryAssetContent === ($file['content'] ?? null) ) {
+            $binaryExported = true;
+            break;
+        }
+    }
+    $binaryFontMetadata = $binaryReportResult['source_reports']['figma']['archive']['canvas']['chunks'][2]['payload']['kiwi_message']['nodeChanges'][0]['derivedTextData']['fontMetaData'] ?? array();
+    try {
+        json_encode(array('source_reports' => $binaryReportResult['source_reports']), JSON_THROW_ON_ERROR);
+        $binaryReportJsonEncodes = true;
+    } catch (JsonException) {
+        $binaryReportJsonEncodes = false;
+    }
+    $assert(in_array($binaryReportResult['status'] ?? null, array('success', 'success_with_warnings'), true), 'binary-report-transform-success');
+    $assert($binaryExported, 'binary-report-export-preserves-asset-bytes');
+    $assert(! array_key_exists('content', $binaryReportResult['source_reports']['figma']['assets'][0] ?? array()), 'binary-report-omits-asset-content');
+    $assert(! array_key_exists('fontDigest', $binaryFontMetadata), 'binary-report-omits-invalid-font-digest');
+    $assert($binaryReportJsonEncodes, 'binary-report-worker-payload-json-encodes');
     
     $assetMetadataFixture = SyntheticFigKiwiFixtureBuilder::figArchive(
         SyntheticFigKiwiFixtureBuilder::canvas(array(SyntheticFigKiwiFixtureBuilder::jsonZlibChunk(array('metadata' => array('ignored' => true))))),


### PR DESCRIPTION
## Summary
- omit raw archive asset bytes from report metadata while preserving generated export bytes
- omit invalid UTF-8 decoded archive metadata rather than applying lossy substitution
- cover a synthetic binary archive transform and worker-style JSON encoding

## Testing
- composer test (from figma-transformer)
- php -l figma-transformer/src/FigmaTransformer.php
- php -l figma-transformer/tests/contract/KiwiParserContract.php

Fixes #1654

AI assistance: GPT-6 Astra was orchestrated with OpenCode to investigate, implement, and test this repair; human direction and review guide the work.