### PR TITLE
fix(figma-transformer): flow mobile footer panels

### DIFF
--- a/figma-transformer/src/Html/ResponsiveBreakpointSafetyPolicy.php
+++ b/figma-transformer/src/Html/ResponsiveBreakpointSafetyPolicy.php
@@ -42,11 +42,14 @@ final class ResponsiveBreakpointSafetyPolicy
 
         if ( null !== $parentNode && (LayoutIntentClassifier::CHROME_GROUP_ROLE_FOOTER === $parentChromeRole || 'footer' === $parentName) ) {
             if ( $this->isFooterInsetPanel($node, $parentNode) && null !== $width ) {
-                return array('reason_code' => 'responsive_footer_inset_panel_safety', 'declarations' => array_merge($this->mobileSafeSourceMaxWidthDeclarations($width, $viewportWidth, 'fixed'), array('height:auto', 'left:24px')));
+                return array('reason_code' => 'responsive_footer_inset_panel_safety', 'declarations' => array_merge(
+                    $this->mobileSafeSourceMaxWidthDeclarations($width, $viewportWidth, 'fixed'),
+                    array('height:auto', 'position:relative', 'left:24px', 'right:auto', 'top:auto', 'bottom:auto')
+                ));
             }
 
             if ( $this->isFooterBottomBand($node, $parentNode) ) {
-                return array('reason_code' => 'responsive_footer_bottom_band_safety', 'declarations' => array_merge(array('height:auto', 'position:relative', 'left:auto', 'top:auto', 'justify-content:center', 'flex-wrap:wrap', 'align-content:flex-start'), $this->mobilePaddingClampDeclarations($baseMap)));
+                return array('reason_code' => 'responsive_footer_bottom_band_safety', 'declarations' => array_merge(array('width:100%', 'max-width:100%', 'height:auto', 'position:relative', 'left:auto', 'right:auto', 'top:auto', 'bottom:auto', 'margin-left:0', 'margin-right:0', 'justify-content:center', 'flex-wrap:wrap', 'align-content:flex-start'), $this->mobilePaddingClampDeclarations($baseMap)));
             }
         }
 
@@ -250,7 +253,7 @@ final class ResponsiveBreakpointSafetyPolicy
     private function namedResponsiveShellDecision(array $node, ?array $parentNode, array $baseMap, string $name, string $parentName, bool $isContainer, ?float $width, string $positioning, string $display, ?string $chromeRole, float $viewportWidth): array
     {
         if ( 'footer' === $name && $isContainer && $this->hasFooterResponsiveShell($node) ) {
-            return array('reason_code' => 'responsive_footer_shell_safety', 'declarations' => array('height:auto', 'min-height:' . $this->formatter->number($this->footerResponsiveMinHeight($node)) . 'px'));
+            return array('reason_code' => 'responsive_footer_shell_safety', 'declarations' => array('height:auto', 'min-height:0'));
         }
 
         if ( (LayoutIntentClassifier::CHROME_GROUP_ROLE_NAVIGATION === $chromeRole || 'navigation' === $name) && $isContainer ) {
@@ -562,18 +565,6 @@ final class ResponsiveBreakpointSafetyPolicy
     {
         $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
         return empty($layout['display']) && ! empty($this->nodeInspector->nodeList($node));
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     */
-    private function footerResponsiveMinHeight(array $node): float
-    {
-        $baseHeight = $this->nodeBoxHeight($node) ?? 0.0;
-        $insetPanel = $this->footerInsetPanel($node);
-        $bottomBand = $this->footerBottomBand($node);
-
-        return max($baseHeight, ($this->nodeBoxHeight($insetPanel ?? array()) ?? 0.0) + ($this->nodeBoxHeight($bottomBand ?? array()) ?? 0.0));
     }
 
     /**

--- a/figma-transformer/tests/browser/fixtures/footer-newsletter-flow.scenegraph.json
+++ b/figma-transformer/tests/browser/fixtures/footer-newsletter-flow.scenegraph.json
@@ -1,0 +1,110 @@
+{
+  "name": "Responsive Footer Flow Fixture",
+  "nodes": [
+    {
+      "id": "component:footer",
+      "type": "COMPONENT",
+      "name": "Footer",
+      "width": 1440,
+      "height": 602,
+      "children": [
+        {
+          "id": "component:footer:newsletter",
+          "type": "FRAME",
+          "name": "Inset signup panel",
+          "x": 112,
+          "y": 0,
+          "width": 1216,
+          "height": 409,
+          "layoutPositioning": "ABSOLUTE",
+          "children": [
+            {
+              "id": "component:footer:newsletter:copy",
+              "type": "TEXT",
+              "name": "Signup copy",
+              "characters": "A compact signup panel with enough copy to prove that mobile flow remains content-sized.",
+              "width": 544,
+              "height": 58,
+              "fontSize": 18,
+              "lineHeightPx": 29
+            }
+          ]
+        },
+        {
+          "id": "component:footer:band",
+          "type": "FRAME",
+          "name": "Footer band",
+          "x": 0,
+          "y": 409,
+          "width": 1440,
+          "height": 193,
+          "layoutPositioning": "ABSOLUTE",
+          "layoutMode": "HORIZONTAL",
+          "children": [
+            {
+              "id": "component:footer:band:links",
+              "type": "TEXT",
+              "name": "Footer links",
+              "characters": "About Contact Privacy",
+              "width": 240,
+              "height": 26,
+              "fontSize": 16
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "page:desktop",
+      "type": "FRAME",
+      "name": "Desktop page",
+      "width": 1440,
+      "height": 1200,
+      "layoutMode": "VERTICAL",
+      "itemSpacing": 64,
+      "children": [
+        {
+          "id": "page:desktop:hero",
+          "type": "FRAME",
+          "name": "Hero",
+          "width": 1440,
+          "height": 420
+        },
+        {
+          "id": "page:desktop:footer",
+          "type": "INSTANCE",
+          "name": "Footer",
+          "componentId": "component:footer",
+          "width": 1440,
+          "height": 602
+        }
+      ]
+    },
+    {
+      "id": "page:mobile",
+      "type": "FRAME",
+      "name": "Mobile page",
+      "width": 390,
+      "height": 1086,
+      "layoutMode": "VERTICAL",
+      "itemSpacing": 64,
+      "children": [
+        {
+          "id": "page:mobile:hero",
+          "type": "FRAME",
+          "name": "Hero",
+          "width": 390,
+          "height": 420
+        },
+        {
+          "id": "page:mobile:footer",
+          "type": "INSTANCE",
+          "name": "Footer",
+          "componentId": "component:footer",
+          "width": 390,
+          "height": 602
+        }
+      ]
+    }
+  ]
+}

--- a/figma-transformer/tests/browser/footer-newsletter-flow.mjs
+++ b/figma-transformer/tests/browser/footer-newsletter-flow.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const directory = path.dirname(fileURLToPath(import.meta.url));
+const repository = path.resolve(directory, '..', '..', '..');
+const fixturePath = path.join(directory, 'fixtures', 'footer-newsletter-flow.scenegraph.json');
+const transformerPath = path.join(repository, 'figma-transformer', 'figma-transformer.php');
+const requireFromVisualParity = createRequire(path.join(repository, 'php-transformer', 'tools', 'visual-parity', 'package.json'));
+const { chromium } = requireFromVisualParity('playwright');
+const scenegraph = JSON.parse(await readFile(fixturePath, 'utf8'));
+const php = `require ${JSON.stringify(transformerPath)}; $scenegraph = json_decode(file_get_contents($argv[1]), true); $result = blocks_engine_figma_transformer_transform_scenegraph($scenegraph, array('frame_id' => 'page:desktop', 'responsive_variants' => array(array('frame_id' => 'page:desktop', 'viewport_width' => 1440, 'primary' => true), array('frame_id' => 'page:mobile', 'viewport_width' => 390)))); $files = array(); foreach ($result['files'] as $file) { if (in_array($file['path'], array('index.html', 'style.css'), true)) { $files[$file['path']] = $file['content']; } } echo json_encode($files);`;
+const files = JSON.parse(execFileSync('php', ['-r', php, fixturePath], { encoding: 'utf8' }));
+
+const browser = await chromium.launch({ headless: true });
+try {
+  const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+  await page.setContent(files['index.html'].replace('<link rel="stylesheet" href="style.css">', `<style>${files['style.css']}</style>`));
+  const layout = await page.evaluate(() => {
+    const footer = document.querySelector('footer');
+    const [newsletter, band] = footer.children;
+    const pageRoot = document.querySelector('[data-figma-root]');
+    const footerBox = footer.getBoundingClientRect();
+    const newsletterBox = newsletter.getBoundingClientRect();
+    const bandBox = band.getBoundingClientRect();
+    return {
+      documentWidth: document.documentElement.scrollWidth,
+      viewportWidth: window.innerWidth,
+      footerHeight: footerBox.height,
+      newsletter: { top: newsletterBox.top, bottom: newsletterBox.bottom, width: newsletterBox.width, position: getComputedStyle(newsletter).position },
+      band: { left: bandBox.left, top: bandBox.top, bottom: bandBox.bottom, width: bandBox.width, position: getComputedStyle(band).position },
+      pageBottom: pageRoot.getBoundingClientRect().bottom,
+      footerBottom: footerBox.bottom,
+    };
+  });
+
+  assert.ok(layout.documentWidth <= layout.viewportWidth, `document width ${layout.documentWidth} must fit viewport ${layout.viewportWidth}`);
+  assert.equal(layout.newsletter.position, 'relative', 'the inset panel enters footer flow at the narrow breakpoint');
+  assert.equal(layout.band.position, 'relative', 'the footer band enters footer flow at the narrow breakpoint');
+  assert.ok(layout.newsletter.width <= layout.viewportWidth, 'the newsletter panel fits the mobile viewport');
+  assert.ok(layout.band.width <= layout.viewportWidth, 'the footer band fits the mobile viewport');
+  assert.ok(layout.band.left >= 0, 'the footer band does not retain an off-canvas desktop breakout offset');
+  assert.ok(layout.band.top >= layout.newsletter.bottom, 'the authored non-overlapping newsletter and footer band remain sequential');
+  assert.ok(layout.footerBottom - layout.band.bottom <= 1, 'the footer does not retain unused space after its final semantic region');
+} finally {
+  await browser.close();
+}
+
+console.log('Responsive footer newsletter flow browser regression passed');

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -1112,8 +1112,8 @@ function blocks_engine_figma_transformer_run_site_generation_quality_contract(ca
     ));
     $responsiveFooterCss = $fileContent($responsiveFooterResult, 'style.css');
     $assert(str_contains($responsiveFooterCss, '.figma-node-responsive-footer-desktop-footer-footer{height:auto}'), 'responsive-footer-shell-safety-uses-component-structure');
-    $assert(str_contains($responsiveFooterCss, '.figma-node-responsive-footer-desktop-footer-shared-footer-newsletter-newsletter-signup{width:calc(100% - 48px);max-width:342px;height:auto;left:24px}'), 'responsive-footer-newsletter-safety-uses-source-clone');
-    $assert(str_contains($responsiveFooterCss, '.figma-node-responsive-footer-desktop-footer-shared-footer-bottom-frame-19{height:auto;position:relative;left:auto;top:auto;justify-content:center;flex-wrap:wrap'), 'responsive-footer-bottom-row-safety-uses-source-clone');
+    $assert(str_contains($responsiveFooterCss, '.figma-node-responsive-footer-desktop-footer-shared-footer-newsletter-newsletter-signup{width:calc(100% - 48px);max-width:342px;height:auto;position:relative;left:24px;right:auto;top:auto;bottom:auto}'), 'responsive-footer-newsletter-safety-uses-source-clone');
+    $assert(str_contains($responsiveFooterCss, '.figma-node-responsive-footer-desktop-footer-shared-footer-bottom-frame-19{width:100%;max-width:100%;height:auto;position:relative;left:auto;right:auto;top:auto;bottom:auto;margin-left:0;margin-right:0;justify-content:center;flex-wrap:wrap'), 'responsive-footer-bottom-row-safety-uses-source-clone');
 
     $geometryFooterComponent = array(
         'id'       => 'geometry-footer:component',


### PR DESCRIPTION
## Summary
- move geometry-derived mobile footer inset panels and lower bands into normal flow
- clear desktop full-bleed offsets when the lower band becomes a mobile flow region
- cover viewport containment and footer region ordering with a source-shaped browser fixture

## Verification
- `php figma-transformer/tests/contract/run.php`
- `node figma-transformer/tests/browser/footer-newsletter-flow.mjs`
- private decoded-fixture browser check at 390px: document width 390; newsletter x=24/w=342; footer band x=0/w=390; band begins at the newsletter bottom

## Scope
The separate ordered-list-flow issue remains isolated in #1660.

## AI Assistance
OpenAI `gpt-5.6-terra` via OpenCode analyzed decoded Figma geometry, implemented the generic responsive flow policy, authored the regression coverage, and ran verification.