### PR TITLE
fix(forms): keep the separator an accessible name carries

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Elements/FormControlMetadataBuilder.php
+++ b/php-transformer/src/HtmlToBlocks/Elements/FormControlMetadataBuilder.php
@@ -147,12 +147,25 @@ final class FormControlMetadataBuilder
 
     public function label(DOMElement $control): string
     {
-        $ariaLabel = trim(SourceDom::attr($control, 'aria-label'));
+        $authoredAriaLabel = SourceDom::attr($control, 'aria-label');
+        $ariaLabel = trim($authoredAriaLabel);
+        $label = $this->labelElement($control);
         if ( '' !== $ariaLabel ) {
-            return $this->collapseRepeatedLabel($ariaLabel);
+            $collapsed = $this->collapseRepeatedLabel($ariaLabel);
+            // An authored label can carry the space that separates its own text
+            // from a decorative required marker rendered beside it. Reported text
+            // keeps that separator, exactly as the label element's text does, so
+            // the rendered line box matches the source instead of closing up.
+            if ( 1 === preg_match('/\s$/u', $authoredAriaLabel)
+                && $label instanceof DOMElement
+                && $this->hasDecorativeRequiredMarker($label)
+            ) {
+                return $collapsed . ' ';
+            }
+
+            return $collapsed;
         }
 
-        $label = $this->labelElement($control);
         if ( $label instanceof DOMElement ) {
             return $this->labelText($label);
         }

--- a/php-transformer/tests/unit/form-associated-label-submit.php
+++ b/php-transformer/tests/unit/form-associated-label-submit.php
@@ -88,6 +88,33 @@ $assert(
     $nativeSubmit
 );
 
+$labelOf = static function (string $html) use ($transformer): string {
+    $fallbacks = $transformer->transform($html)->toArray()['fallbacks'] ?? array();
+    foreach ( $fallbacks as $fallback ) {
+        foreach ( $fallback['controls'] ?? array() as $control ) {
+            if ( isset($control['label']) && str_starts_with((string) $control['label'], 'Details') ) {
+                return (string) $control['label'];
+            }
+        }
+    }
+
+    return '';
+};
+
+$spacedMarkerForm = '<main><form aria-label="Quote"><label for="d">Details<span aria-hidden="true">*</span></label><textarea id="d" aria-label="Details " required></textarea><button type="submit">Send</button></form></main>';
+$assert(
+    'Details ' === $labelOf($spacedMarkerForm),
+    '5: an accessible name keeps the space that separates it from a decorative required marker',
+    json_encode($labelOf($spacedMarkerForm))
+);
+
+$plainMarkerForm = '<main><form aria-label="Quote"><label for="d2">Details<span aria-hidden="true">*</span></label><textarea id="d2" aria-label="Details" required></textarea><button type="submit">Send</button></form></main>';
+$assert(
+    'Details' === $labelOf($plainMarkerForm),
+    '6: an accessible name without that separator is reported unchanged',
+    json_encode($labelOf($plainMarkerForm))
+);
+
 if ( $failures > 0 ) {
     fwrite(STDERR, PHP_EOL . "form associated-label/submit tests: {$passes} passed, {$failures} FAILED" . PHP_EOL);
     exit(1);


### PR DESCRIPTION
## Problem

A source can separate a field label from its decorative required marker with whitespace, and expose that same spacing in the control's accessible name:

```html
<label for="d">Details …cleaned)<span aria-hidden="true">*</span></label>
<textarea id="d" aria-label="Details …cleaned) " required></textarea>
```

`labelText()` already preserves that separator when it reads the label element. But `label()` returns early on a trimmed `aria-label`, so a control that exposes an accessible name never reaches that logic and the separator is lost.

Rendered result: the imported label measured 512.594px against the source's 514.813px, because the marker closed up against the text.

## Change

When an accessible name ends in whitespace and the control's label element carries a decorative required marker, keep that single separator, matching what `labelText()` already does for label-element text. An accessible name without the separator is reported unchanged.

## Evidence

Fresh import of a real source, desktop 1440:

| | label width |
|---|---|
| source | 514.813px |
| before | 512.594px |
| after | **514.813px** |

Element-box parity against the live source went from 155/160 to **156/160**, and every desktop route is now exact: `/` 27/27, `/about-us` 9/9, `/contact` 16/16, `/get-a-quote` 28/28.

## Testing

`composer test` passes. `tests/unit/form-associated-label-submit.php` adds both directions: the separator is kept when the source has it, and is not invented when it does not.

## AI assistance

Root-caused and implemented with GPT-5.1 Cortex through OpenCode: I traced the loss from the live DOM through the capture and the compiled entity to this early return, then verified the fix on a real import in a browser.