### PR TITLE
Fix responsive crop cascade edge cases

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -12180,6 +12180,14 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             return array();
         }
 
+        // A zero authored box is serializable but core image crop attributes
+        // would manufacture positive geometry. Negative HTML dimensions are not
+        // serializable by core/image and are discarded before block creation.
+        // In either case, fail closed rather than promoting the crop.
+        if ($this->imageHasNonPositiveDimension($image, 'width') || $this->imageHasNonPositiveDimension($image, 'height')) {
+            return array();
+        }
+
         if ( '' === $aspectRatio || $this->imageDimensionsDetermineDifferentAspectRatio($width, $height, $aspectRatio) ) {
             return (($declarations['object-fit']['inline'] ?? false) === true) ? array( 'scale' => $scale ) : array();
         }
@@ -12236,11 +12244,29 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
         if (! preg_match('/^(\d*\.?\d+)([a-z]+)$/i', $width, $widthMatch)
             || ! preg_match('/^(\d*\.?\d+)([a-z]+)$/i', $height, $heightMatch)
             || strtolower($widthMatch[2]) !== strtolower($heightMatch[2])
-            || ! preg_match('#^(\d*\.?\d+)(?:\s*/\s*(\d*\.?\d+))?$#', $aspectRatio, $ratioMatch)) {
+            || ! preg_match('#^(\d*\.?\d+)(?:\s*/\s*(\d*\.?\d+))?$#', $aspectRatio, $ratioMatch)
+            || 0.0 >= (float) $widthMatch[1]
+            || 0.0 >= (float) $heightMatch[1]
+            || 0.0 >= (float) $ratioMatch[1]
+            || 0.0 >= (float) ($ratioMatch[2] ?? '1')) {
             return false;
         }
         $ratio = (float) $ratioMatch[1] / (float) ($ratioMatch[2] ?? '1');
         return abs(((float) $widthMatch[1] / (float) $heightMatch[1]) - $ratio) > 0.000001;
+    }
+
+    private function imageHasNonPositiveDimension(DOMElement $image, string $property): bool
+    {
+        $inline = trim($this->cssValueWithoutImportant((string) ($this->styleResolver->cssDeclarations($this->attr($image, 'style'))[ $property ] ?? '')));
+        $value = $inline;
+        if ('' === $value || in_array(strtolower($value), array( 'auto', 'inherit', 'initial', 'unset', 'revert', 'revert-layer' ), true)) {
+            $value = trim($this->cssValueWithoutImportant((string) ($this->styleResolver->presentationDeclarations($image)[ $property ] ?? '')));
+        }
+        if ('' === $value || in_array(strtolower($value), array( 'auto', 'inherit', 'initial', 'unset', 'revert', 'revert-layer' ), true)) {
+            $value = trim($this->attr($image, $property));
+        }
+        return 1 === preg_match('/^[+-]?(?:\d+|\d*\.\d+)(?:%|px|r?em|ex|ch|lh|rlh|vw|vh|vmin|vmax|vi|vb|cm|mm|q|in|pt|pc)?$/i', $value)
+            && 0.0 >= (float) $value;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Style/CssCascade.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssCascade.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
 
+use Automattic\BlocksEngine\PhpTransformer\Css\CssSyntaxScanner;
+
 /** Shared author-origin importance, specificity, and source-order cascade. */
 final class CssCascade
 {
@@ -43,6 +45,93 @@ final class CssCascade
             }
         }
         return false;
+    }
+
+    /**
+     * Evaluate the supported subset of a CSS @supports condition.
+     *
+     * The tri-state evaluator preserves unknown terms through `not`, `and`, and
+     * `or`; callers only receive true when the condition is positively known.
+     */
+    public static function supportsConditionApplies(string $condition): bool
+    {
+        return true === self::booleanConditionValue($condition, static function (string $term): ?bool {
+            [$property, $value] = array_pad(array_map('trim', explode(':', strtolower($term), 2)), 2, '');
+            return ('display' === $property && in_array($value, array( 'flex', 'grid', 'inline-flex', 'inline-grid' ), true))
+                || ('aspect-ratio' === $property && 1 === preg_match('#^\d*\.?\d+\s*(?:/\s*\d*\.?\d+)?$#', $value))
+                || ('object-fit' === $property && in_array($value, array( 'cover', 'contain' ), true))
+                ? true
+                : null;
+        });
+    }
+
+    /** @param callable(string): ?bool $termValue */
+    private static function booleanConditionValue(string $condition, callable $termValue): ?bool
+    {
+        $condition = self::stripBooleanOuterParentheses(trim($condition));
+        if ('' === $condition) return null;
+        foreach (array( 'or', 'and' ) as $operator) {
+            $terms = self::splitTopLevelBooleanOperator($condition, $operator);
+            if (null === $terms) return null;
+            if (1 < count($terms)) {
+                $result = 'and' === $operator ? true : false;
+                foreach ($terms as $term) {
+                    $value = self::booleanConditionValue($term, $termValue);
+                    if ('and' === $operator && false === $value) return false;
+                    if ('or' === $operator && true === $value) return true;
+                    if (null === $value) $result = null;
+                }
+                return $result;
+            }
+        }
+        if (1 === preg_match('/^not\b\s*/i', $condition, $match)) {
+            $value = self::booleanConditionValue(substr($condition, strlen($match[0])), $termValue);
+            return null === $value ? null : ! $value;
+        }
+        return $termValue($condition);
+    }
+
+    private static function stripBooleanOuterParentheses(string $condition): string
+    {
+        while (str_starts_with($condition, '(') && str_ends_with($condition, ')')) {
+            $state = CssSyntaxScanner::state();
+            $closing = null;
+            for ($offset = 0, $length = strlen($condition); $offset < $length; ) {
+                $next = CssSyntaxScanner::consume($condition, $offset, $state);
+                if (null === $next) return $condition;
+                if (0 === $state['parens']) { $closing = $next - 1; break; }
+                $offset = $next;
+            }
+            if (strlen($condition) - 1 !== $closing) break;
+            $condition = trim(substr($condition, 1, -1));
+        }
+        return $condition;
+    }
+
+    /** @return list<string>|null */
+    private static function splitTopLevelBooleanOperator(string $condition, string $operator): ?array
+    {
+        $terms = array();
+        $start = 0;
+        $state = CssSyntaxScanner::state();
+        for ($offset = 0, $length = strlen($condition); $offset < $length; ) {
+            $next = CssSyntaxScanner::consume($condition, $offset, $state);
+            if (null === $next) return null;
+            if (CssSyntaxScanner::isTopLevel($state)
+                && 0 === strcasecmp(substr($condition, $offset, strlen($operator)), $operator)
+                && ! preg_match('/[a-z0-9_-]/i', $condition[$offset - 1] ?? '')
+                && ! preg_match('/[a-z0-9_-]/i', $condition[$offset + strlen($operator)] ?? '')
+            ) {
+                $terms[] = trim(substr($condition, $start, $offset - $start));
+                $start = $offset + strlen($operator);
+                $offset = $start;
+                continue;
+            }
+            $offset = $next;
+        }
+        if (! CssSyntaxScanner::isComplete($state)) return null;
+        $terms[] = trim(substr($condition, $start));
+        return $terms;
     }
 
     private static function mediaAlternativeApplies(string $alternative, float $viewportWidth, float $rootFontSize): bool

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolver.php
@@ -2534,22 +2534,12 @@ final class StyleResolver implements ElementPresentationResolver
             $condition = trim($condition);
             if (preg_match('/^@layer\b/i', $condition)) continue;
             if (preg_match('/^@supports\b/i', $condition)) {
-                if (!$this->knownImageShapeSupportsCondition($condition)) return false;
+                if (!CssCascade::supportsConditionApplies((string) preg_replace('/^@supports\s*/i', '', $condition))) return false;
             } elseif (preg_match('/^@media\b/i', $condition)) {
                 if (!CssCascade::mediaConditionApplies((string) preg_replace('/^@media\s*/i', '', $condition), 1440.0)) return false;
             } else return false;
         }
         return true;
-    }
-
-    private function knownImageShapeSupportsCondition(string $condition): bool
-    {
-        $query = strtolower(trim((string) preg_replace('/^@supports\s*/i', '', $condition)));
-        $query = preg_replace('/^\((.*)\)$/s', '$1', $query) ?? $query;
-        [$property, $value] = array_pad(array_map('trim', explode(':', $query, 2)), 2, '');
-        return ('display' === $property && in_array($value, array('flex', 'grid', 'inline-flex', 'inline-grid'), true))
-            || ('aspect-ratio' === $property && 1 === preg_match('#^\d*\.?\d+\s*(?:/\s*\d*\.?\d+)?$#', $value))
-            || ('object-fit' === $property && in_array($value, array('cover', 'contain'), true));
     }
 
     /**

--- a/php-transformer/tests/unit/compile-fragment-author-stylesheet.php
+++ b/php-transformer/tests/unit/compile-fragment-author-stylesheet.php
@@ -185,6 +185,91 @@ $assert(
     ! isset($unsupportedCropAttrs['aspectRatio']) && ! isset($unsupportedCropAttrs['scale']),
     'unresolved supports conditions do not flatten into crop declarations'
 );
+$compoundSupportedCrop = $compiler->compileFragment(
+    $arbitraryFragment,
+    'design/home.html',
+    'html',
+    array( 'static_css' => '@supports ((display:grid) and (object-fit:cover)){.n3x img{aspect-ratio:5 / 6;object-fit:cover}}' )
+);
+$compoundSupportedCropAttrs = is_array($compoundSupportedCrop->blocks[0]['attrs'] ?? null) ? $compoundSupportedCrop->blocks[0]['attrs'] : array();
+$assert(
+    '5/6' === ($compoundSupportedCropAttrs['aspectRatio'] ?? null) && 'cover' === ($compoundSupportedCropAttrs['scale'] ?? null),
+    'compound known @supports conditions promote crop declarations'
+);
+$compoundUnsupportedCrop = $compiler->compileFragment(
+    $arbitraryFragment,
+    'design/home.html',
+    'html',
+    array( 'static_css' => '@supports ((display:grid) and not (object-fit:cover)){.n3x img{aspect-ratio:5 / 6;object-fit:cover}}' )
+);
+$compoundUnsupportedCropAttrs = is_array($compoundUnsupportedCrop->blocks[0]['attrs'] ?? null) ? $compoundUnsupportedCrop->blocks[0]['attrs'] : array();
+$assert(
+    ! isset($compoundUnsupportedCropAttrs['aspectRatio']) && ! isset($compoundUnsupportedCropAttrs['scale']),
+    'compound known-false @supports conditions do not promote crop declarations'
+);
+$compoundUnknownCrop = $compiler->compileFragment(
+    $arbitraryFragment,
+    'design/home.html',
+    'html',
+    array( 'static_css' => '@supports ((display:grid) and (unknown-crop-feature:value)){.n3x img{aspect-ratio:5 / 6;object-fit:cover}}' )
+);
+$compoundUnknownCropAttrs = is_array($compoundUnknownCrop->blocks[0]['attrs'] ?? null) ? $compoundUnknownCrop->blocks[0]['attrs'] : array();
+$assert(
+    ! isset($compoundUnknownCropAttrs['aspectRatio']) && ! isset($compoundUnknownCropAttrs['scale']),
+    'compound unknown @supports conditions fail closed rather than promoting crop declarations'
+);
+$zeroHeightCrop = $compiler->compileFragment(
+    '<img src="https://example.com/zero-height.jpg" alt="Zero height" width="100" height="0" style="aspect-ratio:4/3;object-fit:cover">',
+    'design/home.html',
+    'html'
+);
+$zeroHeightCropAttrs = is_array($zeroHeightCrop->blocks[0]['attrs'] ?? null) ? $zeroHeightCrop->blocks[0]['attrs'] : array();
+$assert(
+    '100px' === ($zeroHeightCropAttrs['width'] ?? null) && '0px' === ($zeroHeightCropAttrs['height'] ?? null)
+        && ! isset($zeroHeightCropAttrs['aspectRatio']) && ! isset($zeroHeightCropAttrs['scale']),
+    'zero HTML height survives serialization without crop promotion or division'
+);
+$zeroWidthCrop = $compiler->compileFragment(
+    '<img src="https://example.com/zero-width.jpg" alt="Zero width" width="0" height="100" style="aspect-ratio:4/3;object-fit:cover">',
+    'design/home.html',
+    'html'
+);
+$zeroWidthCropAttrs = is_array($zeroWidthCrop->blocks[0]['attrs'] ?? null) ? $zeroWidthCrop->blocks[0]['attrs'] : array();
+$assert(
+    '0px' === ($zeroWidthCropAttrs['width'] ?? null) && '100px' === ($zeroWidthCropAttrs['height'] ?? null)
+        && ! isset($zeroWidthCropAttrs['aspectRatio']) && ! isset($zeroWidthCropAttrs['scale']),
+    'zero HTML width survives serialization without manufactured crop geometry'
+);
+$signedZeroCssCrop = $compiler->compileFragment(
+    '<img class="signed-zero-css" src="https://example.com/signed-zero-css.jpg" alt="Signed zero CSS">',
+    'design/home.html',
+    'html',
+    array( 'static_css' => '.signed-zero-css{width:+0;height:+0px;aspect-ratio:4/3;object-fit:cover}' )
+);
+$signedZeroCssCropAttrs = is_array($signedZeroCssCrop->blocks[0]['attrs'] ?? null) ? $signedZeroCssCrop->blocks[0]['attrs'] : array();
+$assert(
+    ! isset($signedZeroCssCropAttrs['aspectRatio']) && ! isset($signedZeroCssCropAttrs['scale']),
+    'signed zero CSS dimensions fail closed for crop promotion'
+);
+$negativeHtmlDimensionCrop = null;
+$negativeHtmlDimensionError = null;
+try {
+    $negativeHtmlDimensionCrop = $compiler->compileFragment(
+        '<img src="https://example.com/negative-width.jpg" alt="Negative width" width="-100" height="100" style="aspect-ratio:4/3;object-fit:cover">',
+        'design/home.html',
+        'html'
+    );
+} catch (\Throwable $error) {
+    $negativeHtmlDimensionError = $error;
+}
+$negativeHtmlDimensionCropAttrs = is_array($negativeHtmlDimensionCrop?->blocks[0]['attrs'] ?? null) ? $negativeHtmlDimensionCrop->blocks[0]['attrs'] : array();
+$assert(
+    null === $negativeHtmlDimensionError
+        && ! isset($negativeHtmlDimensionCropAttrs['width'])
+        && ! isset($negativeHtmlDimensionCropAttrs['aspectRatio'])
+        && ! isset($negativeHtmlDimensionCropAttrs['scale']),
+    'negative HTML dimensions are omitted before core/image serialization and fail closed for crop promotion without throwing'
+);
 
 /**
  * Resolve the first block's attributes for a fragment compiled against $css.

--- a/php-transformer/tests/unit/static-css-cascade.php
+++ b/php-transformer/tests/unit/static-css-cascade.php
@@ -113,6 +113,18 @@ $assert(
     ! CssCascade::mediaConditionApplies('not screen and (unknown-feature: value)', 1440.0),
     'an unknown media feature remains fail-closed when negated'
 );
+$assert(
+    CssCascade::supportsConditionApplies('((display:grid) and (object-fit:cover)) or not (display:flex)'),
+    'compound known @supports expressions honor parentheses, and, or, and not'
+);
+$assert(
+    ! CssCascade::supportsConditionApplies('(display:grid) and not (object-fit:cover)'),
+    'known-false compound @supports expressions do not apply'
+);
+$assert(
+    ! CssCascade::supportsConditionApplies('(display:grid) and (unknown-feature:value)'),
+    'unknown @supports terms remain fail-closed inside compound expressions'
+);
 
 $result = $resolve($page, '@media print { .main-nav { display: none; } }', '//nav', array( 'display' ));
 $assert(! isset($result['display']), 'a non-visual media type does not apply');

--- a/php-transformer/tools/visual-parity/tests/image-custom-host-promotion.mjs
+++ b/php-transformer/tools/visual-parity/tests/image-custom-host-promotion.mjs
@@ -71,7 +71,7 @@ try {
     await after.close();
   }
 
-    const responsiveCropSource = '<!doctype html><style>.responsive-crop{display:block;width:300px;margin:0}.responsive-crop img{display:block;width:100%;aspect-ratio:1 / 1!important;object-fit:contain!important}@media (min-width:701px){.responsive-crop{width:960px}.responsive-crop img{aspect-ratio:4 / 3!important;object-fit:cover!important}}</style><main><figure class="responsive-crop"><img src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" alt="Responsive crop"></figure></main>';
+    const responsiveCropSource = '<!doctype html><style>@supports ((display:grid) and (object-fit:cover)){.responsive-crop{display:block;width:300px;margin:0}.responsive-crop img{display:block;width:100%;aspect-ratio:1 / 1!important;object-fit:contain!important}@media (min-width:701px){.responsive-crop{width:960px}.responsive-crop img{aspect-ratio:4 / 3!important;object-fit:cover!important}}}</style><main><figure class="responsive-crop"><img src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" alt="Responsive crop"></figure></main>';
     const responsiveCropResult = transform(responsiveCropSource);
     const responsiveCrop = responsiveCropResult.blocks.find((block) => block.blockName === 'core/image');
     assert.deepEqual(
@@ -100,6 +100,63 @@ try {
         assert.deepEqual(source, expected, `#841 source crop has its expected ${width}px authored behavior`);
         assert.deepEqual(output, source, `#841 transformed core/image retains the ${width}px crop and bounds`);
     }
+
+    const supportsEvidence = async (html, css) => {
+        const page = await browser.newPage({ viewport: { width: 600, height: 300 } });
+        await page.setContent(`<!doctype html><style>body{margin:0}${css}</style>${html}`);
+        const evidence = await page.locator('.supports-crop img').evaluate((image) => {
+            const box = image.getBoundingClientRect();
+            const style = getComputedStyle(image);
+            return { aspectRatio: style.aspectRatio, objectFit: style.objectFit, width: box.width, height: box.height };
+        });
+        await page.close();
+        return evidence;
+    };
+    for (const fixture of [
+        { name: 'true compound @supports', condition: '(display:grid) and (object-fit:cover)', promoted: true },
+        { name: 'known-false compound @supports', condition: '(display:grid) and (object-fit:invalid)', promoted: false },
+        { name: 'unknown-term compound @supports', condition: '(display:grid) and (unrecognized-property:value)', promoted: false },
+    ]) {
+        const source = `<style>.supports-crop{display:block;width:120px}.supports-crop img{display:block;width:120px;height:90px}@supports (${fixture.condition}){.supports-crop img{aspect-ratio:4 / 3;object-fit:cover}}</style><figure class="supports-crop"><img src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" alt="Supports crop"></figure>`;
+        const result = transform(source);
+        const image = result.blocks.find((block) => block.blockName === 'core/image');
+        assert.ok(image, `${fixture.name} compiles to core/image`);
+        assert.deepEqual(
+            { aspectRatio: image.attrs.aspectRatio, scale: image.attrs.scale },
+            fixture.promoted ? { aspectRatio: '4/3', scale: 'cover' } : { aspectRatio: undefined, scale: undefined },
+            `${fixture.name} ${fixture.promoted ? 'promotes' : 'does not promote'} crop attributes`
+        );
+        const css = result.assets.filter((asset) => asset.kind === 'css').map((asset) => asset.content).join('\n');
+        const before = await supportsEvidence(source, '');
+        const after = await supportsEvidence(result.serialized_blocks, css);
+        assert.deepEqual(after, before, `${fixture.name} preserves rendered crop and bounds`);
+    }
+
+    const zeroSizeSource = '<style>.zero-size-crop{display:block}.zero-size-crop img{display:block;width:+0;height:+0px;aspect-ratio:4 / 3;object-fit:cover}</style><figure class="zero-size-crop"><img src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" width="0" height="0" alt="Zero size crop"></figure>';
+    let zeroSizeResult;
+    assert.doesNotThrow(() => { zeroSizeResult = transform(zeroSizeSource); }, '#841 signed-zero authored crop compiles');
+    const zeroSizeImage = zeroSizeResult.blocks.find((block) => block.blockName === 'core/image');
+    assert.ok(zeroSizeImage, 'zero-sized authored crop compiles to core/image');
+    assert.deepEqual(
+        { aspectRatio: zeroSizeImage.attrs.aspectRatio, scale: zeroSizeImage.attrs.scale },
+        { aspectRatio: undefined, scale: undefined },
+        'signed-zero authored crop does not manufacture promoted crop geometry'
+    );
+    const zeroSizeCss = zeroSizeResult.assets.filter((asset) => asset.kind === 'css').map((asset) => asset.content).join('\n');
+    const zeroSizeEvidence = async (html, css) => {
+        const page = await browser.newPage({ viewport: { width: 600, height: 300 } });
+        await page.setContent(`<!doctype html><style>body{margin:0}${css}</style>${html}`);
+        const evidence = await page.locator('.zero-size-crop img').evaluate((image) => {
+            const box = image.getBoundingClientRect();
+            return { width: box.width, height: box.height };
+        });
+        await page.close();
+        return evidence;
+    };
+    const zeroSizeBefore = await zeroSizeEvidence(zeroSizeSource, '');
+    const zeroSizeAfter = await zeroSizeEvidence(zeroSizeResult.serialized_blocks, zeroSizeCss);
+    assert.deepEqual(zeroSizeBefore, { width: 0, height: 0 }, 'signed-zero source keeps zero bounds');
+    assert.deepEqual(zeroSizeAfter, zeroSizeBefore, 'signed-zero transformed output keeps zero bounds');
 } finally {
   await browser.close();
 }

--- a/php-transformer/tools/visual-parity/tests/image-custom-host-promotion.mjs
+++ b/php-transformer/tools/visual-parity/tests/image-custom-host-promotion.mjs
@@ -70,6 +70,36 @@ try {
     await before.close();
     await after.close();
   }
+
+    const responsiveCropSource = '<!doctype html><style>.responsive-crop{display:block;width:300px;margin:0}.responsive-crop img{display:block;width:100%;aspect-ratio:1 / 1!important;object-fit:contain!important}@media (min-width:701px){.responsive-crop{width:960px}.responsive-crop img{aspect-ratio:4 / 3!important;object-fit:cover!important}}</style><main><figure class="responsive-crop"><img src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" alt="Responsive crop"></figure></main>';
+    const responsiveCropResult = transform(responsiveCropSource);
+    const responsiveCrop = responsiveCropResult.blocks.find((block) => block.blockName === 'core/image');
+    assert.deepEqual(
+        { aspectRatio: responsiveCrop?.attrs.aspectRatio, scale: responsiveCrop?.attrs.scale },
+        { aspectRatio: '4/3', scale: 'cover' },
+        '#841 promotes the desktop crop selected after the base rule'
+    );
+    const responsiveCropCss = responsiveCropResult.assets
+        .filter((asset) => asset.kind === 'css')
+        .map((asset) => asset.content)
+        .join('\n');
+    const responsiveEvidence = async (html, css, width) => {
+        const page = await browser.newPage({ viewport: { width, height: 900 } });
+        await page.setContent(`<!doctype html><style>body{margin:0}${css}</style>${html}`);
+        const evidence = await page.locator('.responsive-crop img').evaluate((image) => {
+            const box = image.getBoundingClientRect();
+            const style = getComputedStyle(image);
+            return { aspectRatio: style.aspectRatio, objectFit: style.objectFit, width: box.width, height: box.height };
+        });
+        await page.close();
+        return evidence;
+    };
+    for (const [width, expected] of [[1440, { aspectRatio: '4 / 3', objectFit: 'cover', width: 960, height: 720 }], [390, { aspectRatio: '1 / 1', objectFit: 'contain', width: 300, height: 300 }]]) {
+        const source = await responsiveEvidence(responsiveCropSource, '', width);
+        const output = await responsiveEvidence(responsiveCropResult.serialized_blocks, responsiveCropCss, width);
+        assert.deepEqual(source, expected, `#841 source crop has its expected ${width}px authored behavior`);
+        assert.deepEqual(output, source, `#841 transformed core/image retains the ${width}px crop and bounds`);
+    }
 } finally {
   await browser.close();
 }


### PR DESCRIPTION
## Summary
- guard responsive crop promotion against zero, signed-zero, and invalid negative dimensions
- evaluate compound known @supports conditions through a shared tri-state boolean evaluator
- add compiler and browser parity coverage for condition outcomes and zero geometry

## Verification
- composer test
- npm test (php-transformer/tools/visual-parity)
- disposable WordPress 7.0.4 editor acceptance

Follow-up to #841 and #1666.

AI assistance: GPT6Astra via OpenCode orchestrated review; openai/gpt-5.6-terra via direct OpenCode implementation.