### PR TITLE
fix(figma-transformer): project compact header variants

### DIFF
--- a/figma-transformer/src/Html/ResponsiveBreakpointSafetyPolicy.php
+++ b/figma-transformer/src/Html/ResponsiveBreakpointSafetyPolicy.php
@@ -204,14 +204,6 @@ final class ResponsiveBreakpointSafetyPolicy
     public function responsiveChromeFlowDecision(array $node, ?array $parentNode, array $baseMap, ?array $variantNode, string $name, string $parentName, bool $isContainer, ?string $chromeRole, ?string $parentChromeRole): array
     {
         if ( (LayoutIntentClassifier::CHROME_GROUP_ROLE_HEADER === $chromeRole || $this->isHeaderChromeShellName($name)) && $isContainer ) {
-            $variantHeight = null === $variantNode ? null : $this->nodeBoxHeight($variantNode);
-            if ( 'INSTANCE' === strtoupper((string) ($node['type'] ?? '')) && null !== $variantHeight && $variantHeight > 0.0 && $this->headerVariantTopologyChanged($node, $variantNode) ) {
-                // A structurally different compact header can leave desktop
-                // descendants unmatched. Its explicit variant height is the
-                // paint boundary; do not let those stale descendants cover flow.
-                $height = $this->formatter->number($variantHeight) . 'px';
-                return array('reason_code' => 'responsive_header_variant_paint_boundary', 'declarations' => array('width:100%', 'max-width:100%', 'height:' . $height, 'min-height:' . $height, 'overflow:clip'));
-            }
             return array('reason_code' => 'responsive_header_chrome_safety', 'declarations' => $this->breakpointDimensionPolicy->headerChromeDeclarations($this->responsiveHeaderMinHeight($node, $baseMap, $variantNode)));
         }
 
@@ -678,26 +670,6 @@ final class ResponsiveBreakpointSafetyPolicy
         }
 
         return max($baseHeight, $variantHeight);
-    }
-
-    /**
-     * A matching header can still use normal responsive flow. Only a changed
-     * compact-header structure needs a hard paint boundary for stale children.
-     *
-     * @param array<string, mixed> $node
-     * @param array<string, mixed> $variantNode
-     */
-    private function headerVariantTopologyChanged(array $node, array $variantNode): bool
-    {
-        $signature = static function (array $header): array {
-            $children = is_array($header['children'] ?? null) ? $header['children'] : array();
-            return array_map(
-                static fn (array $child): string => strtolower(trim((string) ($child['type'] ?? '') . ':' . (string) ($child['name'] ?? ''))),
-                array_values(array_filter($children, 'is_array'))
-            );
-        };
-
-        return $signature($node) !== $signature($variantNode);
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -296,6 +296,9 @@ final class StaticHtmlEmitter
      */
     private array $suppressedVisualNodeIds = array();
 
+    /** @var array<string, array{children: array<int, array<string, mixed>>, breakpoint: int, class: string, height: float}> */
+    private array $responsiveHeaderVariantProjections = array();
+
     /**
      * Reset state whose lifetime is one public emission call.
      *
@@ -668,6 +671,7 @@ final class StaticHtmlEmitter
             $pageDecisionTraceOffset = $this->emissionSession->decisionTraceState()->count();
             $pageResponsiveTraceOffset = count($this->breakpointMediaDiffBuilder()->decisionTraces());
             $pageLinkDiagnosticsBefore = $this->linkState->diagnostics();
+            $this->responsiveHeaderVariantProjections = $this->responsiveHeaderVariantProjections($frameNode, $page, $nodeMap);
             $pageDocument = $this->emitPageDocument(array($frameNode), $path, $this->sanitizeText($pageName), $pageName, is_scalar($page['page_type'] ?? null) ? (string) $page['page_type'] : '', is_scalar($page['slug'] ?? null) ? (string) $page['slug'] : $this->templateSlugFromPath($path), 1, $emission['css_rules'], $diagnostics, $nodeStyleDiagnostics, $options);
             $pageRules = array_splice($emission['css_rules'], $pageCssRuleOffset);
             $pageSharedStyles = $this->staticHtmlCssRuleSet()->applySharedStyleClasses($pageRules, true);
@@ -714,6 +718,10 @@ final class StaticHtmlEmitter
             foreach ( $pageMediaBlocks as $mediaBlock ) {
                 $mediaBlocks[] = $mediaBlock;
             }
+            foreach ( $this->responsiveHeaderVariantProjectionRules() as $rule ) {
+                $mediaBlocks[] = $rule;
+            }
+            $this->responsiveHeaderVariantProjections = array();
 
             $pages[] = array(
                 'frame_id'   => $frameId,
@@ -1033,6 +1041,13 @@ final class StaticHtmlEmitter
                     }
                     $content .= $this->emitNode($child, $cssRules, $diagnostics, $nodeStyleDiagnostics, $depth + 1, $node, $parentNode, $insideForm || 'form' === $tag, $insideLink || $nodeIntroducesLink);
                 }
+            }
+            if ( isset($this->responsiveHeaderVariantProjections[$id]) ) {
+                $content .= '<div data-figma-responsive-variant="header">';
+                foreach ( $this->responsiveHeaderVariantProjections[$id]['children'] as $variantChild ) {
+                    $content .= $this->emitNode($variantChild, $cssRules, $diagnostics, $nodeStyleDiagnostics, $depth + 1, $node, $parentNode, $insideForm || 'form' === $tag, $insideLink || $nodeIntroducesLink);
+                }
+                $content .= '</div>';
             }
             if ( $formControlAccessoryControl && ! $insertedAccessoryInput ) {
                 $content .= $this->syntheticFormControlMarkup($node, $className, $textareaAccessoryControl ? 'textarea' : 'input', $parentNode);
@@ -3983,6 +3998,79 @@ final class StaticHtmlEmitter
         $this->linkState->increment('anchors_emitted');
 
         return $this->linkedElementMarkup($element, $href, $type, $buttonLike ? 'figma-link button' : 'figma-link', $buttonLike);
+    }
+
+    /** @return array<string, array{children: array<int, array<string, mixed>>, breakpoint: int, class: string, height: float}> */
+    private function responsiveHeaderVariantProjections(array $frameNode, array $page, array $nodeMap): array
+    {
+        $projections = array();
+        $matcher = new ResponsiveNodeMatcher($this->valueFormatter());
+        $primaryWidth = $this->boxValue($frameNode, 'width') ?? 0.0;
+        foreach ( is_array($page['variants'] ?? null) ? $page['variants'] : array() as $variant ) {
+            $id = is_scalar($variant['frame_id'] ?? null) ? (string) $variant['frame_id'] : '';
+            $width = is_numeric($variant['viewport_width'] ?? null) ? (int) round((float) $variant['viewport_width']) : 0;
+            if ( '' !== $id && $width > 0 && isset($nodeMap[$id]) && is_array($nodeMap[$id]) ) {
+                $breakpoint = $width < $primaryWidth ? (int) round(($primaryWidth + $width) / 2) : $width;
+                $this->collectResponsiveHeaderVariantProjections($frameNode, $nodeMap[$id], null, 0, $breakpoint, $matcher, $projections);
+            }
+        }
+        return $projections;
+    }
+
+    /** @param array<string, array{children: array<int, array<string, mixed>>, breakpoint: int, class: string, height: float}> $projections */
+    private function collectResponsiveHeaderVariantProjections(array $base, array $variant, ?array $parent, int $depth, int $width, ResponsiveNodeMatcher $matcher, array &$projections): void
+    {
+        $baseChildren = array_values(array_filter($this->nodeInspector()->nodeList($base), 'is_array'));
+        $variantChildren = array_values(array_filter($this->nodeInspector()->nodeList($variant), 'is_array'));
+        $id = is_scalar($base['id'] ?? null) ? (string) $base['id'] : '';
+        if ( '' !== $id && $this->layoutIntentClassifier()->chromeGroupRole($base, $parent, $depth) === LayoutIntentClassifier::CHROME_GROUP_ROLE_HEADER && $this->responsiveChildTopology($baseChildren, $matcher) !== $this->responsiveChildTopology($variantChildren, $matcher) ) {
+            $height = $this->boxValue($variant, 'height') ?? 0.0;
+            $projections[$id] = array('children' => $variantChildren, 'breakpoint' => $width, 'class' => 'figma-node-' . $this->slug($id . '-' . (string) ($base['name'] ?? '')), 'height' => $height);
+            return;
+        }
+        $baseCounts = $matcher->siblingSignatureCounts($baseChildren);
+        $baseSources = $matcher->siblingSourceIdentityCounts($baseChildren);
+        $variantCounts = $matcher->siblingSignatureCounts($variantChildren);
+        $variantSources = $matcher->siblingSourceIdentityCounts($variantChildren);
+        $byKey = array();
+        foreach ( $variantChildren as $index => $child ) {
+            foreach ( $matcher->childKeys($child, $index, $variantCounts, $variantSources) as $key ) {
+                $byKey[$key] = $child;
+            }
+        }
+        foreach ( $baseChildren as $index => $child ) {
+            foreach ( $matcher->childKeys($child, $index, $baseCounts, $baseSources) as $key ) {
+                if ( isset($byKey[$key]) ) {
+                    $this->collectResponsiveHeaderVariantProjections($child, $byKey[$key], $base, $depth + 1, $width, $matcher, $projections);
+                    break;
+                }
+            }
+        }
+    }
+
+    /** @param array<int, array<string, mixed>> $children */
+    private function responsiveChildTopology(array $children, ResponsiveNodeMatcher $matcher): array
+    {
+        $counts = $matcher->siblingSignatureCounts($children);
+        $sources = $matcher->siblingSourceIdentityCounts($children);
+        $topology = array();
+        foreach ( $children as $index => $child ) {
+            $topology[] = $matcher->childKeys($child, $index, $counts, $sources)[0] ?? (string) $index;
+        }
+        return $topology;
+    }
+
+    /** @return array<int, string> */
+    private function responsiveHeaderVariantProjectionRules(): array
+    {
+        $rules = array();
+        foreach ( $this->responsiveHeaderVariantProjections as $projection ) {
+            $class = $projection['class'];
+            $rules[] = '.' . $class . '>[data-figma-responsive-variant="header"]{display:none}';
+            $height = $projection['height'] > 0 ? ';height:' . $this->valueFormatter()->number($projection['height']) . 'px;min-height:' . $this->valueFormatter()->number($projection['height']) . 'px' : '';
+            $rules[] = '@media (max-width:' . $projection['breakpoint'] . 'px){.' . $class . '>[data-figma-responsive-variant="header"]{display:contents}.' . $class . '>:not([data-figma-responsive-variant="header"]){display:none}.' . $class . '{width:100%;max-width:100%;' . ltrim($height, ';') . '}}';
+        }
+        return $rules;
     }
 
     /**

--- a/figma-transformer/tests/browser/fixtures/responsive-hero-intro-flow.scenegraph.json
+++ b/figma-transformer/tests/browser/fixtures/responsive-hero-intro-flow.scenegraph.json
@@ -98,7 +98,7 @@
               "layoutMode": "HORIZONTAL",
               "children": [
                 { "id": "hero:mobile:header:logo", "type": "TEXT", "name": "Logo", "characters": "Logo", "width": 228, "height": 35, "fontSize": 24 },
-                { "id": "hero:mobile:header:menu", "type": "TEXT", "name": "Menu", "characters": "Menu", "width": 24, "height": 32, "fontSize": 16 }
+                { "id": "hero:mobile:header:menu", "type": "INSTANCE", "name": "Open menu", "characters": "Menu", "width": 24, "height": 32, "fontSize": 16 }
               ]
             },
             { "id": "hero:mobile:copy", "type": "TEXT", "name": "Hero copy", "characters": "Hero", "width": 342, "height": 130, "fontSize": 40 },

--- a/figma-transformer/tests/browser/responsive-hero-intro-flow.mjs
+++ b/figma-transformer/tests/browser/responsive-hero-intro-flow.mjs
@@ -15,7 +15,7 @@ const php = `require ${JSON.stringify(transformerPath)}; $scenegraph = json_deco
 const files = JSON.parse(execFileSync('php', ['-r', php, fixturePath], { encoding: 'utf8' }));
 
 assert.match(files['style.css'], /min-height:470\.75px/, 'a shorter variant height replaces the primary flow reserve');
-assert.match(files['style.css'], /height:127px;min-height:127px;overflow:clip/, 'an explicit compact header bounds stale desktop navigation paint');
+assert.match(files['style.css'], /data-figma-responsive-variant="header"/, 'a structurally distinct compact header projects its variant children');
 
 const browser = await chromium.launch({ headless: true });
 try {
@@ -29,10 +29,13 @@ try {
     await page.setContent(files['index.html'].replace('<link rel="stylesheet" href="style.css">', `<style>${files['style.css']}</style>`));
     const layout = await page.evaluate(() => {
       const hero = document.querySelector('[data-figma-node-id="hero:desktop"]');
+      const header = document.querySelector('[data-figma-node-id="hero:desktop:header"]');
       const intro = document.querySelector('[data-figma-node-id="intro:desktop"]');
       const introText = document.querySelector('[data-figma-node-id="intro:desktop:copy"]');
       const media = document.querySelector('[data-figma-node-id="hero:desktop:media"]');
       const footer = document.querySelector('[data-figma-node-id="closing:desktop"]');
+      const desktopNavigation = document.querySelector('[data-figma-node-id="hero:desktop:header:navigation"]');
+      const compactMenu = document.querySelector('[data-figma-node-id="hero:mobile:header:menu"]');
       const box = (element) => element.getBoundingClientRect();
       const heroBox = box(hero);
       const introBox = box(intro);
@@ -54,6 +57,7 @@ try {
         }));
       return {
         hero: heroBox.toJSON(),
+        header: box(header).toJSON(),
         intro: introBox.toJSON(),
         introText: introTextBox.toJSON(),
         introTextRects: textRects,
@@ -61,6 +65,9 @@ try {
         introIntersectsMedia: textRects.some((rect) => intersects(rect, mediaBox)),
         introClipped: clipped,
         hitOwnsIntro: hit.some((element) => element === intro || intro.contains(element) || element.contains(intro)),
+        desktopNavigationVisible: desktopNavigation && getComputedStyle(desktopNavigation).display !== 'none',
+        compactMenuVisible: compactMenu && getComputedStyle(compactMenu).display !== 'none' && compactMenu.getBoundingClientRect().width > 0,
+        compactMenuAccessible: compactMenu?.getAttribute('data-figma-node-name') === 'Open menu',
         footer: footerBox.toJSON(),
         documentWidth: document.documentElement.scrollWidth,
         viewportWidth: window.innerWidth,
@@ -69,6 +76,7 @@ try {
     });
 
     assert.equal(layout.hero.height, viewport.heroHeight, `${viewport.name} uses its source hero height`);
+    if (viewport.width <= 430) assert.equal(layout.header.height, 127, `${viewport.name} uses the compact header height`);
     assert.equal(layout.intro.top - layout.hero.bottom, viewport.gap, `${viewport.name} preserves authored hero-to-intro spacing`);
     assert.ok(layout.intro.top >= layout.hero.bottom, `${viewport.name} hero and intro do not overlap`);
     assert.ok(layout.introTextRects.length > 0, `${viewport.name} intro text has rendered range rectangles`);
@@ -76,6 +84,14 @@ try {
     assert.equal(layout.introIntersectsMedia, false, `${viewport.name} intro text does not intersect painted hero media`);
     assert.equal(layout.introClipped, false, `${viewport.name} intro text is not clipped`);
     assert.equal(layout.hitOwnsIntro, true, `${viewport.name} hit testing resolves to intro content instead of hero media`);
+    if (viewport.width <= 430) {
+      assert.equal(layout.desktopNavigationVisible, false, `${viewport.name} does not expose the desktop navigation as clipped compact chrome`);
+      assert.equal(layout.compactMenuVisible, true, `${viewport.name} exposes the compact variant navigation representation`);
+      assert.equal(layout.compactMenuAccessible, true, `${viewport.name} preserves the compact navigation control semantics`);
+    } else {
+      assert.equal(layout.desktopNavigationVisible, true, `${viewport.name} retains desktop navigation`);
+      assert.equal(layout.compactMenuVisible, false, `${viewport.name} hides compact variant navigation`);
+    }
     assert.ok(layout.footer.top >= layout.intro.bottom, `${viewport.name} footer remains after intro flow`);
     assert.ok(layout.documentHeight >= layout.footer.bottom, `${viewport.name} full page contains the footer`);
     assert.ok(layout.documentWidth <= layout.viewportWidth, `${viewport.name} has no horizontal overflow`);


### PR DESCRIPTION
## Summary

Follow-up for the compact-header projection omitted from already-merged #1664. Replaces compact-header clipping with a matched responsive header child-tree projection, preserving the compact source header and its real menu representation rather than hiding stale desktop descendants.

Closes #1662

## Source-model geometry

The verified responsive source model pairs a 1440px desktop page with a 390px mobile variant. At 390px, the hero is 470.75px tall, the header is 127px tall (44px status region plus 83px dropdown header/menu), and the intro begins at y=534.75px. The intro text has eight visible range rectangles; none intersects the hero/media region ending at y=470.75px. The footer starts at y=2954.75px, after the intro.

## Local validation

- `composer validate --strict` in `figma-transformer/`: passed.
- `composer test` in `figma-transformer/`: passed (`Figma Transformer contract tests passed.`).
- `node tests/browser/responsive-hero-intro-flow.mjs` in `figma-transformer/`: passed at desktop, 375px, 390px, and 430px.
- `git diff --check origin/trunk...HEAD`: passed.
- Private 390px source-model browser evidence confirmed: compact menu visible; desktop navigation hidden; visible intro ranges; no intro/media intersection; intro hit testing; no horizontal overflow; footer after intro.

## Candidate limitations

- The browser evidence is a local private Figma-to-static-HTML source-model candidate; private fixture inputs, paths, screenshots, and artifacts are intentionally not published here.
- No WordPress or Studio candidate was built, mutated, registered, or validated. This PR is ready for main browser review, not WordPress/Studio acceptance.

## AI disclosure

OpenAI gpt-5.6-terra via OpenCode was used to inspect the change, run validation, build the local candidate, and prepare this PR.