### PR TITLE
refactor(php-transformer): build site plans before report projection

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -847,8 +847,6 @@ final class ArtifactCompiler
         if ( is_array($sourceUrlParts) && in_array(strtolower((string) ($sourceUrlParts['scheme'] ?? '')), array( 'http', 'https' ), true) && '' !== (string) ($sourceUrlParts['host'] ?? '') && !isset($sourceUrlParts['user'], $sourceUrlParts['pass']) ) {
             $provenance[0]['source_url'] = $sourceUrl;
         }
-        // WordPressSitePlan consumes a canonical result envelope, so give it a
-        // provisional report before final diagnostics and metrics are projected.
         $metrics = array(
             'input_bytes'           => $normalized['bytes'],
             'block_count'           => $this->countBlocks($entryBlocks['blocks']),
@@ -857,12 +855,12 @@ final class ArtifactCompiler
             'transform_duration_ms' => (hrtime(true) - $startedAt) / 1000000,
             'output_bytes'          => strlen($serializedBlocks),
         );
+        $wordpressSitePlan = null;
         // Editability failures retain a failed-quality plan as review evidence;
         // all other failures have no materializable source identity or site plan.
         if ( array() === $identityFailures && ( 'failed' !== $this->statusFromDiagnostics($diagnostics) || 'failed' === ($sourceReports['editability_policy']['status'] ?? null) ) ) {
-            $sourceReports['conversion_report'] = ConversionReportProjection::fromResultParts('artifact', $entryBlocks['blocks'], $allFallbacks, $sourceReports, $assets, $provenance, $metrics);
             try {
-                $sourceReports['wordpress_site_plan'] = ( new WordPressSitePlan() )->fromResult(array(
+                $wordpressSitePlan = ( new WordPressSitePlan() )->fromCompilerResult(array(
                     'schema' => TransformerResult::SCHEMA,
                     'status' => $this->statusFromDiagnostics($diagnostics),
                     'components' => $components,
@@ -879,7 +877,7 @@ final class ArtifactCompiler
                     'context' => array(),
                     'metrics' => $metrics,
                 ));
-                $sourceReports['editability_report'] = (new EditabilityReport())->withTemplateSurfaceSelection($sourceReports['editability_report'], $sourceReports['wordpress_site_plan']['templates']);
+                $sourceReports['editability_report'] = (new EditabilityReport())->withTemplateSurfaceSelection($sourceReports['editability_report'], $wordpressSitePlan['templates']);
             } catch (DocumentIdentityException $exception) {
                 foreach ( $exception->diagnostics() as $identityDiagnostic ) {
                     $diagnostics[] = array_merge($identityDiagnostic, array('source' => self::class));
@@ -894,6 +892,9 @@ final class ArtifactCompiler
         $metrics['diagnostic_count'] = count($diagnostics);
         $metrics['transform_duration_ms'] = (hrtime(true) - $startedAt) / 1000000;
         $sourceReports['conversion_report'] = ConversionReportProjection::fromResultParts('artifact', $entryBlocks['blocks'], $allFallbacks, $sourceReports, $assets, $provenance, $metrics);
+        if ( null !== $wordpressSitePlan ) {
+            $sourceReports['wordpress_site_plan'] = $wordpressSitePlan;
+        }
         // This counter is intentionally outside the canonical report/site-plan
         // projections: it describes process work, not output identity.
         $metrics['html_document_transform_count'] = $this->htmlDocumentTransformCount;

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -891,7 +891,11 @@ final class ArtifactCompiler
 
         $metrics['diagnostic_count'] = count($diagnostics);
         $metrics['transform_duration_ms'] = (hrtime(true) - $startedAt) / 1000000;
-        $sourceReports['conversion_report'] = ConversionReportProjection::fromResultParts('artifact', $entryBlocks['blocks'], $allFallbacks, $sourceReports, $assets, $provenance, $metrics);
+        $reportSourceReports = $sourceReports;
+        if ( null !== $wordpressSitePlan ) {
+            $reportSourceReports['wordpress_site_plan'] = $wordpressSitePlan;
+        }
+        $sourceReports['conversion_report'] = ConversionReportProjection::fromResultParts('artifact', $entryBlocks['blocks'], $allFallbacks, $reportSourceReports, $assets, $provenance, $metrics);
         if ( null !== $wordpressSitePlan ) {
             $sourceReports['wordpress_site_plan'] = $wordpressSitePlan;
         }

--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
@@ -60,6 +60,24 @@ final class WordPressSitePlan
     {
         $data = $result instanceof TransformerResult ? $result->toArray() : $result;
         TransformerResult::assertCanonicalEnvelope($data);
+        return $this->fromCompilerResultData($data, $data['source_reports']['conversion_report']['core_html_fallback_evidence'] ?? array());
+    }
+
+    /**
+     * Projects compiler-owned result data before its terminal conversion report exists.
+     *
+     * @internal ArtifactCompiler builds this data and retains public canonical-envelope validation in fromResult().
+     * @param array<string,mixed> $data
+     * @return array<string,mixed>
+     */
+    public function fromCompilerResult(array $data): array
+    {
+        return $this->fromCompilerResultData($data, $data['source_reports']['core_html_fallback_evidence'] ?? array());
+    }
+
+    /** @param array<string,mixed> $data @param array<string,mixed> $coreHtmlFallbackEvidence @return array<string,mixed> */
+    private function fromCompilerResultData(array $data, array $coreHtmlFallbackEvidence): array
+    {
         $this->sourceOrigin = $this->urlOrigin($this->sourceUrlFromProvenance($data['provenance'] ?? array()));
         $editabilityPolicy = $data['source_reports']['editability_policy'] ?? null;
         if (!is_array($editabilityPolicy) || EditabilityPolicy::SCHEMA !== ($editabilityPolicy['schema'] ?? null) || 'required' !== ($editabilityPolicy['enforcement'] ?? null) || !in_array($editabilityPolicy['status'] ?? null, array('passed', 'failed'), true)) {
@@ -160,8 +178,8 @@ final class WordPressSitePlan
             'visual_repair' => $compiled['visual_repair'] ?? array(),
             'runtime_declarations' => $runtimeDeclarations,
             'diagnostics' => array_merge($data['diagnostics'], $inlineShells['diagnostics'], $shells['diagnostics'], $scriptLoading['diagnostics']),
-            'quality' => array('status' => $data['status'], 'pass' => 'failed' !== $data['status'], 'metrics' => array_diff_key($data['metrics'], array('transform_duration_ms' => true)), 'fallbacks' => $data['fallbacks'], 'core_html_fallback_evidence' => $data['source_reports']['conversion_report']['core_html_fallback_evidence'] ?? array(), 'editability_policy' => $editabilityPolicy ?? array()),
-            'reporting' => $this->reporting($pages, $data, array_merge($inlineShells['diagnostics'], $shells['diagnostics'], $scriptLoading['diagnostics']), $surfaces),
+            'quality' => array('status' => $data['status'], 'pass' => 'failed' !== $data['status'], 'metrics' => array_diff_key($data['metrics'], array('transform_duration_ms' => true)), 'fallbacks' => $data['fallbacks'], 'core_html_fallback_evidence' => $coreHtmlFallbackEvidence, 'editability_policy' => $editabilityPolicy ?? array()),
+            'reporting' => $this->reporting($pages, $data, $coreHtmlFallbackEvidence, array_merge($inlineShells['diagnostics'], $shells['diagnostics'], $scriptLoading['diagnostics']), $surfaces),
         );
         $plan['plan_identity'] = self::planIdentity($plan);
         self::assertValid($plan);
@@ -1235,8 +1253,8 @@ final class WordPressSitePlan
         foreach ($value as $child) if (is_array($child)) $rows = array_merge($rows, $this->jsonLdPublicationEvidence($child, $timestamp));
         return $rows;
     }
-    /** @param array<string,mixed> $compiled @param array<string,mixed> $data @return array<string,mixed> */
-    private function reporting(array $pages, array $data, array $scriptDiagnostics = array(), array $surfaces = array()): array { $documents = array(); foreach ($pages as $page) if (is_array($page)) $documents[] = array('source_path' => $page['source_path'] ?? '', 'kind' => 'page', 'body_format' => 'blocks', 'block_document' => true, 'provenance' => $page['provenance'] ?? array()); foreach ($surfaces as $surface) $documents[] = array('source_path' => $surface['source_path'] ?? '', 'kind' => 'template_surface', 'body_format' => 'blocks', 'block_document' => true, 'template_surface' => $surface['template_surface'] ?? array(), 'provenance' => $surface['provenance'] ?? array()); return array('source_documents' => $documents, 'metrics' => array('source_document_count' => count($documents), 'block_document_count' => count($documents), 'native_block_count' => $data['metrics']['block_count'] ?? 0, 'fallback_count' => $data['metrics']['fallback_count'] ?? 0), 'core_html_fallback_evidence' => $data['source_reports']['conversion_report']['core_html_fallback_evidence'] ?? array(), 'diagnostic_codes' => array_values(array_map(static fn(array $diagnostic): string => (string) ($diagnostic['code'] ?? ''), array_merge($data['diagnostics'], $scriptDiagnostics)))); }
+    /** @param array<string,mixed> $compiled @param array<string,mixed> $data @param array<string,mixed> $coreHtmlFallbackEvidence @return array<string,mixed> */
+    private function reporting(array $pages, array $data, array $coreHtmlFallbackEvidence, array $scriptDiagnostics = array(), array $surfaces = array()): array { $documents = array(); foreach ($pages as $page) if (is_array($page)) $documents[] = array('source_path' => $page['source_path'] ?? '', 'kind' => 'page', 'body_format' => 'blocks', 'block_document' => true, 'provenance' => $page['provenance'] ?? array()); foreach ($surfaces as $surface) $documents[] = array('source_path' => $surface['source_path'] ?? '', 'kind' => 'template_surface', 'body_format' => 'blocks', 'block_document' => true, 'template_surface' => $surface['template_surface'] ?? array(), 'provenance' => $surface['provenance'] ?? array()); return array('source_documents' => $documents, 'metrics' => array('source_document_count' => count($documents), 'block_document_count' => count($documents), 'native_block_count' => $data['metrics']['block_count'] ?? 0, 'fallback_count' => $data['metrics']['fallback_count'] ?? 0), 'core_html_fallback_evidence' => $coreHtmlFallbackEvidence, 'diagnostic_codes' => array_values(array_map(static fn(array $diagnostic): string => (string) ($diagnostic['code'] ?? ''), array_merge($data['diagnostics'], $scriptDiagnostics)))); }
 
     /** @param mixed $documents @param array<int,array<string,mixed>> $legacyRoutes @return array<int,array<string,mixed>> */
     private function canonicalRoutes(mixed $documents, array $legacyRoutes): array { if (!is_array($documents)) throw new InvalidArgumentException('Compiled site documents must be an array.'); $legacy = array(); foreach ($legacyRoutes as $route) if (is_array($route) && is_string($route['source_path'] ?? null)) $legacy[$route['source_path']] = $route; $entryRoot = self::entryRootFromDocuments($documents); $routes = array(); $paths = array(); foreach ($documents as $order => $document) { if (!is_array($document) || !self::safePath($document['source_path'] ?? null)) throw new InvalidArgumentException('Compiled site route source is invalid.'); $metadata = is_array($document['metadata'] ?? null) ? $document['metadata'] : array(); $explicitRoute = is_string($metadata['route_path'] ?? null) && '' !== $metadata['route_path']; if ('' !== $entryRoot && ! str_starts_with((string) $document['source_path'], $entryRoot . '/') && !$explicitRoute) throw new InvalidArgumentException('Compiled site document is outside the entrypoint content root.'); $path = $explicitRoute ? self::canonicalRoutePath($metadata['route_path']) : self::pageRoutePath($document['source_path'], $entryRoot); if (isset($paths[$path])) throw new InvalidArgumentException('WordPress site plan has colliding page routes.'); $paths[$path] = true; $previous = $legacy[$document['source_path']] ?? array(); $routes[] = array('kind' => 'route', 'source_path' => $document['source_path'], 'target_path' => $path, 'target_slug' => self::value($document, 'slug', self::routeSlug($path)), 'title' => self::value($document, 'title'), 'parent_source_path' => self::value($metadata, 'parent_source_path'), 'source_relation' => !empty($document['entrypoint']) ? 'entrypoint' : ($previous['source_relation'] ?? 'document'), 'order' => $order); } return $routes; }

--- a/php-transformer/tests/contract/wordpress-site-plan.php
+++ b/php-transformer/tests/contract/wordpress-site-plan.php
@@ -38,6 +38,11 @@ $first = (new ArtifactCompiler())->compile($artifact)->toArray();
 $second = (new ArtifactCompiler())->compile($artifact)->toArray();
 $plan = $first['source_reports']['wordpress_site_plan'] ?? array();
 $assert(array() !== $plan, 'Compiler emits a complete site plan: ' . json_encode(array($first['source_reports']['wordpress_site_plan_diagnostics'] ?? array(), $first['source_reports']['compiled_site']['template_parts'] ?? array())));
+$preReportResult = $first;
+unset($preReportResult['source_reports']['conversion_report'], $preReportResult['source_reports']['wordpress_site_plan']);
+unset($preReportResult['metrics']['html_document_transform_count'], $preReportResult['metrics']['normalization_count'], $preReportResult['metrics']['analysis_count'], $preReportResult['metrics']['terminal_reduction_count']);
+$assert($plan === (new WordPressSitePlan())->fromCompilerResult($preReportResult), 'The compiler pre-report projection retains the final canonical site plan.');
+$throws(static fn() => (new WordPressSitePlan())->fromResult($preReportResult), 'Public site-plan projection retains strict canonical conversion-report validation.');
 $writes = $writeMap($plan['writes']);
 
 $assert(WordPressSitePlan::SCHEMA === ($plan['schema'] ?? null), 'Compiler projects the v2 canonical WordPress site plan.');
@@ -98,7 +103,12 @@ $overDepthWithFailure['files']['index.html'] .= str_repeat('<div style="padding:
 $pathological = (new ArtifactCompiler())->compile($overDepthWithFailure)->toArray();
 $pathologicalPolicy = $pathological['source_reports']['editability_policy'] ?? array();
 $assert('failed' === ($pathological['status'] ?? null) && 'failed' === ($pathologicalPolicy['status'] ?? null) && 'required' === ($pathologicalPolicy['enforcement'] ?? null) && 'wrapper_to_content_ratio' === ($pathologicalPolicy['failures'][0]['metric'] ?? null) && 'index.html' === ($pathologicalPolicy['failures'][0]['source_path'] ?? null) && 25 < ($pathological['source_reports']['editability_report']['metrics']['max_nesting_depth'] ?? 0) && 'failed' === ($pathological['source_reports']['wordpress_site_plan']['quality']['status'] ?? null) && false === ($pathological['source_reports']['wordpress_site_plan']['quality']['pass'] ?? null) && 'editability_policy_failed' === ($pathological['diagnostics'][0]['code'] ?? null) && 'index.html' === ($pathological['diagnostics'][0]['context']['source_path'] ?? null), 'An over-depth artifact with a substantive editability failure still rejects with source attribution and failed-quality site-plan evidence.');
-$fallbackPlan = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => '<main><svg><script>secretToken()</script><path onclick="secretHandler()" d="M0 0"></path></svg></main>')))->toArray()['source_reports']['wordpress_site_plan'] ?? array();
+$fallbackResult = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => '<main><svg><script>secretToken()</script><path onclick="secretHandler()" d="M0 0"></path></svg></main>')))->toArray();
+$fallbackPlan = $fallbackResult['source_reports']['wordpress_site_plan'] ?? array();
+$fallbackPreReportResult = $fallbackResult;
+unset($fallbackPreReportResult['source_reports']['conversion_report'], $fallbackPreReportResult['source_reports']['wordpress_site_plan']);
+unset($fallbackPreReportResult['metrics']['html_document_transform_count'], $fallbackPreReportResult['metrics']['normalization_count'], $fallbackPreReportResult['metrics']['analysis_count'], $fallbackPreReportResult['metrics']['terminal_reduction_count']);
+$assert($fallbackPlan === (new WordPressSitePlan())->fromCompilerResult($fallbackPreReportResult), 'The compiler pre-report projection retains the canonical site plan for nonempty sanitization fallback evidence.');
 $fallbackPlanEvidence = $fallbackPlan['quality']['core_html_fallback_evidence'] ?? array();
 $fallbackPlanEmission = $fallbackPlanEvidence['emissions'][0] ?? array();
 $assert('blocks-engine/core-html-fallback-evidence/v1' === ($fallbackPlanEvidence['schema'] ?? '') && $fallbackPlanEvidence === ($fallbackPlan['reporting']['core_html_fallback_evidence'] ?? null) && 'sanitization' === ($fallbackPlanEmission['reason'] ?? '') && 1 === ($fallbackPlanEvidence['totals']['emissions'] ?? 0) && !str_contains((string) ($fallbackPlanEmission['source_subtree']['snippet'] ?? ''), 'secretToken'), 'Site plans retain bounded, payload-safe core/html fallback evidence for matrix consumers.');

--- a/php-transformer/tests/fixtures/parity/artifact-button-runtime-controls-commerce-boundary.json
+++ b/php-transformer/tests/fixtures/parity/artifact-button-runtime-controls-commerce-boundary.json
@@ -32,6 +32,11 @@
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "source_reports.runtime_dependency_parity.status", "assert": "equals", "value": "pass" },
+    { "path": "source_reports.conversion_report.source_summary.page_count", "assert": "equals", "value": 1 },
+    { "path": "source_reports.conversion_report.source_summary.asset_count", "assert": "equals", "value": 0 },
+    { "path": "source_reports.conversion_report.source_summary.route_count", "assert": "equals", "value": 1 },
+    { "path": "source_reports.conversion_report.source_summary.navigation_link_count", "assert": "equals", "value": 0 },
+    { "path": "source_reports.conversion_report.source_summary.menu_count", "assert": "equals", "value": 0 },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:button {\"className\":\"donate-submit\",\"type\":\"button\",\"tagName\":\"button\"} -->" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<button type=\"button\" class=\"wp-block-button__link wp-element-button\">Donate Now</button>" },
     { "path": "serialized_blocks", "assert": "contains", "value": "data-lightbox=\"Foggy cliff portrait\"" },


### PR DESCRIPTION
## Summary

Continues #1360 by removing the provisional conversion report from artifact compilation. Internal site-plan construction consumes producer-owned fallback evidence, then the compiler constructs the terminal report once. Public `WordPressSitePlan::fromResult()` retains strict canonical-envelope validation. Serialized source-report ordering is preserved.

## Verification

All ten CI checks passed on `242e71506f4f007754a73cab40462367a1ac6fdb`: [Composer tests, WordPress integration across PHP 8.2-8.5, and visual parity tools](https://github.com/Automattic/blocks-engine/actions/runs/34509923957), plus [solved-site promotion](https://github.com/Automattic/blocks-engine/actions/runs/34509924550).

- Added pre-report/final-plan equality coverage for ordinary output and nonempty sanitization fallback evidence, plus rejection of pre-report data through the public API.
- Focused site-plan contract passed on the candidate.
- Initial external-harness comparison of 385 HTML fixtures and nine targeted cases did not catch a final artifact-report regression. CI caught a plan/report asset-count mismatch. The correction retains the completed plan in the final report's transient inputs without changing persisted key order.
- Direct full artifact parity passed all 305 fixtures on baseline and corrected candidate. The original candidate reproduced the CI failure. Added explicit terminal-report counts to the affected commerce/runtime artifact fixture.
- PHP syntax checks and `git diff --check` passed.
- Local test execution encountered `FAIL [empty-plaintext-drops]`; separate baseline and candidate runs reproduced the same failure in that environment. Final CI Composer suites passed across PHP 8.2-8.5 as linked above.

Repo-native reproduction, from `php-transformer` after installing Composer dependencies:

```sh
php tests/contract/wordpress-site-plan.php
php tests/unit/text-leaf-element-converter.php
composer test
php tests/parity/run.php
```

## AI Assistance

Implemented and reviewed with AI assistance through OpenCode, coordinated by GPT-6 Astra under Chris Huber's direction. Delegated agents handled implementation and independent review; the coordinator reviewed the diff and required fresh baseline/candidate evidence before publication.
