### PR TITLE
Fix responsive image crop cascade resolution

### DIFF
--- a/php-transformer/dev/VisualParity/StaticCssCascade.php
+++ b/php-transformer/dev/VisualParity/StaticCssCascade.php
@@ -5,6 +5,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\VisualParity;
 
 use Automattic\BlocksEngine\PhpTransformer\Css\CssSelectorMatcher;
 use Automattic\BlocksEngine\PhpTransformer\Css\CssStylesheetTransformer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssCascade;
 use DOMDocument;
 use DOMElement;
 
@@ -155,25 +156,14 @@ final class StaticCssCascade
         foreach ($declarations as $name => $rawValue) {
             $important = 1 === preg_match('/\s*!important\s*$/i', $rawValue);
             $value = preg_replace('/\s*!important\s*$/i', '', $rawValue) ?? $rawValue;
-            $current = $resolved[$name] ?? null;
-            if (is_array($current)
-                && (int) $current['important'] > (int) $important) {
-                continue;
-            }
-            if (is_array($current)
-                && (bool) $current['important'] === $important
-                && ($current['specificity'] > $specificity
-                    || ($current['specificity'] === $specificity && $current['order'] > $order)
-                    || ($current['specificity'] === $specificity && $current['order'] === $order && $current['inline'] && ! $inline))) {
-                continue;
-            }
-            $resolved[$name] = array(
+            CssCascade::apply($resolved, $name, array(
                 'value' => $value,
                 'important' => $important,
                 'specificity' => $specificity,
                 'order' => $order,
                 'inline' => $inline,
-            );
+                'layer' => null,
+            ));
         }
     }
 
@@ -336,35 +326,7 @@ final class StaticCssCascade
      */
     private function mediaConditionApplies(string $condition): bool
     {
-        $condition = strtolower(trim($condition));
-
-        if ( '' === $condition ) {
-            return true;
-        }
-
-        if ( preg_match('/\b(?:print|speech|aural|braille|embossed|tty)\b/', $condition) ) {
-            return false;
-        }
-
-        foreach ( array( 'min' => '>=', 'max' => '<=' ) as $bound => $comparison ) {
-            if ( ! preg_match_all('/\(\s*' . $bound . '-width\s*:\s*([0-9.]+)\s*(px|rem|em)?\s*\)/', $condition, $matches, PREG_SET_ORDER) ) {
-                continue;
-            }
-            foreach ( $matches as $widthMatch ) {
-                $value = (float) $widthMatch[1];
-                if ( in_array($widthMatch[2] ?? 'px', array( 'rem', 'em' ), true) ) {
-                    $value *= self::ROOT_FONT_SIZE_PX;
-                }
-                $holds = '>=' === $comparison
-                    ? self::REFERENCE_VIEWPORT_WIDTH_PX >= $value
-                    : self::REFERENCE_VIEWPORT_WIDTH_PX <= $value;
-                if ( ! $holds ) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
+        return CssCascade::mediaConditionApplies($condition, self::REFERENCE_VIEWPORT_WIDTH_PX, self::ROOT_FONT_SIZE_PX);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -9746,7 +9746,7 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
         // the carrier element is gone. Promote it to native aspectRatio/scale
         // attributes so WordPress reproduces the authored crop. `+` never
         // overrides an attribute already resolved above.
-        $attrs += $this->imageShapeConstraintAttributes($image);
+        $attrs += $this->imageShapeConstraintAttributes($image, $width, $height);
 
         if ( $figure instanceof DOMElement ) {
             $caption = $this->firstChildElement($figure, 'figcaption');
@@ -9766,10 +9766,20 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
     {
         $inline = trim($this->cssValueWithoutImportant((string) ($this->styleResolver->cssDeclarations($this->attr($image, 'style'))[ $property ] ?? '')));
         if ( '' !== $inline && ! in_array(strtolower($inline), array( 'auto', 'inherit', 'initial', 'unset', 'revert', 'revert-layer' ), true) ) {
-            return ! $linked && preg_match('/^(?:\d+|\d*\.\d+)$/', $inline) ? $inline . 'px' : $inline;
+            return $this->imageDimensionValue($inline, $linked);
         }
         $attribute = trim($this->attr($image, $property));
-        return ! $linked && preg_match('/^(?:\d+|\d*\.\d+)$/', $attribute) ? $attribute . 'px' : $attribute;
+        return $this->imageDimensionValue($attribute, $linked);
+    }
+
+    /** Keep core/image dimensions to CSS lengths WordPress can serialize safely. */
+    private function imageDimensionValue(string $value, bool $linked): string
+    {
+        $value = trim($value);
+        if (1 !== preg_match('/^(?:\d+|\d*\.\d+)(?:%|px|r?em|ex|ch|lh|rlh|vw|vh|vmin|vmax|vi|vb|cm|mm|q|in|pt|pc)?$/i', $value)) {
+            return '';
+        }
+        return ! $linked && preg_match('/^(?:\d+|\d*\.\d+)$/', $value) ? $value . 'px' : $value;
     }
 
     /** @return array<string, mixed> */
@@ -10004,12 +10014,13 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
 
     private function hasCropFocusThatCoreImageCannotCarry(DOMElement $image): bool
     {
-        $scale = strtolower($this->cssValueWithoutImportant($this->imageShapeDeclaration($image, 'object-fit')));
+        $declarations = $this->styleResolver->imageShapeDeclarations($image);
+        $scale = strtolower($this->cssValueWithoutImportant((string) ($declarations['object-fit']['value'] ?? '')));
         if ( ! in_array($scale, array( 'cover', 'contain' ), true) ) {
             return false;
         }
 
-        return '' !== trim($this->cssValueWithoutImportant($this->imageShapeDeclaration($image, 'object-position')));
+        return '' !== trim($this->cssValueWithoutImportant((string) ($declarations['object-position']['value'] ?? '')));
     }
 
     private function customVideoElement(DOMElement $element): ?DOMElement
@@ -12151,168 +12162,32 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
      *
      * @return array<string, string>
      */
-    private function imageShapeConstraintAttributes(DOMElement $image): array
+    private function imageShapeConstraintAttributes(DOMElement $image, string $width, string $height): array
     {
-        $declarations = array(
-            'aspect-ratio' => $this->imageShapeDeclaration($image, 'aspect-ratio'),
-            'object-fit' => $this->imageShapeDeclaration($image, 'object-fit'),
-        );
+        $declarations = $this->styleResolver->imageShapeDeclarations($image);
         $aspectRatio  = $this->normalizedAspectRatio(
-            (string) $declarations['aspect-ratio']
+            (string) ($declarations['aspect-ratio']['value'] ?? '')
         );
         // `object-fit:cover !important` is a common defence against core's
         // `.wp-block-image img` rules. Strip importance symmetrically with
         // normalizedAspectRatio, or the keyword never matches the allowlist below
         // and the whole promotion silently declines.
         $scale        = strtolower($this->cssValueWithoutImportant(
-            (string) $declarations['object-fit']
+            (string) ($declarations['object-fit']['value'] ?? '')
         ));
 
         if ( ! in_array($scale, array( 'cover', 'contain' ), true) ) {
             return array();
         }
 
-        if ( '' === $aspectRatio ) {
-            $inlineScale = strtolower($this->cssValueWithoutImportant((string) ($this->styleResolver->cssDeclarations($this->attr($image, 'style'))['object-fit'] ?? '')));
-            return $scale === $inlineScale ? array( 'scale' => $scale ) : array();
+        if ( '' === $aspectRatio || $this->imageDimensionsDetermineDifferentAspectRatio($width, $height, $aspectRatio) ) {
+            return (($declarations['object-fit']['inline'] ?? false) === true) ? array( 'scale' => $scale ) : array();
         }
 
         return array(
             'aspectRatio' => $aspectRatio,
             'scale'       => $scale,
         );
-    }
-
-    /** Resolve one crop declaration at the desktop viewport using the CSS cascade. */
-    private function imageShapeDeclaration(DOMElement $element, string $property): string
-    {
-        $winner = null;
-        foreach ($this->sourceStyles()->imageShapeRules() as $rule) {
-            if ($property !== $rule['property'] || ! $this->styleResolver->matchesCssSelector($element, $rule['selector'])) {
-                continue;
-            }
-            if (array() !== $rule['conditions']) {
-                $minWidth = $this->conditionsDesktopMinWidth($rule['conditions']);
-                if (null === $minWidth || $minWidth > self::DESKTOP_REFERENCE_WIDTH) {
-                    continue;
-                }
-            }
-            $candidate = array(
-                'value' => $rule['value'],
-                'specificity' => $this->styleResolver->mediaTextSelectorSpecificity($rule['selector']),
-                'order' => $rule['order'],
-                'inline' => false,
-            );
-            if ($this->imageShapeDeclarationWins($candidate, $winner)) {
-                $winner = $candidate;
-            }
-        }
-        $inlineEntries = $this->styleResolver->imageShapeDeclarationEntries($this->attr($element, 'style'));
-        foreach ($inlineEntries as $index => $entry) {
-            if ($property !== $entry['property']) {
-                continue;
-            }
-            $candidate = array('value' => $entry['value'], 'specificity' => array(PHP_INT_MAX, PHP_INT_MAX, PHP_INT_MAX), 'order' => PHP_INT_MAX - count($inlineEntries) + $index, 'inline' => true);
-            if ($this->imageShapeDeclarationWins($candidate, $winner)) {
-                $winner = $candidate;
-            }
-        }
-
-        return is_array($winner) ? $winner['value'] : '';
-    }
-
-    /** @param array{value:string,specificity:array{int,int,int},order:int,inline:bool} $candidate @param array{value:string,specificity:array{int,int,int},order:int,inline:bool}|null $current */
-    private function imageShapeDeclarationWins(array $candidate, ?array $current): bool
-    {
-        if (null === $current) {
-            return true;
-        }
-        $candidateImportant = $this->cssValueIsImportant($candidate['value']);
-        $currentImportant = $this->cssValueIsImportant($current['value']);
-        if ($candidateImportant !== $currentImportant) {
-            return $candidateImportant;
-        }
-        $specificity = $this->styleResolver->compareMediaTextSpecificity($candidate['specificity'], $current['specificity']);
-        return 0 < $specificity || (0 === $specificity && $candidate['order'] >= $current['order']);
-    }
-
-    /**
-     * The min-width (px) at which a conditional rule's `@media` prelude(s) begin
-     * to apply, or null when a condition cannot be positively evaluated at the
-     * desktop viewport. `@layer` is an unconditional grouping wrapper. A bounded
-     * set of modern crop-relevant `@supports` tests is accepted; unknown feature
-     * queries remain unresolved rather than being flattened. Nested conditions
-     * must all qualify; the effective breakpoint is the widest.
-     *
-     * @param list<string> $conditions
-     */
-    private function conditionsDesktopMinWidth(array $conditions): ?int
-    {
-        $minWidth = 0;
-
-        foreach ( $conditions as $condition ) {
-            $condition = trim($condition);
-            if ( 1 === preg_match('/^@layer\b/i', $condition) ) {
-                continue;
-            }
-            if ( 1 === preg_match('/^@supports\b/i', $condition) ) {
-                if ($this->supportsDesktopImageCropCondition($condition)) {
-                    continue;
-                }
-                return null;
-            }
-            if ( 1 !== preg_match('/^@media\b/i', $condition) ) {
-                return null;
-            }
-            // `not` inverts the feature test, so a min-width it names is the
-            // breakpoint below which the rule applies -- the opposite of a
-            // desktop override.
-            if ( 1 === preg_match('/\bnot\b/i', $condition) ) {
-                return null;
-            }
-            // Only `screen`/`all` describe the viewport the block renders at; a
-            // `print` (or speech/tv) crop must never become the block's crop.
-            if ( 1 === preg_match('/^@media\s+(?:only\s+)?([a-z-]+)/i', $condition, $typeMatch)
-                && ! in_array(strtolower($typeMatch[1]), array( 'all', 'screen' ), true)
-            ) {
-                return null;
-            }
-            if ( 1 === preg_match('/max-width\s*:/i', $condition) ) {
-                return null;
-            }
-            if ( 1 !== preg_match('/min-width\s*:\s*(\d+(?:\.\d+)?)\s*(px|r?em)\b/i', $condition, $matches) ) {
-                return null;
-            }
-            // `em`/`rem` breakpoints resolve against the root font size in a
-            // media query -- an `em` here is never the element's own font size.
-            $breakpoint = (float) $matches[1];
-            if ( 'px' !== strtolower($matches[2]) ) {
-                $breakpoint *= self::ROOT_FONT_SIZE_PX;
-            }
-            $minWidth = max($minWidth, (int) round($breakpoint));
-        }
-
-        return $minWidth;
-    }
-
-    /** Bounded browser-capability facts used for crop rules under @supports. */
-    private function supportsDesktopImageCropCondition(string $condition): bool
-    {
-        $query = strtolower(trim(preg_replace('/^@supports\s*/i', '', $condition) ?? ''));
-        $query = preg_replace('/^\((.*)\)$/s', '$1', $query) ?? $query;
-        [$property, $value] = array_pad(array_map('trim', explode(':', $query, 2)), 2, '');
-
-        if ('display' === $property) {
-            return in_array($value, array('flex', 'grid', 'inline-flex', 'inline-grid'), true);
-        }
-        if ('aspect-ratio' === $property) {
-            return '' !== $this->normalizedAspectRatio($value);
-        }
-        if ('object-fit' === $property) {
-            return in_array($value, array('cover', 'contain'), true);
-        }
-
-        return false;
     }
 
     private function cssValueWithoutImportant(string $value): string
@@ -12341,7 +12216,7 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             return '';
         }
 
-        if ( preg_match('#^(\d+(?:\.\d+)?)\s*/\s*(\d+(?:\.\d+)?)$#', $value, $matches) ) {
+        if ( preg_match('#^(\d*\.?\d+)\s*/\s*(\d*\.?\d+)$#', $value, $matches) ) {
             if ( 0.0 === (float) $matches[1] || 0.0 === (float) $matches[2] ) {
                 return '';
             }
@@ -12349,11 +12224,23 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             return $matches[1] . '/' . $matches[2];
         }
 
-        if ( preg_match('#^\d+(?:\.\d+)?$#', $value) ) {
+        if ( preg_match('#^\d*\.?\d+$#', $value) ) {
             return 0.0 === (float) $value ? '' : $value;
         }
 
         return '';
+    }
+
+    private function imageDimensionsDetermineDifferentAspectRatio(string $width, string $height, string $aspectRatio): bool
+    {
+        if (! preg_match('/^(\d*\.?\d+)([a-z]+)$/i', $width, $widthMatch)
+            || ! preg_match('/^(\d*\.?\d+)([a-z]+)$/i', $height, $heightMatch)
+            || strtolower($widthMatch[2]) !== strtolower($heightMatch[2])
+            || ! preg_match('#^(\d*\.?\d+)(?:\s*/\s*(\d*\.?\d+))?$#', $aspectRatio, $ratioMatch)) {
+            return false;
+        }
+        $ratio = (float) $ratioMatch[1] / (float) ($ratioMatch[2] ?? '1');
+        return abs(((float) $widthMatch[1] / (float) $heightMatch[1]) - $ratio) > 0.000001;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Style/CssCascade.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssCascade.php
@@ -9,10 +9,18 @@ final class CssCascade
     /** @param array<string, mixed> $candidate @param array<string, mixed> $current */
     public static function wins(array $candidate, array $current): bool
     {
-        return (int) $candidate['important'] > (int) $current['important']
-            || ((bool) $candidate['important'] === $current['important']
-                && ($candidate['specificity'] > $current['specificity']
-                    || ($candidate['specificity'] === $current['specificity'] && $candidate['order'] >= $current['order'])));
+        if ((bool) $candidate['important'] !== (bool) $current['important']) {
+            return (bool) $candidate['important'];
+        }
+        if ((bool) ($candidate['inline'] ?? false) !== (bool) ($current['inline'] ?? false)) {
+            return (bool) ($candidate['inline'] ?? false);
+        }
+        $layer = self::compareLayers($candidate['layer'] ?? null, $current['layer'] ?? null, (bool) $candidate['important']);
+        if (0 !== $layer) {
+            return 0 < $layer;
+        }
+        $specificity = self::compareSpecificity($candidate['specificity'], $current['specificity']);
+        return 0 < $specificity || (0 === $specificity && $candidate['order'] >= $current['order']);
     }
 
     /** @param array<string, array<string, mixed>> $facts @param array<string, mixed> $candidate */
@@ -24,5 +32,87 @@ final class CssCascade
             return true;
         }
         return false;
+    }
+
+    /** Evaluate a comma-separated visual media query list at a viewport width. */
+    public static function mediaConditionApplies(string $condition, float $viewportWidth, float $rootFontSize = 16.0): bool
+    {
+        foreach (\Automattic\BlocksEngine\PhpTransformer\Css\CssValueSplitter::splitTopLevel($condition, array(',')) as $alternative) {
+            if (self::mediaAlternativeApplies($alternative, $viewportWidth, $rootFontSize)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static function mediaAlternativeApplies(string $alternative, float $viewportWidth, float $rootFontSize): bool
+    {
+        $alternative = strtolower(trim($alternative));
+        $negated = str_starts_with($alternative, 'not ');
+        if ($negated) $alternative = trim(substr($alternative, 4));
+        if (str_starts_with($alternative, 'only ')) $alternative = trim(substr($alternative, 5));
+        $applies = true;
+        foreach (preg_split('/\s+and\s+/i', $alternative) ?: array() as $term) {
+            $term = trim($term);
+            $termApplies = self::mediaTermApplies($term, $viewportWidth, $rootFontSize);
+            // An unknown feature has no reliable truth value in this evaluator,
+            // so it cannot qualify a rule even when the query is negated.
+            if (null === $termApplies) {
+                return false;
+            }
+            if (! $termApplies) {
+                $applies = false;
+                break;
+            }
+        }
+        return $negated ? ! $applies : $applies;
+    }
+
+    private static function mediaTermApplies(string $term, float $viewportWidth, float $rootFontSize): ?bool
+    {
+        if (in_array($term, array('', 'all', 'screen'), true)) return true;
+        if (in_array($term, array('print', 'speech'), true)) return false;
+        if (preg_match('/^[a-z-]+$/', $term)) return null;
+        $term = trim($term, " \t\n\r\0\x0B()");
+        return self::mediaWidthTermApplies($term, $viewportWidth, $rootFontSize);
+    }
+
+    private static function mediaWidthTermApplies(string $term, float $viewportWidth, float $rootFontSize): ?bool
+    {
+        $number = '(\d*\.?\d+)\s*(px|r?em)';
+        if (preg_match('/^(min|max)-width\s*:\s*' . $number . '$/i', $term, $match)) {
+            return self::compareWidth('min' === strtolower($match[1]) ? '>=' : '<=', $viewportWidth, self::widthPixels($match[2], $match[3], $rootFontSize));
+        }
+        if (preg_match('/^width\s*(<=|>=|<|>)\s*' . $number . '$/i', $term, $match)) {
+            return self::compareWidth($match[1], $viewportWidth, self::widthPixels($match[2], $match[3], $rootFontSize));
+        }
+        if (preg_match('/^' . $number . '\s*(<=|<)\s*width$/i', $term, $match)) {
+            return self::compareWidth('<=' === $match[3] ? '>=' : '>', $viewportWidth, self::widthPixels($match[1], $match[2], $rootFontSize));
+        }
+        if (preg_match('/^' . $number . '\s*(<=|<)\s*width\s*(<=|<)\s*' . $number . '$/i', $term, $match)) {
+            return self::compareWidth('<=' === $match[3] ? '>=' : '>', $viewportWidth, self::widthPixels($match[1], $match[2], $rootFontSize))
+                && self::compareWidth($match[4], $viewportWidth, self::widthPixels($match[5], $match[6], $rootFontSize));
+        }
+        return null;
+    }
+
+    private static function widthPixels(string $value, string $unit, float $rootFontSize): float { return (float) $value * ('px' === strtolower($unit) ? 1 : $rootFontSize); }
+    private static function compareWidth(string $operator, float $actual, float $expected): bool { return match ($operator) { '>=' => $actual >= $expected, '>' => $actual > $expected, '<=' => $actual <= $expected, '<' => $actual < $expected }; }
+
+    private static function compareLayers(mixed $candidate, mixed $current, bool $important): int
+    {
+        if ($candidate === $current) return 0;
+        if (null === $candidate) return $important ? -1 : 1;
+        if (null === $current) return $important ? 1 : -1;
+        return $important ? $current <=> $candidate : $candidate <=> $current;
+    }
+
+    private static function compareSpecificity(mixed $left, mixed $right): int
+    {
+        if (is_array($left) && is_array($right)) {
+            foreach (array(0, 1, 2) as $index) if (($left[$index] ?? 0) !== ($right[$index] ?? 0)) return ($left[$index] ?? 0) <=> ($right[$index] ?? 0);
+            return 0;
+        }
+        return $left <=> $right;
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
@@ -2387,9 +2387,13 @@ final class StyleResolver implements ElementPresentationResolver
             'cascaded_values' => array(),
         );
         $imageOrder = 0;
+        $layers = array();
+        if (preg_match_all('/@layer\s+([a-z0-9_-]+(?:\.[a-z0-9_-]+)?(?:\s*,\s*[a-z0-9_-]+(?:\.[a-z0-9_-]+)?)*)\s*;/i', $css, $layerStatements)) {
+            foreach ($layerStatements[1] as $statement) foreach (explode(',', $statement) as $name) $layers[strtolower(trim($name))] ??= count($layers);
+        }
         (new CssStylesheetTransformer())->visitStyleRules(
             $css,
-            function (string $prelude, string $body, array $conditions) use (&$analysis, &$imageOrder): void {
+            function (string $prelude, string $body, array $conditions) use (&$analysis, &$imageOrder, &$layers): void {
                 $rawDeclarations = $this->cssDeclarations($body);
                 $declarations = $this->safeVisualDeclarations($rawDeclarations);
                 // A materialized SVG asset is an isolated document: it cannot
@@ -2418,6 +2422,12 @@ final class StyleResolver implements ElementPresentationResolver
                     ))
                     : array();
                 $imageEntries = $this->imageShapeDeclarationEntries($body);
+                $layer = null;
+                foreach ($conditions as $condition) if (preg_match('/^@layer\s+([a-z0-9_-]+(?:\.[a-z0-9_-]+)*)\b/i', trim($condition), $match)) {
+                    $name = strtolower($match[1]);
+                    $layers[$name] ??= count($layers);
+                    $layer = $name;
+                }
 
                 foreach (explode(',', $prelude) as $selector) {
                     $selector = trim($selector);
@@ -2444,6 +2454,7 @@ final class StyleResolver implements ElementPresentationResolver
                                 'value' => $entry['value'],
                                 'conditions' => $conditions,
                                 'order' => $imageOrder++,
+                                'layer' => $layer,
                             );
                         }
                     }
@@ -2472,6 +2483,7 @@ final class StyleResolver implements ElementPresentationResolver
             }
         );
 
+        $analysis['layer_names'] = array_keys($layers);
         return $analysis;
     }
 
@@ -2492,6 +2504,52 @@ final class StyleResolver implements ElementPresentationResolver
         }
 
         return $entries;
+    }
+
+    /** Resolve image crop declarations at the desktop reference viewport. */
+    public function imageShapeDeclarations(DOMElement $element): array
+    {
+        $facts = array();
+        foreach ($this->context->sourceStyles()->imageShapeRules() as $rule) {
+            if (!$this->matchesCssSelector($element, $rule['selector']) || !$this->imageShapeConditionsApply($rule['conditions'])) continue;
+            CssCascade::apply($facts, $rule['property'], array(
+                'value' => $rule['value'],
+                'important' => CssValueInspector::isImportant($rule['value']),
+                'specificity' => $this->mediaTextSelectorSpecificity($rule['selector']), 'order' => $rule['order'], 'inline' => false, 'layer' => $rule['layer'] ?? null,
+            ));
+        }
+        foreach ($this->imageShapeDeclarationEntries(SourceDom::attr($element, 'style')) as $order => $entry) {
+            CssCascade::apply($facts, $entry['property'], array(
+                'value' => $entry['value'], 'important' => CssValueInspector::isImportant($entry['value']),
+                'specificity' => array(PHP_INT_MAX, PHP_INT_MAX, PHP_INT_MAX), 'order' => PHP_INT_MAX - 1000 + $order, 'inline' => true, 'layer' => null,
+            ));
+        }
+        return $facts;
+    }
+
+    /** @param list<string> $conditions */
+    private function imageShapeConditionsApply(array $conditions): bool
+    {
+        foreach ($conditions as $condition) {
+            $condition = trim($condition);
+            if (preg_match('/^@layer\b/i', $condition)) continue;
+            if (preg_match('/^@supports\b/i', $condition)) {
+                if (!$this->knownImageShapeSupportsCondition($condition)) return false;
+            } elseif (preg_match('/^@media\b/i', $condition)) {
+                if (!CssCascade::mediaConditionApplies((string) preg_replace('/^@media\s*/i', '', $condition), 1440.0)) return false;
+            } else return false;
+        }
+        return true;
+    }
+
+    private function knownImageShapeSupportsCondition(string $condition): bool
+    {
+        $query = strtolower(trim((string) preg_replace('/^@supports\s*/i', '', $condition)));
+        $query = preg_replace('/^\((.*)\)$/s', '$1', $query) ?? $query;
+        [$property, $value] = array_pad(array_map('trim', explode(':', $query, 2)), 2, '');
+        return ('display' === $property && in_array($value, array('flex', 'grid', 'inline-flex', 'inline-grid'), true))
+            || ('aspect-ratio' === $property && 1 === preg_match('#^\d*\.?\d+\s*(?:/\s*\d*\.?\d+)?$#', $value))
+            || ('object-fit' === $property && in_array($value, array('cover', 'contain'), true));
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Style/StylesheetAnalysisComposer.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StylesheetAnalysisComposer.php
@@ -97,6 +97,7 @@ final class StylesheetAnalysisComposer
     public function composedStyleAnalysis(array $payloads): array
     {
         $composed = array('static' => array(), 'conditional' => array(), 'navigation_state' => array(), 'reveal_state' => array(), 'image_shape' => array(), 'pseudo' => array(), 'cascaded_values' => array(), 'custom_properties' => array('root' => array(), 'fallback' => array()));
+        $layers = array();
         foreach ( $payloads as $payload ) {
             $key = hash('sha256', $payload);
             $analysis = $this->analysisCache->style($key);
@@ -113,6 +114,7 @@ final class StylesheetAnalysisComposer
                     'image_shape' => $style['image_shape'],
                     'pseudo' => $style['pseudo'],
                     'cascaded_values' => $style['cascaded_values'],
+                    'layer_names' => $style['layer_names'],
                     'custom_properties' => $this->cssCustomPropertyAnalysis($payload),
                 );
                 $this->analysisCache->rememberStyle($key, $analysis);
@@ -122,8 +124,10 @@ final class StylesheetAnalysisComposer
             foreach ( array('static', 'conditional', 'navigation_state', 'reveal_state', 'pseudo', 'cascaded_values') as $part ) {
                 $composed[$part] = array_merge($composed[$part], $analysis[$part]);
             }
+            foreach ($analysis['layer_names'] ?? array() as $layer) $layers[$layer] ??= count($layers);
             foreach ( $analysis['image_shape'] as $rule ) {
                 $rule['order'] = count($composed['image_shape']);
+                if (null !== ($rule['layer'] ?? null)) $rule['layer'] = $layers[$rule['layer']];
                 $composed['image_shape'][] = $rule;
             }
             $composed['custom_properties']['root'] = array_merge($composed['custom_properties']['root'], $analysis['custom_properties']['root']);

--- a/php-transformer/tests/fixtures/parity/html-responsive-image-crop-cascade.json
+++ b/php-transformer/tests/fixtures/parity/html-responsive-image-crop-cascade.json
@@ -1,0 +1,37 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-responsive-image-crop-cascade",
+  "description": "Crop promotion follows the desktop author cascade: comma media alternatives, em/rem and chained range widths, known @supports wrappers, normal and important layer order, selector/inline importance, and exact 1440px boundaries. Unknown conditional wrappers remain authored CSS but fail closed for promotion. Explicit HTML dimensions win over a conflicting promoted ratio; CSS auto ratios do not force a replaced image ratio.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-responsive-image-crop-cascade.json",
+    "notes": "Regression coverage for #841 crop-promotion cascade resolution at the 1440px reference viewport."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Upstream primitive image behavior; no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<style>.media{aspect-ratio:1/1;object-fit:contain}@media (max-width:40rem), screen and (.5rem <= width < 90.0001rem){@supports (display:grid){.media{aspect-ratio:.5 / 1;object-fit:cover}}}@supports (unknown-feature:value){.media{aspect-ratio:7/1}}@layer early{#layered{aspect-ratio:2/1!important;object-fit:cover!important}}@layer late{#layered{aspect-ratio:.25/1!important;object-fit:contain!important}}#layered{aspect-ratio:3/1!important;object-fit:contain!important}.inline{aspect-ratio:3/2!important;object-fit:contain!important}</style><figure><img class=\"media\" src=\"https://example.com/media.jpg\" alt=\"Media\"></figure><figure><img id=\"layered\" src=\"https://example.com/layered.jpg\" alt=\"Layered\"></figure><figure><img class=\"inline\" style=\"aspect-ratio:4/3!important;object-fit:cover!important\" src=\"https://example.com/inline.jpg\" alt=\"Inline\"></figure><figure><img style=\"object-fit:cover\" width=\"320\" height=\"200\" src=\"https://example.com/dimensions.jpg\" alt=\"Dimensions\"></figure><figure><img style=\"aspect-ratio:auto .5/1;object-fit:cover\" src=\"https://example.com/auto.jpg\" alt=\"Auto\"></figure>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/image", "attrs": { "url": "https://example.com/media.jpg", "aspectRatio": ".5/1", "scale": "cover" } },
+    { "path": "blocks.1", "name": "core/image", "attrs": { "url": "https://example.com/layered.jpg", "aspectRatio": "2/1", "scale": "cover" } },
+    { "path": "blocks.2", "name": "core/image", "attrs": { "url": "https://example.com/inline.jpg", "aspectRatio": "4/3", "scale": "cover" } },
+    { "path": "blocks.3", "name": "core/image", "attrs": { "url": "https://example.com/dimensions.jpg", "width": "320px", "height": "200px", "scale": "cover" } },
+    { "path": "blocks.4", "name": "core/image", "attrs": { "url": "https://example.com/auto.jpg", "scale": "cover" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 5 },
+    { "path": "blocks.0.attrs.aspectRatio", "assert": "equals", "value": ".5/1" },
+    { "path": "blocks.1.attrs.aspectRatio", "assert": "equals", "value": "2/1" },
+    { "path": "blocks.2.attrs.aspectRatio", "assert": "equals", "value": "4/3" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "style=\"aspect-ratio:.5/1;object-fit:cover\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "style=\"object-fit:cover;width:320px;height:200px\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"aspectRatio\":\"7/1\"" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}

--- a/php-transformer/tests/unit/compile-fragment-author-stylesheet.php
+++ b/php-transformer/tests/unit/compile-fragment-author-stylesheet.php
@@ -265,6 +265,22 @@ $assert(
     'an explicit inline object-fit becomes a scale-only native image attribute without inventing box geometry'
 );
 
+$cascadeSignals = (new ArtifactCompiler())->compileFragment(
+    '<img class="crop" style="aspect-ratio:4/3!important;object-fit:cover!important" width="320" height="200" src="https://example.com/cascade.jpg" alt="Cascade">',
+    'design/home.html',
+    'html',
+    array('static_css' => '@layer late, early;@layer late{.crop{aspect-ratio:1/1;object-fit:contain}}@layer early{.crop{aspect-ratio:2/1!important;object-fit:cover!important}}.crop{aspect-ratio:3/1!important;object-fit:contain!important}@media (max-width:40rem), screen and (.5rem <= width < 90.0001rem){img.crop{aspect-ratio:.5/1!important;object-fit:cover!important}}.crop{aspect-ratio:7/1!important}')
+);
+$cascadeAttrs = $cascadeSignals->blocks[0]['attrs'] ?? array();
+$assert(
+    ! isset($cascadeAttrs['aspectRatio']) && 'cover' === ($cascadeAttrs['scale'] ?? null),
+    'inline important wins author important while media alternatives, fractional ranges, selector specificity, source order, and normal/important layer ordering remain evaluated without contradicting explicit dimensions'
+);
+$assert(
+    '320px' === ($cascadeAttrs['width'] ?? null) && '200px' === ($cascadeAttrs['height'] ?? null),
+    'explicit dimensions are serialized as lengths and suppress a contradictory promoted aspect ratio'
+);
+
 if ( 0 < $failures ) {
     exit(1);
 }

--- a/php-transformer/tests/unit/static-css-cascade.php
+++ b/php-transformer/tests/unit/static-css-cascade.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\VisualParity\StaticCssCascade;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssCascade;
 
 $failures = 0;
 $passes = 0;
@@ -99,6 +100,19 @@ $assert(! isset($result['display']), 'a max-width block below the reference widt
 $wide = '@media (min-width: 768px) { .main-nav { display: flex; } }';
 $result = $resolve($page, $wide, '//nav', array( 'display' ));
 $assert('flex' === ( $result['display'] ?? '' ), 'a min-width block satisfied at the reference width applies');
+
+$responsiveAlternatives = '@media (max-width:40rem), screen and (.5rem <= width < 90.0001rem) { .main-nav { display: grid; } }';
+$result = $resolve($page, $responsiveAlternatives, '//nav', array( 'display' ));
+$assert('grid' === ( $result['display'] ?? '' ), 'generic static responsive media keeps top-level alternatives and fractional range syntax at desktop');
+
+$assert(
+    CssCascade::mediaConditionApplies('print, not screen and (90.0001rem < width)', 1440.0),
+    'a negated comma alternative applies when its supported fractional strict left-sided range is false at the viewport'
+);
+$assert(
+    ! CssCascade::mediaConditionApplies('not screen and (unknown-feature: value)', 1440.0),
+    'an unknown media feature remains fail-closed when negated'
+);
 
 $result = $resolve($page, '@media print { .main-nav { display: none; } }', '//nav', array( 'display' ));
 $assert(! isset($result['display']), 'a non-visual media type does not apply');


### PR DESCRIPTION
## Summary
- resolve promoted core/image crops through the shared desktop author cascade
- support media alternatives, ranges, layers, importance, specificity, and source order
- prevent crop metadata from contradicting resolved image dimensions

## Verification
- composer test
- npm test (php-transformer/tools/visual-parity)
- disposable WordPress 7.0.4 editor acceptance via Docker

Closes #841.

AI assistance: GPT6Astra via OpenCode orchestrated review; openai/gpt-5.6-terra via direct OpenCode implementation.