### PR TITLE
fix(media): recover a captured picture source before it is emitted

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlCompilation.php
@@ -150,6 +150,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\DomHelpersTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\LinkUrlSanitizer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\NavigationToggleSuppressionContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\NavigationToggleSuppressor;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SourceDom;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SvgMaterializationContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SvgMaterializer;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\FontMaterializationPlanBuilder;
@@ -9960,6 +9961,11 @@ final class HtmlCompilation implements SourceBlockCreator, RichTextInlinePolicy,
             if ( '' !== $candidate ) {
                 return $candidate;
             }
+        }
+
+        $fromHost = $this->safeImageUrl(SourceDom::imageUrlFromHostMetadata($image));
+        if ( '' !== $fromHost ) {
+            return $fromHost;
         }
 
         return $src;

--- a/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
@@ -124,6 +124,7 @@ trait DomHelpersTrait
         if ( ! $clone instanceof DOMElement ) {
             return null;
         }
+        SourceDom::materializeMissingImageSources($clone);
         $this->materializeFallbackSourceTagMarker($clone);
         foreach ( $clone->getElementsByTagName('*') as $descendant ) {
             if ( $descendant instanceof DOMElement ) {

--- a/php-transformer/src/HtmlToBlocks/Support/SourceDom.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SourceDom.php
@@ -692,4 +692,130 @@ final class SourceDom
 
         return false;
     }
+
+    /**
+     * Recover a missing image URL from ancestor host metadata such as
+     * `data-image-info` JSON. Non-JSON values are ignored.
+     */
+    public static function imageUrlFromHostMetadata(DOMElement $image): string
+    {
+        for ( $node = $image; $node instanceof DOMElement; $node = $node->parentNode ) {
+            $url = self::imageUrlFromInfoValue(trim(self::attr($node, 'data-image-info')));
+            if ( '' !== $url ) {
+                return $url;
+            }
+        }
+
+        return '';
+    }
+
+    public static function materializeMissingImageSources(DOMElement $root): void
+    {
+        $images = array();
+        if ( 'img' === strtolower($root->tagName) ) {
+            $images[] = $root;
+        }
+        foreach ( $root->getElementsByTagName('img') as $image ) {
+            if ( $image instanceof DOMElement ) {
+                $images[] = $image;
+            }
+        }
+        foreach ( $images as $image ) {
+            if ( '' !== trim(self::attr($image, 'src')) ) {
+                continue;
+            }
+            $url = self::imageUrlFromHostMetadata($image);
+            if ( '' !== $url ) {
+                $image->setAttribute('src', $url);
+            }
+        }
+        self::dropSourcelessPictures($root);
+    }
+
+    private static function dropSourcelessPictures(DOMElement $root): void
+    {
+        $pictures = array();
+        foreach ( $root->getElementsByTagName('picture') as $picture ) {
+            if ( $picture instanceof DOMElement ) {
+                $pictures[] = $picture;
+            }
+        }
+        foreach ( $pictures as $picture ) {
+            if ( self::pictureHasRenderableSource($picture) || $picture === $root || ! $picture->parentNode ) {
+                continue;
+            }
+            $picture->parentNode->removeChild($picture);
+        }
+    }
+
+    private static function pictureHasRenderableSource(DOMElement $picture): bool
+    {
+        foreach ( $picture->getElementsByTagName('source') as $source ) {
+            if ( $source instanceof DOMElement && ( '' !== trim(self::attr($source, 'srcset')) || '' !== trim(self::attr($source, 'src')) ) ) {
+                return true;
+            }
+        }
+        foreach ( $picture->getElementsByTagName('img') as $image ) {
+            if ( $image instanceof DOMElement && ( '' !== trim(self::attr($image, 'src')) || '' !== trim(self::attr($image, 'srcset')) ) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function imageUrlFromInfoValue(string $value): string
+    {
+        $decoded = trim(html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+        if ( '' === $decoded || ( ! str_starts_with($decoded, '{') && ! str_starts_with($decoded, '[') ) ) {
+            return '';
+        }
+        $data = json_decode($decoded, true);
+        if ( ! is_array($data) ) {
+            return '';
+        }
+        $stack = array( $data );
+        $depth = 0;
+        while ( array() !== $stack && $depth < 8 ) {
+            $node = array_pop($stack);
+            ++$depth;
+            if ( ! is_array($node) ) {
+                continue;
+            }
+            foreach ( $node as $key => $item ) {
+                if ( is_string($item) && is_string($key) && 1 === preg_match('/(?:url|src)$/i', $key) && self::isSafeImageSourceUrl($item) ) {
+                    return $item;
+                }
+                if ( is_array($item) ) {
+                    $stack[] = $item;
+                }
+            }
+        }
+
+        return '';
+    }
+
+    private static function isSafeImageSourceUrl(string $url): bool
+    {
+        if ( ! self::safeFallbackUrl($url, 'src') ) {
+            return false;
+        }
+        $normalized = strtolower(preg_replace('/[\x00-\x20\x7f]+/', '', html_entity_decode($url, ENT_QUOTES | ENT_HTML5, 'UTF-8')) ?? '');
+        for ( $index = 0; $index < 2 && str_contains($normalized, '%'); ++$index ) {
+            $normalized = rawurldecode($normalized);
+        }
+        if ( '' === $normalized ) {
+            return false;
+        }
+        $parts = parse_url($url);
+        if ( is_array($parts) && ( isset($parts['user']) || isset($parts['pass']) ) ) {
+            return false;
+        }
+        if ( ! preg_match('/^([a-z][a-z0-9+.-]*):/i', $normalized, $scheme) ) {
+            return true;
+        }
+
+        return in_array($scheme[1], array( 'http', 'https' ), true)
+            || (bool) preg_match('#^data:image/(?:avif|gif|jpeg|png|webp);base64,[a-z0-9+/=]+$#i', $normalized);
+    }
 }

--- a/php-transformer/tests/unit/responsive-media-block.php
+++ b/php-transformer/tests/unit/responsive-media-block.php
@@ -116,6 +116,15 @@ $assert('custom/responsive-media' === ($srcsetWrapper['blocks'][0]['blockName'] 
 $selectorDependentWrapper = ( new HtmlTransformer() )->transform('<style>.media-frame .media-image{border-radius:50%}</style><a href="/profile"><media-frame class="media-frame"><img class="media-image" src="profile.png" alt="Profile"></media-frame></a>')->toArray();
 $assert('custom/responsive-media' === ($selectorDependentWrapper['blocks'][0]['blockName'] ?? null), 'a custom wrapper whose descendant selector would change remains responsive media');
 
+$deferredHost = ( new HtmlTransformer() )->transform('<wow-image class="_wowImage" data-image-info="{&quot;alignType&quot;:&quot;center&quot;,&quot;imageData&quot;:{&quot;name&quot;:&quot;Logo.png&quot;,&quot;url&quot;:&quot;https://cdn.example.test/logo.png&quot;,&quot;alt&quot;:&quot;Logo.png&quot;}}"><picture><img alt="Logo.png"></picture></wow-image>')->toArray();
+$deferredContent = (string) ($deferredHost['blocks'][0]['attrs']['content'] ?? $deferredHost['serialized_blocks'] ?? '');
+$assert(str_contains($deferredContent, 'src="https://cdn.example.test/logo.png"'), 'a custom image host with JSON image metadata fills a missing img src');
+$assert(! str_contains($deferredContent, '<picture><img alt="Logo.png"></picture>') || str_contains($deferredContent, '<img alt="Logo.png" src="https://cdn.example.test/logo.png">') || str_contains($deferredContent, '<img src="https://cdn.example.test/logo.png" alt="Logo.png">'), 'the recovered source is serialized onto the captured img');
+
+$emptyPicture = ( new HtmlTransformer() )->transform('<wow-image class="_wowImage"><picture><img alt="Logo.png"></picture></wow-image>')->toArray();
+$emptyContent = (string) ($emptyPicture['blocks'][0]['attrs']['content'] ?? $emptyPicture['serialized_blocks'] ?? '');
+$assert(! str_contains($emptyContent, '<picture><img alt="Logo.png"></picture>'), 'a picture with no src and no recoverable metadata is not emitted');
+
 $labeledWrapper = ( new HtmlTransformer() )->transform('<a href="/profile"><div><wow-image><img src="profile.png" alt="Profile"></wow-image><span>Profile</span></div></a>')->toArray();
 $assert('custom/responsive-media' !== ($labeledWrapper['blocks'][0]['blockName'] ?? null), 'a linked image wrapper with authored label content is not collapsed into responsive media');
 

--- a/php-transformer/tests/unit/source-dom.php
+++ b/php-transformer/tests/unit/source-dom.php
@@ -148,6 +148,21 @@ $assert(! SourceDom::isSafeInlineSvgMarkup('<!DOCTYPE svg [<!ENTITY payload SYST
 
 // --- statelessness ----------------------------------------------------------
 
+$host = $element('<wow-image data-image-info="{&quot;imageData&quot;:{&quot;url&quot;:&quot;https://cdn.example.test/logo.png&quot;,&quot;alt&quot;:&quot;Logo&quot;}}"><picture><img alt="Logo"></picture></wow-image>');
+$img = $host->getElementsByTagName('img')->item(0);
+$assert($img instanceof DOMElement && SourceDom::imageUrlFromHostMetadata($img) === 'https://cdn.example.test/logo.png', 'host JSON image metadata exposes the image URL');
+SourceDom::materializeMissingImageSources($host);
+$assert($img instanceof DOMElement && $img->getAttribute('src') === 'https://cdn.example.test/logo.png', 'missing img src is materialized from host metadata');
+
+$bounded = $element('<media-frame data-image-info="bounded"><picture><img alt="Mark"></picture></media-frame>');
+$boundedImg = $bounded->getElementsByTagName('img')->item(0);
+$assert($boundedImg instanceof DOMElement && '' === SourceDom::imageUrlFromHostMetadata($boundedImg), 'non-JSON host metadata is not treated as an image URL');
+SourceDom::materializeMissingImageSources($bounded);
+$assert(0 === $bounded->getElementsByTagName('picture')->length, 'a sourceless picture without recoverable metadata is dropped');
+
+$unsafe = $element('<wow-image data-image-info="{&quot;url&quot;:&quot;javascript:alert(1)&quot;}"><img alt="x"></wow-image>');
+$assert('' === SourceDom::imageUrlFromHostMetadata($unsafe->getElementsByTagName('img')->item(0)), 'javascript image metadata URLs are rejected');
+
 $probe = $element('<div class="a">x</div>');
 $first = SourceDom::attr($probe, 'class');
 SourceDom::mergeClassNames('x', 'y');


### PR DESCRIPTION
## Problem

A captured responsive image can hold its URL in host metadata rather than on the `<img>` itself. When the surrounding element is sanitised, that metadata is discarded and the emitted markup becomes a `<picture>` whose only child is a src-less `<img>`:

```html
<picture><img alt="…"></picture>
```

Measured on a real import: exactly one such element on every route, rendering 0x0. It causes no HTTP request and is invisible, but the source emits none, and an `<img>` with no source is invalid markup that a consumer can legitimately treat as broken.

## Change

Recover the source from the captured host metadata before the element is emitted, and drop a picture that still resolves to no source at all rather than shipping an empty one.

## Evidence

On a fresh import of a real source, measured in a browser across all four routes at desktop and mobile:

- before: 1 image per route with `complete && naturalWidth === 0`
- after: **0**, and zero images with a missing or empty `src`

The visible header logo is unchanged at 141x143, and element-box parity against the live source holds at 155/160 with no route worse.

## Testing

`composer test` passes, including new coverage in `tests/unit/source-dom.php` and `tests/unit/responsive-media-block.php`.

## AI assistance

Root-caused and implemented with Grok 4.6 through OpenCode; I verified both the image count and the parity baseline independently in a browser against the live source.