### PR TITLE
fix(figma-transformer): serialize complete reports safely

### DIFF
--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -188,7 +188,7 @@ final class FigmaTransformer
                 array_merge($diagnostics, $scenegraphResult['diagnostics'] ?? array()),
                 $scenegraphResult['files'] ?? array(),
                 $scenegraphResult['assets'] ?? array(),
-                $mergedSourceReports,
+                $this->jsonSafeSourceReports($mergedSourceReports),
                 $scenegraphResult['parity'] ?? $parity,
                 array_merge(
                     $metrics,
@@ -217,7 +217,7 @@ final class FigmaTransformer
             $diagnostics,
             array(),
             $archive['assets'],
-            $sourceReports,
+            $this->jsonSafeSourceReports($sourceReports),
             $parity,
             $metrics
         );
@@ -251,31 +251,59 @@ final class FigmaTransformer
      */
     private function jsonSafeArchiveReport(array $archive): array
     {
-        return $this->omitInvalidUtf8ArchiveValues($archive);
+        return $this->jsonSafeSourceReports($archive);
     }
 
     /**
+     * Source reports cross a JSON boundary while emitted files are written as
+     * bytes. Omit malformed text, non-finite measurements, and unsupported
+     * values only from reports; never alter artifact file payloads.
+     *
      * @param array<string|int, mixed> $value
      * @return array<string|int, mixed>
      */
-    private function omitInvalidUtf8ArchiveValues(array $value): array
+    private function jsonSafeSourceReports(array $value): array
     {
+        $safe = true;
+        $report = $this->jsonSafeSourceReportValue($value, $safe);
+
+        return is_array($report) ? $report : array();
+    }
+
+    private function jsonSafeSourceReportValue(mixed $value, bool &$safe): mixed
+    {
+        if ( is_string($value) ) {
+            $safe = $this->isValidUtf8($value);
+            return $value;
+        }
+        if ( is_float($value) ) {
+            $safe = is_finite($value);
+            return $value;
+        }
+        if ( null === $value || is_bool($value) || is_int($value) ) {
+            $safe = true;
+            return $value;
+        }
+        if ( ! is_array($value) ) {
+            $safe = false;
+            return null;
+        }
+
         $report = array();
         $isList = array_is_list($value);
-
         foreach ( $value as $key => $child ) {
             if ( is_string($key) && ! $this->isValidUtf8($key) ) {
                 continue;
             }
-            if ( is_string($child) && ! $this->isValidUtf8($child) ) {
+            $childSafe = true;
+            $child = $this->jsonSafeSourceReportValue($child, $childSafe);
+            if ( ! $childSafe ) {
                 continue;
             }
-
-            $report[$key] = is_array($child)
-                ? $this->omitInvalidUtf8ArchiveValues($child)
-                : $child;
+            $report[$key] = $child;
         }
 
+        $safe = true;
         return $isList ? array_values($report) : $report;
     }
 
@@ -996,10 +1024,10 @@ final class FigmaTransformer
             array_merge($diagnostics, is_array($artifact['diagnostics'] ?? null) ? $artifact['diagnostics'] : array()),
             $artifact['files'],
             $artifact['assets'],
-            array(
+            $this->jsonSafeSourceReports(array(
                 'figma' => array_merge($figmaSourceReport, array('html' => $artifact['source_report'])),
                 'compiled_site' => $this->compiledSiteSourceReport($artifact),
-            ),
+            )),
             $this->parityReportBuilder->build($options['parity'] ?? array()),
             array_merge(
                 $metrics,

--- a/figma-transformer/tests/contract/KiwiParserContract.php
+++ b/figma-transformer/tests/contract/KiwiParserContract.php
@@ -124,7 +124,10 @@ function blocks_engine_figma_transformer_run_kiwi_parser_contract(callable $asse
         )),
         array('images/' . $binaryAssetId => $binaryAssetContent)
     );
-    $binaryReportResult = blocks_engine_figma_transformer_transform_file($binaryReportFixture);
+    $binaryReportResult = blocks_engine_figma_transformer_transform_file(
+        $binaryReportFixture,
+        array('frame_ids' => array('4:1'), 'entry_frame_id' => '4:1')
+    );
     @unlink($binaryReportFixture);
     $binaryExported = false;
     foreach ( $binaryReportResult['files'] ?? array() as $file ) {
@@ -134,8 +137,27 @@ function blocks_engine_figma_transformer_run_kiwi_parser_contract(callable $asse
         }
     }
     $binaryFontMetadata = $binaryReportResult['source_reports']['figma']['archive']['canvas']['chunks'][2]['payload']['kiwi_message']['nodeChanges'][0]['derivedTextData']['fontMetaData'] ?? array();
+    $workerFiles = array_map(
+        static function (array $file): array {
+            $payload = array('path' => (string) ($file['path'] ?? ''));
+            if (array_key_exists('content', $file)) {
+                $payload['content_base64'] = base64_encode((string) $file['content']);
+            }
+            return $payload;
+        },
+        $binaryReportResult['files'] ?? array()
+    );
+    $workerResponse = array(
+        'schema' => 'static-site-importer/import-cli-receipt/v1',
+        'status' => 'completed',
+        'response' => array(
+            'success' => true,
+            'artifact' => array('files' => $workerFiles),
+            'figma_transform_report' => array('source_reports' => $binaryReportResult['source_reports']),
+        ),
+    );
     try {
-        json_encode(array('source_reports' => $binaryReportResult['source_reports']), JSON_THROW_ON_ERROR);
+        json_encode($workerResponse, JSON_THROW_ON_ERROR);
         $binaryReportJsonEncodes = true;
     } catch (JsonException) {
         $binaryReportJsonEncodes = false;
@@ -144,7 +166,8 @@ function blocks_engine_figma_transformer_run_kiwi_parser_contract(callable $asse
     $assert($binaryExported, 'binary-report-export-preserves-asset-bytes');
     $assert(! array_key_exists('content', $binaryReportResult['source_reports']['figma']['assets'][0] ?? array()), 'binary-report-omits-asset-content');
     $assert(! array_key_exists('fontDigest', $binaryFontMetadata), 'binary-report-omits-invalid-font-digest');
-    $assert($binaryReportJsonEncodes, 'binary-report-worker-payload-json-encodes');
+    $assert(isset($binaryReportResult['source_reports']['figma']['html']['pages']), 'binary-report-selected-frame-emits-page-report');
+    $assert($binaryReportJsonEncodes, 'binary-report-selected-frame-cli-response-json-encodes');
     
     $assetMetadataFixture = SyntheticFigKiwiFixtureBuilder::figArchive(
         SyntheticFigKiwiFixtureBuilder::canvas(array(SyntheticFigKiwiFixtureBuilder::jsonZlibChunk(array('metadata' => array('ignored' => true))))),


### PR DESCRIPTION
## Summary
- omit non-JSON report metadata at the Figma transformer source-report boundary
- retain emitted artifact bytes and represent binary worker files with base64 at the transfer boundary
- cover selected-frame output in a synthetic complete worker receipt

## Testing
- `composer test`
- private selected-frame SSI CLI response and written-asset byte-identity verification

AI assistance: GPT-6 Astra was orchestrated with OpenCode to diagnose, implement, and test this repair; human direction and review guide the work.