### PR TITLE
fix(php-transformer): retain theme-owned runtime scripts once

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -808,7 +808,8 @@ final class ArtifactCompiler
                 'dependencies' => $editorModule['script_dependencies'],
             );
         }
-        $companionPluginPayload = $companionPluginPayloadBuilder->fromBlockTypes($blockTypes, $normalized['files'], $artifact, $allGeneratedBlocks, $runtimeIslandPackage, $editorScripts);
+        $themeOwnedRequiredScripts = RuntimeIslandPackageBuilder::themeOwnedRequiredScriptOccurrences($runtimeIslandPackage, $sourceReports['compiled_site']['pages'] ?? array());
+        $companionPluginPayload = $companionPluginPayloadBuilder->fromBlockTypes($blockTypes, $normalized['files'], $artifact, $allGeneratedBlocks, $runtimeIslandPackage, $editorScripts, $themeOwnedRequiredScripts);
         if ( array() !== $companionPluginPayload ) {
             $sourceReports['companion_plugin_payload'] = $companionPluginPayload;
         }
@@ -4034,7 +4035,7 @@ final class ArtifactCompiler
         }
 
         $metadata = array();
-        foreach ( $matches[0] as $tag ) {
+        foreach ( $matches[0] as $index => $tag ) {
             $src = $this->htmlAttribute((string) $tag, 'src');
             if ( '' === $src ) {
                 continue;
@@ -4047,7 +4048,7 @@ final class ArtifactCompiler
 
             $metadata[] = array_filter(array(
                 'path'               => (string) ($asset['path'] ?? ''),
-                'selector'           => 'script[src="' . $src . '"]',
+                'selector'           => 'script:nth-of-type(' . ($index + 1) . ')',
                 'attributes'         => array_filter(array(
                     'src'   => $src,
                     'type'  => $this->htmlAttribute((string) $tag, 'type'),

--- a/php-transformer/src/ArtifactCompiler/CompanionPluginPayload.php
+++ b/php-transformer/src/ArtifactCompiler/CompanionPluginPayload.php
@@ -43,9 +43,10 @@ final class CompanionPluginPayload
      * @param array<int, array<string, mixed>> $generatedBlocks     Static-render blocks generated at core/html fallbacks (issue #497).
      * @param array<string, mixed>             $runtimeIslandPackage Generic runtime-island package.
      * @param array<int, array<string, mixed>> $editorScripts Editor-only scripts for existing core blocks.
+     * @param array<string, bool>               $themeOwnedRequiredScripts Theme-owned required scripts keyed by source path and selector.
      * @return array<string, mixed> Empty array when there are no generated blocks or scripts.
      */
-    public function fromBlockTypes(array $blockTypes, array $files, array $artifact, array $generatedBlocks = array(), array $runtimeIslandPackage = array(), array $editorScripts = array()): array
+    public function fromBlockTypes(array $blockTypes, array $files, array $artifact, array $generatedBlocks = array(), array $runtimeIslandPackage = array(), array $editorScripts = array(), array $themeOwnedRequiredScripts = array()): array
     {
         $blocks = array();
         $seenNames = array();
@@ -77,7 +78,7 @@ final class CompanionPluginPayload
             $blocks[] = $block;
         }
 
-        $preservedJs = $this->preservedJs($runtimeIslandPackage);
+        $preservedJs = $this->preservedJs($runtimeIslandPackage, $themeOwnedRequiredScripts);
         if ( array() === $blocks && array() === $preservedJs && array() === $editorScripts ) {
             return array();
         }
@@ -110,9 +111,10 @@ final class CompanionPluginPayload
      * Map preserved first-party runtime scripts into SSI's companion payload.
      *
      * @param array<string, mixed> $runtimeIslandPackage
+     * @param array<string, bool>  $themeOwnedRequiredScripts
      * @return array<int, array<string, string>>
      */
-    private function preservedJs(array $runtimeIslandPackage): array
+    private function preservedJs(array $runtimeIslandPackage, array $themeOwnedRequiredScripts): array
     {
         $entries = array();
         $seen = array();
@@ -134,6 +136,11 @@ final class CompanionPluginPayload
                 if ( '' === $content ) {
                     continue;
                 }
+                $selector = is_scalar($script['selector'] ?? null) ? (string) $script['selector'] : ( is_scalar($island['selector'] ?? null) ? (string) $island['selector'] : '' );
+                $sourcePath = is_scalar($island['source_path'] ?? null) ? (string) $island['source_path'] : '';
+                if ( isset($themeOwnedRequiredScripts[$sourcePath . "\n" . $selector]) ) {
+                    continue;
+                }
                 $handle = trim($handleHint . '-' . ((int) $index + 1), '-');
                 $block = '';
                 $signature = hash('sha256', $block . "\0" . $content);
@@ -145,8 +152,8 @@ final class CompanionPluginPayload
                     'handle'      => $handle,
                     'content'     => $content,
                     'block'       => $block,
-                    'selector'    => is_scalar($island['selector'] ?? null) ? (string) $island['selector'] : '',
-                    'source_path' => is_scalar($island['source_path'] ?? null) ? (string) $island['source_path'] : '',
+                    'selector'    => $selector,
+                    'source_path' => $sourcePath,
                 ), static fn (string $value): bool => '' !== $value);
             }
         }

--- a/php-transformer/src/ArtifactCompiler/RuntimeIslandPackageBuilder.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeIslandPackageBuilder.php
@@ -118,6 +118,47 @@ final class RuntimeIslandPackageBuilder
     }
 
     /**
+     * Return required non-script runtime-island scripts already declared by a
+     * compiled theme document, keyed by source path and script occurrence.
+     *
+     * @param array<string, mixed>             $package
+     * @param array<int, array<string, mixed>> $pages
+     * @return array<string, bool>
+     */
+    public static function themeOwnedRequiredScriptOccurrences(array $package, array $pages): array
+    {
+        $themeScriptOccurrences = array();
+        foreach ( $pages as $page ) {
+            $sourcePath = is_string($page['source_path'] ?? null) ? $page['source_path'] : '';
+            foreach ( $page['document_metadata']['scripts'] ?? array() as $script ) {
+                if ( '' !== $sourcePath && is_array($script) && is_int($script['order'] ?? null) ) {
+                    $themeScriptOccurrences[$sourcePath . "\nscript:nth-of-type(" . ($script['order'] + 1) . ')'] = true;
+                }
+            }
+        }
+
+        $owned = array();
+        foreach ( $package['islands'] ?? array() as $island ) {
+            if ( ! is_array($island) || 'script' === ($island['kind'] ?? null) ) {
+                continue;
+            }
+            $sourcePath = is_string($island['source_path'] ?? null) ? $island['source_path'] : '';
+            foreach ( $island['scripts'] ?? array() as $script ) {
+                if ( ! is_array($script) || 'telemetry' === ($script['role'] ?? null) ) {
+                    continue;
+                }
+                $selector = is_string($script['selector'] ?? null) ? $script['selector'] : '';
+                $identity = $sourcePath . "\n" . $selector;
+                if ( '' !== $sourcePath && '' !== $selector && isset($themeScriptOccurrences[$identity]) ) {
+                    $owned[$identity] = true;
+                }
+            }
+        }
+
+        return $owned;
+    }
+
+    /**
      * @param array<string, mixed>             $runtimeIsland One preserved runtime island.
      * @param array<int, array<string, mixed>> $files
      * @return array<string, mixed>
@@ -189,7 +230,7 @@ final class RuntimeIslandPackageBuilder
                 }
             }
 
-            $scripts[] = $this->buildScript($sourceKind, $attributes, $scriptRole, $inline, $files, $sourcePath);
+            $scripts[] = $this->buildScript($sourceKind, $attributes, $scriptRole, $inline, $files, $sourcePath, is_scalar($runtimeIsland['selector'] ?? null) ? (string) $runtimeIsland['selector'] : '');
 
             return $this->dedupeRows($scripts);
         }
@@ -214,7 +255,7 @@ final class RuntimeIslandPackageBuilder
                     }
                 }
             }
-            $scripts[] = $this->buildScript($sourceKind, $attributes, $scriptRole, $inline, $files, $sourcePath);
+            $scripts[] = $this->buildScript($sourceKind, $attributes, $scriptRole, $inline, $files, $sourcePath, is_scalar($requiredScript['selector'] ?? null) ? (string) $requiredScript['selector'] : '');
         }
 
         return $this->dedupeRows($scripts);
@@ -225,7 +266,7 @@ final class RuntimeIslandPackageBuilder
      * @param array<int, array<string, mixed>> $files
      * @return array<string, mixed>
      */
-    private function buildScript(string $sourceKind, array $attributes, string $scriptRole, string $inline, array $files, string $sourcePath): array
+    private function buildScript(string $sourceKind, array $attributes, string $scriptRole, string $inline, array $files, string $sourcePath, string $selector): array
     {
         $src = trim((string) ($attributes['src'] ?? ''));
         $script = array(
@@ -245,6 +286,10 @@ final class RuntimeIslandPackageBuilder
             }
         } elseif ( '' !== $inline ) {
             $script['content'] = $inline;
+        }
+
+        if ( '' !== $selector ) {
+            $script['selector'] = $selector;
         }
 
         $role = $this->scriptRole($scriptRole, $src, (string) ($script['content'] ?? ''));

--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
@@ -8,6 +8,7 @@ use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
 use Automattic\BlocksEngine\PhpTransformer\Contract\EditabilityPolicy;
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\RuntimeDeclarations;
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\RuntimeEntityManifest;
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\RuntimeIslandPackageBuilder;
 use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\SrcsetParser;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\FontMaterializationPlanBuilder;
@@ -1382,6 +1383,7 @@ final class WordPressSitePlan
             if ( is_array($script) && is_string($script['source_path'] ?? null) && is_string($script['selector'] ?? null) ) $superseded[$script['source_path'] . "\n" . $script['selector']] = true;
         }
         $package = is_array($sourceReports['runtime_island_package'] ?? null) ? $sourceReports['runtime_island_package'] : array();
+        $themeOwnedRequiredScripts = RuntimeIslandPackageBuilder::themeOwnedRequiredScriptOccurrences($package, $sourceReports['compiled_site']['pages'] ?? array());
         foreach ( $package['islands'] ?? array() as $island ) {
             if ( !is_array($island) ) continue;
             $sourcePath = is_string($island['source_path'] ?? null) ? $island['source_path'] : '';
@@ -1391,6 +1393,8 @@ final class WordPressSitePlan
             $carried = false;
             foreach ( $island['scripts'] ?? array() as $script ) {
                 if ( !is_array($script) ) continue;
+                $scriptSelector = is_string($script['selector'] ?? null) ? $script['selector'] : '';
+                if ( isset($themeOwnedRequiredScripts[$sourcePath . "\n" . $scriptSelector]) ) continue;
                 $scriptDropped = 'telemetry' === ($script['role'] ?? null);
                 $scriptCarried = !$scriptDropped && is_string($script['content'] ?? null) && '' !== trim($script['content']);
                 $carried = $carried || $scriptCarried;

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -5154,16 +5154,15 @@ $rootedScriptCompanion = $compiler->compile(
 )->toArray();
 $rootedScriptPayload = $rootedScriptCompanion['source_reports']['companion_plugin_payload'] ?? array();
 $rootedPreservedJs = $rootedScriptPayload['preserved_js'] ?? array();
-$assert(1 === count($rootedPreservedJs), 'root-relative first-party script is resolved against the artifact root and carried once');
-$assert(str_contains((string) ($rootedPreservedJs[0]['content'] ?? ''), 'totalAmplitude'), 'application identifiers containing a telemetry vendor name remain first-party companion code');
+$assert(array() === $rootedPreservedJs, 'theme-declared root-relative first-party script is not duplicated in the companion payload');
 $rootedPlan = $rootedScriptCompanion['source_reports']['wordpress_site_plan'] ?? array();
 $rootedPageMarkup = (string) ($rootedPlan['pages'][0]['canonical_block_markup'] ?? '');
 $assert(str_contains($rootedPageMarkup, '<canvas id="canvas"></canvas>'), 'root-relative first-party canvas runtime preserves its script-addressable markup');
 $rootedPlanWriteSources = array_column($rootedPlan['writes'] ?? array(), 'source_path');
-$assert(!in_array('website/script.js', $rootedPlanWriteSources, true), 'companion-owned first-party script is not duplicated into the theme plan');
+$assert(in_array('website/script.js', $rootedPlanWriteSources, true), 'theme-owned root-relative first-party script remains in the theme plan');
 $assert(!in_array('website/.netlify/scripts/rum.js', $rootedPlanWriteSources, true), 'dropped telemetry script is not written into the theme plan');
 $rootedPlanScripts = array_merge(...array_map(static fn(array $page): array => $page['document_metadata']['scripts'] ?? array(), $rootedPlan['pages'] ?? array()));
-$assert(array() === $rootedPlanScripts, 'companion-owned and dropped script declarations are absent from theme loading');
+$assert(1 === count($rootedPlanScripts) && isset($rootedPlanScripts[0]['asset_reference']), 'theme loading retains the first-party declaration and removes dropped telemetry');
 
 $companionNoSite = $compiler->compile(
     array(
@@ -5315,7 +5314,33 @@ foreach ( $runtimeIslandFixture['cases'] as $runtimeIslandCase ) {
         $firstParty = array_values(array_filter($island['scripts'] ?? array(), static fn (array $s): bool => 'first_party' === ($s['role'] ?? '')));
         $assert(count($firstParty) >= (int) ($expect['first_party_scripts_min'] ?? 0), 'island carries the expected first-party scripts for case ' . $caseName);
     }
+
 }
+
+$canvasScriptOwnership = $compiler->compile($runtimeIslandFixture['cases'][2]['artifact'])->toWordPressSitePlanView();
+$canvasThemeScripts = array_merge(...array_map(static fn(array $page): array => $page['document_metadata']['scripts'] ?? array(), $canvasScriptOwnership['wordpress_site_plan']['pages'] ?? array()));
+$canvasCompanionScripts = $canvasScriptOwnership['companion_plugin_payload']['preserved_js'] ?? array();
+$assert(array() === $canvasCompanionScripts && 2 === count($canvasThemeScripts), 'theme-owned canvas scripts are omitted from the companion payload by source document and script occurrence');
+$assert(isset($canvasThemeScripts[0]['asset_reference']) && isset($canvasThemeScripts[1]['asset_reference']), 'theme-owned canvas scripts retain their original declaration order and loading path');
+
+$inlineCanvasOwnership = $compiler->compile(array(
+    'entrypoint' => 'index.html',
+    'files' => array(
+        'index.html' => '<main><canvas id="chart"></canvas><script>document.getElementById("chart").getContext("2d");</script></main>',
+    ),
+))->toWordPressSitePlanView();
+$inlineCanvasScripts = $inlineCanvasOwnership['wordpress_site_plan']['pages'][0]['document_metadata']['scripts'] ?? array();
+$assert(array() === ($inlineCanvasOwnership['companion_plugin_payload']['preserved_js'] ?? array()) && 1 === count($inlineCanvasScripts) && isset($inlineCanvasScripts[0]['asset_reference']), 'inline-only canvas execution remains once in its theme declaration');
+
+$repeatedInlineDocuments = $compiler->compile(array(
+    'entrypoint' => 'index.html',
+    'files' => array(
+        'index.html' => '<main><canvas id="chart"></canvas><script>document.getElementById("chart").getContext("2d");</script></main>',
+        'about.html' => '<main><canvas id="chart"></canvas><script>document.getElementById("chart").getContext("2d");</script></main>',
+    ),
+))->toWordPressSitePlanView();
+$repeatedThemeScripts = array_map(static fn (array $page): int => count($page['document_metadata']['scripts'] ?? array()), $repeatedInlineDocuments['wordpress_site_plan']['pages'] ?? array());
+$assert(array(1, 1) === $repeatedThemeScripts && array() === ($repeatedInlineDocuments['companion_plugin_payload']['preserved_js'] ?? array()), 'identical inline scripts in separate documents remain distinct theme declarations without multipage companion packaging');
 
 $normalized = $compiler->compile(
     array(

--- a/php-transformer/tests/fixtures/parity/artifact-button-runtime-controls-commerce-boundary.json
+++ b/php-transformer/tests/fixtures/parity/artifact-button-runtime-controls-commerce-boundary.json
@@ -33,7 +33,7 @@
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "source_reports.runtime_dependency_parity.status", "assert": "equals", "value": "pass" },
     { "path": "source_reports.conversion_report.source_summary.page_count", "assert": "equals", "value": 1 },
-    { "path": "source_reports.conversion_report.source_summary.asset_count", "assert": "equals", "value": 0 },
+    { "path": "source_reports.conversion_report.source_summary.asset_count", "assert": "equals", "value": 1 },
     { "path": "source_reports.conversion_report.source_summary.route_count", "assert": "equals", "value": 1 },
     { "path": "source_reports.conversion_report.source_summary.navigation_link_count", "assert": "equals", "value": 0 },
     { "path": "source_reports.conversion_report.source_summary.menu_count", "assert": "equals", "value": 0 },


### PR DESCRIPTION
## Summary
Continues #1360. Investigation of downstream script deduplication found that the released producer duplicates inline canvas behavior across theme and companion outputs. This repairs the producer before removing downstream compensation.

- Resolve theme-owned required script occurrences in one shared runtime-island helper using source document and script selector identity, rather than content hashes.
- Keep canvas-required scripts on their existing theme path, retaining route scope and loading metadata, and omit duplicate companion entries.
- Preserve the established standalone script path and telemetry exclusion. No multi-page companion schema or enqueue behavior is introduced.

## Verification
All ten checks passed on `d391df35a0a0caceb3cd8f5acf4951c1c4c47f6f`: [Composer tests and WordPress integration across PHP 8.2-8.5, plus visual parity tools](https://github.com/Automattic/blocks-engine/actions/runs/34549714944), and [solved-site promotion](https://github.com/Automattic/blocks-engine/actions/runs/34549715228).

Reproduce from php-transformer after Composer install:
```sh
composer run test:canonical
composer run test:parity
```
Both passed; parity covers 307 fixtures. Contracts cover external-plus-inline canvas, inline-only canvas, repeated inline bodies across documents, and first-party root-relative scripts. Independent review checked the final bounded ownership approach.

SSI stays unchanged until this producer fix is released and its consumer dependency is updated. No release or deployment is included.

## AI Assistance
OpenCode GPT-6 Astra coordinated implementation, independent review, and verification under Chris Huber direction. Review rejected broader companion routing changes; the final repair preserves theme execution semantics and centralizes the ownership decision.