### PR TITLE
fix(php-transformer): preserve inherited border-box resets

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -6187,9 +6187,22 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
 
     private function isLinkedSvgLogoAnchor(DOMElement $anchor): bool
     {
-        return $this->sourceElementClassifier->hasLogoBrandSignal($anchor)
-            && 0 < $anchor->getElementsByTagName('svg')->length
-            && '' === trim($this->runtime->stripAllTags($this->innerHtmlWithoutTags($anchor, array( 'svg' ))));
+        if ( 0 === $anchor->getElementsByTagName('svg')->length
+            || '' !== trim($this->runtime->stripAllTags($this->innerHtmlWithoutTags($anchor, array( 'svg' )))) ) {
+            return false;
+        }
+
+        if ( $this->sourceElementClassifier->hasLogoBrandSignal($anchor) ) {
+            return true;
+        }
+
+        foreach ( $anchor->getElementsByTagName('*') as $descendant ) {
+            if ( $descendant instanceof DOMElement && $this->sourceElementClassifier->hasLogoBrandSignal($descendant) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/LogoPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/LogoPattern.php
@@ -39,7 +39,8 @@ final class LogoPattern implements PatternRecognizerInterface
      */
     public function match(DOMElement $element, callable $presentationAttributes, callable $innerHtml, callable $outerHtml, callable $materializeSvgImages, callable $createBlock): ?array
     {
-        if ( ! $this->hasLogoSignal($element) || '' === trim($element->textContent ?? '') ) {
+        if ( ! $this->hasLogoSignal($element)
+            || ( '' === trim($element->textContent ?? '') && 0 === $element->getElementsByTagName('svg')->length ) ) {
             return null;
         }
 
@@ -129,7 +130,7 @@ final class LogoPattern implements PatternRecognizerInterface
         $html = $this->semanticMarkerSpansAsMarks($html);
         $html = trim($html);
         $text = $this->plainText($html);
-        if ( '' === $text ) {
+        if ( '' === $text && ! preg_match('/<img\b[^>]*>/i', $html) ) {
             return '';
         }
 

--- a/php-transformer/src/HtmlToBlocks/Style/AuthorStyleRuleProjector.php
+++ b/php-transformer/src/HtmlToBlocks/Style/AuthorStyleRuleProjector.php
@@ -125,25 +125,37 @@ final class AuthorStyleRuleProjector
         }
 
         $usesBorderBox = false;
+        $rootUsesBorderBox = false;
+        $universalInheritsBoxSizing = false;
         ( new CssStylesheetTransformer() )->visitStyleRules(
             $authorStyles->combinedCss(),
-            function (string $prelude, string $body, array $ancestors) use (&$usesBorderBox): void {
+            function (string $prelude, string $body, array $ancestors) use (&$usesBorderBox, &$rootUsesBorderBox, &$universalInheritsBoxSizing): void {
                 if ( $usesBorderBox || array() !== $ancestors ) {
                     return;
                 }
                 $boxSizing = CssValueInspector::comparable((string) ($this->styleResolver->cssDeclarations($body)['box-sizing'] ?? ''));
-                if ( 'border-box' !== $boxSizing ) {
+                if ( ! in_array($boxSizing, array( 'border-box', 'inherit' ), true) ) {
                     return;
                 }
                 foreach ( CssStylesheetTransformer::splitSelectorList($prelude) ?? array() as $selector ) {
-                    if ( '*' === trim((string) preg_replace('/\/\*.*?\*\//s', '', $selector)) ) {
+                    $selector = trim((string) preg_replace('/\/\*.*?\*\//s', '', $selector));
+                    if ( '*' === $selector && 'border-box' === $boxSizing ) {
                         $usesBorderBox = true;
                         return;
+                    }
+                    if ( '*' === $selector && 'inherit' === $boxSizing ) {
+                        $universalInheritsBoxSizing = true;
+                    }
+                    if ( in_array(strtolower($selector), array( 'html', ':root' ), true) && 'border-box' === $boxSizing ) {
+                        $rootUsesBorderBox = true;
                     }
                 }
             }
         );
-        return $this->universalBorderBoxResets[$authorStyles] = $usesBorderBox;
+        // The common reset sets the root to border-box and makes every element
+        // inherit it. Materialized core Groups preserve that inherited model.
+        return $this->universalBorderBoxResets[$authorStyles] = $usesBorderBox
+            || ( $rootUsesBorderBox && $universalInheritsBoxSizing );
     }
 
     /** @param array<string, string> $declarations */

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializer.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializer.php
@@ -193,7 +193,14 @@ final class SvgMaterializer implements SvgElementMaterializer
             }
             $rule = ($richTextImage ? '' : '>img') . '{display:' . $imageDisplay . ($preserveInlineGeometry ? ';vertical-align:baseline' : '') . $mediaBox . '}';
             $geometryClass = $this->context->layoutGeometry()->allocateCarrier($this->styleResolver->geometryStructuralPath($element) . "\n" . $rule);
-            $this->context->layoutGeometry()->registerRule($geometryClass, ($preserveBlockDisplay ? '.' . $geometryClass . '{line-height:0}' : '') . '.' . $geometryClass . $rule);
+            $geometryCss = ($preserveBlockDisplay ? '.' . $geometryClass . '{line-height:0}' : '') . '.' . $geometryClass . $rule;
+            if ( ! $richTextImage && null !== $this->svgPercentageWidth(trim(SourceDom::attr($element, 'width'))) ) {
+                // Core/image wraps linked media in an inline anchor. Let a responsive
+                // SVG resolve its percentage width against the sized figure, not its
+                // shrink-to-fit link wrapper.
+                $geometryCss .= '.' . $geometryClass . '>a{display:block;width:100%}';
+            }
+            $this->context->layoutGeometry()->registerRule($geometryClass, $geometryCss);
         } elseif ( ! $richTextImage ) {
             // Core/image rejects typography.lineHeight. A standalone SVG still
             // needs its source line box removed when it becomes a figure.

--- a/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
+++ b/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
@@ -111,6 +111,12 @@ $borderBox = ( new ArtifactCompiler() )->compile(array( 'files' => array(
 $borderBoxCss = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), $borderBox['assets'] ?? array()));
 $assert(! str_contains($borderBoxCss, '.cascade-stack{display:block;width:640px;padding:48px;border:2px solid #18231d;box-sizing:content-box}'), 'an authored border-box reset remains authoritative');
 
+$inheritedBorderBox = ( new ArtifactCompiler() )->compile(array( 'files' => array(
+    array( 'path' => 'index.html', 'kind' => 'html', 'content' => '<style>html{box-sizing:border-box}*,*::before,*::after{box-sizing:inherit}.cascade-stack{display:block;width:640px;padding:48px;border:2px solid #18231d}</style><div class="cascade-stack"><p>Copy</p></div>' ),
+) ) )->toArray();
+$inheritedBorderBoxCss = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), $inheritedBorderBox['assets'] ?? array()));
+$assert(! str_contains($inheritedBorderBoxCss, '.cascade-stack{display:block;width:640px;padding:48px;border:2px solid #18231d;box-sizing:content-box}'), 'an inherited universal border-box reset remains authoritative');
+
 $rounded = ( new ArtifactCompiler() )->compile(array( 'files' => array(
     array( 'path' => 'index.html', 'kind' => 'html', 'content' => '<style>.dot{width:10px;height:10px;border-radius:50%;background:#ff5f57}</style><span class="dot"></span>' ),
 ) ) )->toArray();

--- a/php-transformer/tests/unit/author-selector-semantics.php
+++ b/php-transformer/tests/unit/author-selector-semantics.php
@@ -624,6 +624,11 @@ $logoAssetCount = count(array_filter($logoControl['assets'] ?? array(), static f
 $assert(str_contains($logoMarkup, 'assets/materialized-svg/') && 1 === $logoAssetCount && ! str_contains($logoMarkup, '<svg') && ! str_contains($logoMarkup, 'wp-block-blocks-engine-author-layout'), 'passive SVG logo controls retain materialized assets without a companion block');
 $assert(array() === ($logoControl['source_reports']['conversion_report']['gutenberg_incompatibilities']['author_layout_topology'] ?? array()), 'SVG-to-image materialization preserves author-layout topology without a false wrapper-change diagnostic');
 
+$inlineSvgOnlyLogo = $transform('<style>.brand-logo{width:228px;height:35px}</style><a class="site-link" href="/"><div class="brand-logo"><svg viewBox="0 0 228 30" width="100%" height="100%" role="img" aria-label="Brand logo"><path d="M0 0h228v30H0z"/></svg></div></a>');
+$inlineSvgOnlyLogoMarkup = (string) ($inlineSvgOnlyLogo['serialized_blocks'] ?? '');
+$inlineSvgOnlyLogoAssets = array_filter($inlineSvgOnlyLogo['assets'] ?? array(), static fn (array $asset): bool => 'inline-svg' === ($asset['source'] ?? ''));
+$assert(str_contains($inlineSvgOnlyLogoMarkup, 'brand-logo') && str_contains($inlineSvgOnlyLogoMarkup, 'assets/materialized-svg/') && str_contains($css($inlineSvgOnlyLogo), '>a{display:block;width:100%}') && 1 === count($inlineSvgOnlyLogoAssets) && ! str_contains($inlineSvgOnlyLogoMarkup, '<svg'), 'an SVG-only logo materializes as a full-width linked image instead of being omitted for lacking text content');
+
 $structuredAnchor = $transform('<style>.row{display:flex}</style><div class="row"><a class="card" href="/"><span>Copy</span><div>Structured</div></a></div>');
 $structuredAnchorBlock = $structuredAnchor['blocks'][0] ?? array();
 $assert(! str_contains((string) ($structuredAnchor['serialized_blocks'] ?? ''), 'wp-block-blocks-engine-author-layout') && str_ends_with((string) ($structuredAnchorBlock['blockName'] ?? ''), '/layout-shell') && 2 === count($structuredAnchorBlock['innerBlocks'] ?? array()), 'block-structured anchor descendants retain native blocks without a companion block');


### PR DESCRIPTION
## Summary
Preserves the common `html{box-sizing:border-box} *,*::before,*::after{box-sizing:inherit}` reset when projecting CSS into native WordPress blocks, and retains linked SVG-only logos as materialized image blocks.

## Border-Box Root
- `php-transformer/src/HtmlToBlocks/Style/AuthorStyleRuleProjector.php:authorStylesUseUniversalBorderBoxReset()`
- The prior detector recognized only explicit `*{box-sizing:border-box}`, then injected `box-sizing:content-box` on generated Groups despite an inherited root reset.

## Linked SVG-Only Logo Root
- `HtmlCompilation::isLinkedSvgLogoAnchor()` previously required the wrapper anchor itself to carry a logo/brand token. An unlabelled link around a descendant `.logo` containing only inline SVG returned `null` before its child could be converted, omitting the header artwork.
- `LogoPattern` also rejected SVG-only logo content because its text content was empty.
- The fix recognizes a descendant logo signal, materializes the safe SVG asset, and makes a percentage-width linked `core/image` resolve against its sized figure rather than its shrink-to-fit link wrapper.
- Existing upstream linked-SVG logo work was reviewed (`#525`); this closes the remaining wrapper-signal case rather than duplicating it.

## Public Reproducer
- `php-transformer/tests/unit/artifact-author-stylesheet-projection.php` covers a root + universal inherited border-box reset with a width-and-padding Group.
- `php-transformer/tests/unit/author-selector-semantics.php` covers an unlabelled link wrapping a descendant `.brand-logo` with a `width="100%" height="100%"` inline SVG.

## Verification
- `php tests/contract/run.php`
- `php tests/unit/author-selector-semantics.php`
- `php tests/unit/artifact-author-stylesheet-projection.php`
- `php tests/unit/engine-support-css-specificity.php`
- `php -l src/HtmlToBlocks/HtmlCompilation.php`
- `php -l src/HtmlToBlocks/Patterns/LogoPattern.php`
- `php -l src/HtmlToBlocks/Support/SvgMaterializer.php`
- Real supported `static-site-importer import` candidate browser proof at 1440x900 and 390x844: header SVG now materializes and loads `200` at `227.7x30`; footer SVG asset also loads `200` at `227.7x30`. Candidate document widths are exactly `1440` and `390`, confirming no horizontal overflow after the inherited border-box fix. The footer is at `x=-114` on mobile in both source and candidate, so that clipping is source-authored, not a transformation regression.

AI assistance: openai/gpt-5.6-terra via OpenCode was used to diagnose browser DOM/CSS behavior and implement the fix.