### PR TITLE
fix(php-transformer): materialize Figma overflow SVGs

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializer.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializer.php
@@ -1125,7 +1125,7 @@ final class SvgMaterializer implements SvgElementMaterializer
             'height', 'id', 'image-rendering', 'letter-spacing', 'marker-end', 'marker-mid', 'marker-start',
             'intercept', 'k1', 'k2', 'k3', 'k4', 'kernelmatrix', 'kernelunitlength',
             'lighting-color', 'markerheight', 'markerunits', 'markerwidth', 'mask', 'mode',
-            'numoctaves', 'offset', 'opacity', 'operator', 'order', 'orient', 'paint-order',
+            'numoctaves', 'offset', 'opacity', 'operator', 'order', 'orient', 'overflow', 'paint-order',
             'href', 'patterncontentunits', 'patterntransform', 'patternunits', 'points',
             'preservealpha', 'preserveaspectratio', 'primitiveunits', 'r', 'radius', 'refx', 'refy',
             'result', 'role', 'rotate', 'rx', 'ry', 'scale', 'seed', 'shape-rendering', 'slope',

--- a/php-transformer/tests/fixtures/parity/html-figma-overflow-vector-native-images.json
+++ b/php-transformer/tests/fixtures/parity/html-figma-overflow-vector-native-images.json
@@ -1,0 +1,35 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-figma-overflow-vector-native-images",
+  "description": "Materializes the safe overflow-visible Figma vectors left after SVG asset promotion as core/image assets, preserving their viewBox, paint, clipping semantics, and accessible name without core/html fallbacks.",
+  "source_reference": {
+    "repo": "blocks-engine",
+    "path": "php-transformer/tests/fixtures/parity/html-figma-overflow-vector-native-images.json",
+    "notes": "Distilled from the public structural forms in the real Figma import: a linked chevron, two complex marks, and two stars."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><svg viewBox=\"0 0 10.828 6.828\" width=\"100%\" height=\"100%\" role=\"img\" aria-label=\"Open subjects\" data-figma-vector=\"true\" overflow=\"visible\"><path d=\"M0 0L5 5L10 0\" fill=\"none\" stroke=\"#1f1f1f\"></path></svg><svg viewBox=\"0 0 106 106\" width=\"100%\" height=\"100%\" aria-hidden=\"true\" data-figma-vector=\"true\" overflow=\"visible\"><defs><clipPath id=\"figma-mark-clip\"><rect width=\"96\" height=\"96\"></rect></clipPath></defs><g clip-path=\"url(#figma-mark-clip)\"><path d=\"M0 0H96V96H0Z\" fill=\"#ffcf00\"></path><path d=\"M24 24H72V72H24Z\" fill=\"#000\"></path></g></svg><svg viewBox=\"0 0 35.385 16\" width=\"100%\" height=\"100%\" aria-hidden=\"true\" data-figma-vector=\"true\" overflow=\"visible\"><path d=\"M4 2H28\" fill=\"none\" stroke=\"#000\" stroke-width=\"4\"></path></svg><svg viewBox=\"0 0 24.029 23.056\" width=\"100%\" height=\"100%\" aria-hidden=\"true\" data-figma-vector=\"true\" overflow=\"visible\"><path d=\"M12 0L16 8L24 9L18 15L20 23L12 19L4 23L6 15L0 9L8 8Z\" fill=\"#1f1f1f\"></path></svg><svg viewBox=\"0 0 24.029 23.056\" width=\"100%\" height=\"100%\" aria-hidden=\"true\" data-figma-vector=\"true\" overflow=\"visible\"><path d=\"M12 0L16 8L24 9L18 15L20 23L12 19L4 23L6 15L0 9L8 8Z\" fill=\"#1f1f1f\"></path></svg></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0.innerBlocks.0", "name": "core/image", "attrs": { "alt": "Open subjects", "width": "100%" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/image", "attrs": { "width": "100%" } },
+    { "path": "blocks.0.innerBlocks.2", "name": "core/image", "attrs": { "width": "100%" } },
+    { "path": "blocks.0.innerBlocks.3", "name": "core/image", "attrs": { "width": "100%" } },
+    { "path": "blocks.0.innerBlocks.4", "name": "core/image", "attrs": { "width": "100%" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "assets", "assert": "count", "count": 5 },
+    { "path": "assets.1.content", "assert": "contains", "value": "clipPath" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:image" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:html" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-figma-overflow-vector-native-images.json
+++ b/php-transformer/tests/fixtures/parity/html-figma-overflow-vector-native-images.json
@@ -1,11 +1,11 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-figma-overflow-vector-native-images",
-  "description": "Materializes the safe overflow-visible Figma vectors left after SVG asset promotion as core/image assets, preserving their viewBox, paint, clipping semantics, and accessible name without core/html fallbacks.",
+  "description": "Materializes the five direct, decorative overflow-visible Figma vectors left after SVG asset promotion as core/image assets, preserving their viewBox, paint, and clipPath markup without core/html fallbacks.",
   "source_reference": {
     "repo": "blocks-engine",
     "path": "php-transformer/tests/fixtures/parity/html-figma-overflow-vector-native-images.json",
-    "notes": "Distilled from the public structural forms in the real Figma import: a linked chevron, two complex marks, and two stars."
+    "notes": "Distilled from the real Figma import's five direct decorative vectors: a chevron, two complex marks, and two stars. None is wrapped in an anchor; all source SVGs are aria-hidden."
   },
   "legacy_comparison": {
     "skip": true,
@@ -13,10 +13,10 @@
   },
   "operation": "html_transformer.transform",
   "input": {
-    "content": "<main><svg viewBox=\"0 0 10.828 6.828\" width=\"100%\" height=\"100%\" role=\"img\" aria-label=\"Open subjects\" data-figma-vector=\"true\" overflow=\"visible\"><path d=\"M0 0L5 5L10 0\" fill=\"none\" stroke=\"#1f1f1f\"></path></svg><svg viewBox=\"0 0 106 106\" width=\"100%\" height=\"100%\" aria-hidden=\"true\" data-figma-vector=\"true\" overflow=\"visible\"><defs><clipPath id=\"figma-mark-clip\"><rect width=\"96\" height=\"96\"></rect></clipPath></defs><g clip-path=\"url(#figma-mark-clip)\"><path d=\"M0 0H96V96H0Z\" fill=\"#ffcf00\"></path><path d=\"M24 24H72V72H24Z\" fill=\"#000\"></path></g></svg><svg viewBox=\"0 0 35.385 16\" width=\"100%\" height=\"100%\" aria-hidden=\"true\" data-figma-vector=\"true\" overflow=\"visible\"><path d=\"M4 2H28\" fill=\"none\" stroke=\"#000\" stroke-width=\"4\"></path></svg><svg viewBox=\"0 0 24.029 23.056\" width=\"100%\" height=\"100%\" aria-hidden=\"true\" data-figma-vector=\"true\" overflow=\"visible\"><path d=\"M12 0L16 8L24 9L18 15L20 23L12 19L4 23L6 15L0 9L8 8Z\" fill=\"#1f1f1f\"></path></svg><svg viewBox=\"0 0 24.029 23.056\" width=\"100%\" height=\"100%\" aria-hidden=\"true\" data-figma-vector=\"true\" overflow=\"visible\"><path d=\"M12 0L16 8L24 9L18 15L20 23L12 19L4 23L6 15L0 9L8 8Z\" fill=\"#1f1f1f\"></path></svg></main>"
+    "content": "<main><svg viewBox=\"0 0 10.828 6.828\" width=\"100%\" height=\"100%\" aria-hidden=\"true\" focusable=\"false\" data-figma-vector=\"true\" overflow=\"visible\"><path d=\"M0 0L5 5L10 0\" fill=\"none\" stroke=\"#1f1f1f\"></path></svg><svg viewBox=\"0 0 106 106\" width=\"100%\" height=\"100%\" aria-hidden=\"true\" data-figma-vector=\"true\" overflow=\"visible\"><defs><clipPath id=\"figma-mark-clip\"><rect width=\"96\" height=\"96\"></rect></clipPath></defs><g clip-path=\"url(#figma-mark-clip)\"><path d=\"M0 0H96V96H0Z\" fill=\"#ffcf00\"></path><path d=\"M24 24H72V72H24Z\" fill=\"#000\"></path></g></svg><svg viewBox=\"0 0 35.385 16\" width=\"100%\" height=\"100%\" aria-hidden=\"true\" data-figma-vector=\"true\" overflow=\"visible\"><path d=\"M4 2H28\" fill=\"none\" stroke=\"#000\" stroke-width=\"4\"></path></svg><svg viewBox=\"0 0 24.029 23.056\" width=\"100%\" height=\"100%\" aria-hidden=\"true\" data-figma-vector=\"true\" overflow=\"visible\"><path d=\"M12 0L16 8L24 9L18 15L20 23L12 19L4 23L6 15L0 9L8 8Z\" fill=\"#1f1f1f\"></path></svg><svg viewBox=\"0 0 24.029 23.056\" width=\"100%\" height=\"100%\" aria-hidden=\"true\" data-figma-vector=\"true\" overflow=\"visible\"><path d=\"M12 0L16 8L24 9L18 15L20 23L12 19L4 23L6 15L0 9L8 8Z\" fill=\"#1f1f1f\"></path></svg></main>"
   },
   "expected_blocks": [
-    { "path": "blocks.0.innerBlocks.0", "name": "core/image", "attrs": { "alt": "Open subjects", "width": "100%" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/image", "attrs": { "width": "100%" } },
     { "path": "blocks.0.innerBlocks.1", "name": "core/image", "attrs": { "width": "100%" } },
     { "path": "blocks.0.innerBlocks.2", "name": "core/image", "attrs": { "width": "100%" } },
     { "path": "blocks.0.innerBlocks.3", "name": "core/image", "attrs": { "width": "100%" } },


### PR DESCRIPTION
## Summary
- Permit the safe SVG `overflow` presentation attribute in the generic passive-materialization allowlist.
- Cover the five actual direct, decorative overflow-visible Figma vectors with native `core/image` asset output.
- Correct the fixture provenance: the five source nodes are not linked and are all `aria-hidden="true"`.

## Root Cause And Scope
`SvgMaterializer::isPassiveSvgMarkup()` rejected `overflow="visible"` because it was absent from the safe presentation-attribute allowlist (`php-transformer/src/HtmlToBlocks/Support/SvgMaterializer.php:1116-1140`). That made `inlineSvgImageAttributesFromMarkup()` return `null`. The owner is the upstream PHP transformer; no Static Site Importer change is required.

The read-only source at `.../iteration-final-f3ac-ec2/intermediate/site/index.html` has exactly five `svg[data-figma-vector="true"][overflow="visible"]` nodes (lines 21, 71, 75, 78, 79). Each has a direct `DIV` parent, no enclosing anchor, and `aria-hidden="true"`. No link semantics exist for this five-vector scope; the prior fixture’s invented `/subjects` link and accessible label were removed. Generic linked image lowering remains owned by `HtmlCompilation::propagateLinkOntoImage()` (`php-transformer/src/HtmlToBlocks/HtmlCompilation.php:11398-11450`).

Sanitization is unchanged: scripts, event handlers, JavaScript URLs, external references, and disallowed SVG elements remain rejected. `html-inline-svg-unsafe` remains in the passing suite.

## Tests
- `composer test` passed before the provenance-only fixture correction: canonical/unit contracts, 306 parity fixtures, dist shape, and package install proof.
- After the correction: `php tests/parity/run.php` passed (306 fixtures); `php tests/unit/svg-element-converter.php` passed (13 tests).
- `html-figma-overflow-vector-native-images` asserts five native `core/image` blocks, five materialized assets, serialized `wp:image` markup, no `wp:html`, and fallback count `0`.
- Five assets for five vector occurrences is current behavior. This PR makes no asset-deduplication claim or assertion.

## Browser Evidence
- Read-only source tree: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/studio-figma-real-selected-browser-review/iteration-final-f3ac-ec2/intermediate/site`.
- Full-source Playwright replacement comparison: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/blocks-engine-figma-svg-evidence/real-source-replacement.json`, `real-source-inline-desktop.png`, and `real-source-image-replacement-desktop.png`. Result: 489 differing pixels of 4,871,520 (`0.00010037934771898709`). This is not pixel parity and is recorded as such.
- Narrow evidence with 1,094 differing pixels is not used to claim parity.

## Gutenberg
No real Gutenberg parse/serialize/edit/save proof was obtained. The disposable editor acceptance runner cannot run because Docker is unavailable, and the public browser asset loading attempt could not construct the editor dependency graph. The existing WordPress 7.0.4 save-shape contract passed as part of `composer test`, but it is not a substitute for a live editor save test.

## Fallback Count
- Fixture output: 0 preserved HTML fallbacks for the five scoped source vector forms.
- The existing imported Studio page is read only and was not re-imported; this PR does not claim a post-change full-site fallback count.

## AI Disclosure
GPT-5.6 Terra via OpenCode, directly orchestrated by GPT-6 Astra.